### PR TITLE
Fix install-gui self-deletion when source equals target

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ Without this setup, macOS will repeatedly prompt for permission to access Apple 
 
 **Step 1: Code signing** — creates a stable certificate so macOS recognizes all twapp instances as the same app:
 
+**Homebrew install:**
+
+```bash
+twapp setup-cert
+twapp install-gui "$(brew --prefix)/Cellar/twapp/$(brew list --versions twapp | awk '{print $2}')/twapp.app"
+```
+
+**Manual install:**
+
 ```bash
 twapp setup-cert
 twapp install-gui ~/.config/twapp/twapp.app

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1126,6 +1126,17 @@ fn cmd_install_gui(binary_path: &str) -> i32 {
         }
     }
 
+    // Check if source and target resolve to the same path
+    let source_canonical = app_source.canonicalize().unwrap_or_else(|_| app_source.clone());
+    let target_canonical = target.canonicalize().unwrap_or_else(|_| target.clone());
+    if source_canonical == target_canonical {
+        eprintln!(
+            "Error: Source and target are the same path: {}\nProvide a different source .app bundle (e.g. from the Homebrew Cellar or a build directory).",
+            source_canonical.display()
+        );
+        return 1;
+    }
+
     // Remove old bundle
     if target.exists() {
         if let Err(e) = std::fs::remove_dir_all(&target) {


### PR DESCRIPTION
## Summary

- Adds source==target path detection in `cmd_install_gui` to prevent deleting the bundle it's about to copy
- Updates README with separate Homebrew vs manual install instructions for the code signing step

## What was happening

When a user runs `twapp install-gui ~/.config/twapp/twapp.app` (following the old README instructions after a Homebrew install), the function:
1. Canonicalizes the source path → `~/.config/twapp/twapp.app`
2. Sets target to `~/.config/twapp/twapp.app`
3. Deletes the target
4. Tries to copy from the source — which was just deleted

## Fix

- Compares canonicalized source and target paths before proceeding
- Shows a clear error message suggesting the correct source path
- README now has separate instructions for Homebrew and manual installs

Fixes #7

## Test plan

- [x] `cargo check` passes with no errors or warnings
- [ ] Homebrew install: verify `twapp install-gui ~/.config/twapp/twapp.app` now shows a helpful error instead of silently deleting
- [ ] Homebrew install: verify the README's Homebrew-specific command works
- [ ] Manual install: verify `twapp install-gui ~/.config/twapp/twapp.app` still works when source differs from target