### PR TITLE
Add configurable font_family setting for terminal

### DIFF
--- a/src-tauri/src/cli/config.rs
+++ b/src-tauri/src/cli/config.rs
@@ -88,6 +88,21 @@ pub fn set_theme_preference(mode: &str) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+pub fn get_font_family_preference() -> String {
+    let path = config_file();
+    if !path.exists() {
+        return r#""SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace"#.to_string();
+    }
+    if let Ok(content) = std::fs::read_to_string(&path) {
+        if let Ok(yaml) = serde_yaml::from_str::<serde_yaml::Value>(&content) {
+            if let Some(font) = yaml.get("font_family").and_then(|v| v.as_str()) {
+                return font.to_string();
+            }
+        }
+    }
+    r#""SF Mono", "Fira Code", "Cascadia Code", Menlo, monospace"#.to_string()
+}
+
 pub fn get_session_color_preference() -> String {
     let path = config_file();
     if !path.exists() {

--- a/src-tauri/src/gui.rs
+++ b/src-tauri/src/gui.rs
@@ -1271,6 +1271,11 @@ fn save_global_config(
 }
 
 #[tauri::command]
+fn get_font_family_preference() -> String {
+    crate::cli::config::get_font_family_preference()
+}
+
+#[tauri::command]
 fn get_session_color_preference() -> String {
     crate::cli::config::get_session_color_preference()
 }
@@ -1546,6 +1551,7 @@ pub fn run(args: GuiArgs) {
             launch_session,
             get_global_config,
             save_global_config,
+            get_font_family_preference,
             get_session_color_preference,
             set_session_color_preference,
             get_default_permissions,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1646,6 +1646,14 @@ function App() {
 
     terminalInstance.current = term;
 
+    // Load font family preference from config
+    invoke<string>("get_font_family_preference")
+      .then((fontFamily) => {
+        term.options.fontFamily = fontFamily;
+        if (fitAddon.current) fitAddon.current.fit();
+      })
+      .catch(() => {});
+
     // Let xterm.js tell us when dimensions actually change
     term.onResize(({ cols, rows }) => {
       invoke("resize_pty", { rows, cols }).catch(console.error);


### PR DESCRIPTION
## Summary

- Add `font_family` key to `~/.config/twapp/config.yaml` config, following the existing `theme`/`session_color` pattern
- When set, the terminal uses the user's preferred font (e.g. Nerd Fonts for starship glyphs)
- When unset, falls back to the current default SF Mono chain

Nerd fonts and icons rendering correctly: 
<img width="834" height="115" alt="Screenshot 2026-02-09 at 1 21 29 PM" src="https://github.com/user-attachments/assets/e3c2f34d-5b29-439f-9376-aa345a2cd000" />



Closes #1

## Test plan

- [x] Build: `npm run tauri build` succeeds
- [x] Set `font_family: "MesloLGS Nerd Font, Menlo, monospace"` in config — Nerd Font glyphs render in terminal
- [x] Remove `font_family` key — falls back to original default fonts