### PR TITLE
Add Intel (x86_64) macOS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,14 @@ on:
 
 jobs:
   check:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: aarch64
+          - runner: macos-13
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,14 @@ permissions:
 
 jobs:
   check:
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: aarch64
+          - runner: macos-13
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -26,7 +33,14 @@ jobs:
 
   release:
     needs: check
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: aarch64
+          - runner: macos-13
+            arch: x86_64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,18 +70,47 @@ jobs:
       - name: Package release
         run: |
           cd src-tauri/target/release/bundle/macos
-          tar -czf twapp-macos-aarch64.tar.gz twapp.app
-          mv twapp-macos-aarch64.tar.gz $GITHUB_WORKSPACE/
+          tar -czf twapp-macos-${{ matrix.arch }}.tar.gz twapp.app
+          mv twapp-macos-${{ matrix.arch }}.tar.gz $GITHUB_WORKSPACE/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: twapp-macos-${{ matrix.arch }}
+          path: twapp-macos-${{ matrix.arch }}.tar.gz
+
+  publish:
+    needs: release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Determine version
+        id: bump
+        run: |
+          BASE_VERSION=$(cat version.txt | tr -d '\n')
+          VERSION="${BASE_VERSION}.${GITHUB_RUN_NUMBER}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
       - name: Create release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git tag "v${{ steps.bump.outputs.version }}"
-          git push origin "v${{ steps.bump.outputs.version }}"
-          gh release create "v${{ steps.bump.outputs.version }}" \
-            twapp-macos-aarch64.tar.gz \
-            --title "v${{ steps.bump.outputs.version }}" \
+          VERSION="${{ steps.bump.outputs.version }}"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            artifacts/twapp-macos-aarch64/twapp-macos-aarch64.tar.gz \
+            artifacts/twapp-macos-x86_64/twapp-macos-x86_64.tar.gz \
+            --title "v${VERSION}" \
             --generate-notes
 
       - name: Update Homebrew formula
@@ -79,20 +122,28 @@ jobs:
             exit 0
           fi
 
-          SHA256=$(shasum -a 256 twapp-macos-aarch64.tar.gz | awk '{print $1}')
           VERSION="${{ steps.bump.outputs.version }}"
+          SHA256_ARM=$(shasum -a 256 artifacts/twapp-macos-aarch64/twapp-macos-aarch64.tar.gz | awk '{print $1}')
+          SHA256_INTEL=$(shasum -a 256 artifacts/twapp-macos-x86_64/twapp-macos-x86_64.tar.gz | awk '{print $1}')
 
           cat > /tmp/twapp.rb <<RUBY
           class Twapp < Formula
             desc "A structured terminal companion for Claude coding sessions"
             homepage "https://github.com/piekstra/twapp"
-            url "https://github.com/piekstra/twapp/releases/download/v${VERSION}/twapp-macos-aarch64.tar.gz"
-            sha256 "${SHA256}"
             license "MIT"
             version "${VERSION}"
 
             depends_on :macos
-            depends_on arch: :arm64
+
+            on_arm do
+              url "https://github.com/piekstra/twapp/releases/download/v${VERSION}/twapp-macos-aarch64.tar.gz"
+              sha256 "${SHA256_ARM}"
+            end
+
+            on_intel do
+              url "https://github.com/piekstra/twapp/releases/download/v${VERSION}/twapp-macos-x86_64.tar.gz"
+              sha256 "${SHA256_INTEL}"
+            end
 
             def install
               prefix.install "twapp.app"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A structured terminal companion for Claude coding sessions — with notes, ticke
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![GitHub release](https://img.shields.io/github/v/release/piekstra/twapp)](https://github.com/piekstra/twapp/releases/latest)
 [![Build](https://img.shields.io/github/actions/workflow/status/piekstra/twapp/release.yml?branch=main)](https://github.com/piekstra/twapp/actions)
-[![macOS](https://img.shields.io/badge/platform-macOS%20(Apple%20Silicon)-lightgrey)](#install)
+[![macOS](https://img.shields.io/badge/platform-macOS%20(Apple%20Silicon%20%7C%20Intel)-lightgrey)](#install)
 
 > Tired of losing productive flow to tab chaos? Afraid of losing a great idea because you're mid-task? **twapp your work.**
 
@@ -121,7 +121,7 @@ twapp permissions add 'Bash(npm test:*)'
 
 ## Install
 
-> **Platform:** macOS (Apple Silicon) only. Linux and Windows are not currently supported.
+> **Platform:** macOS (Apple Silicon and Intel). Linux and Windows are not currently supported.
 
 ### Prerequisites
 
@@ -136,12 +136,20 @@ brew install piekstra/tap/twapp
 ### Manual Install
 
 ```bash
+# Determine architecture
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+  ASSET="twapp-macos-x86_64.tar.gz"
+else
+  ASSET="twapp-macos-aarch64.tar.gz"
+fi
+
 # Download latest release
-curl -fSL -o /tmp/twapp-macos-aarch64.tar.gz \
-  https://github.com/piekstra/twapp/releases/latest/download/twapp-macos-aarch64.tar.gz
+curl -fSL -o /tmp/$ASSET \
+  https://github.com/piekstra/twapp/releases/latest/download/$ASSET
 
 # Extract
-cd /tmp && tar -xzf twapp-macos-aarch64.tar.gz
+cd /tmp && tar -xzf $ASSET
 
 # Install
 mkdir -p ~/.config/twapp/bin
@@ -243,9 +251,11 @@ twapp checks for updates on startup and shows an indicator in the sidebar when a
 Manual update:
 
 ```bash
-curl -fSL -o /tmp/twapp-macos-aarch64.tar.gz \
-  https://github.com/piekstra/twapp/releases/latest/download/twapp-macos-aarch64.tar.gz
-cd /tmp && tar -xzf twapp-macos-aarch64.tar.gz
+ARCH=$(uname -m)
+ASSET="twapp-macos-$([ "$ARCH" = "x86_64" ] && echo x86_64 || echo aarch64).tar.gz"
+curl -fSL -o /tmp/$ASSET \
+  https://github.com/piekstra/twapp/releases/latest/download/$ASSET
+cd /tmp && tar -xzf $ASSET
 twapp install-gui /tmp/twapp.app
 ```
 


### PR DESCRIPTION
## Summary

- Build and release for both **Apple Silicon (aarch64)** and **Intel (x86_64)** macOS targets
- CI checks (`cargo check`, `tsc`, lint) run on both architectures via matrix (`macos-latest` + `macos-13`)
- Release workflow builds both targets in parallel, uploads as artifacts, then a `publish` job creates a single GitHub release with both tarballs
- Homebrew formula updated to use `on_arm`/`on_intel` blocks instead of `depends_on arch: :arm64`
- README badge, platform note, and install/update scripts updated to reflect Intel support

Verified locally: the project compiles and runs successfully on x86_64 (`twapp --version` outputs `twapp 0.4.7`).

## Test plan

- [ ] CI check job passes on both `macos-latest` (ARM) and `macos-13` (Intel)
- [ ] Release produces both `twapp-macos-aarch64.tar.gz` and `twapp-macos-x86_64.tar.gz`
- [ ] Homebrew formula installs correctly on Intel (`brew install piekstra/tap/twapp`)
- [ ] Homebrew formula still installs correctly on Apple Silicon
- [ ] `twapp --version` works on both architectures

🤖 Generated with [Claude Code](https://claude.com/claude-code)