### PR TITLE
Fix Spotlight visibility instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,21 +193,13 @@ twapp --version
 
 ### Spotlight Visibility
 
-Neither the Homebrew cellar nor `~/.config/twapp/` is indexed by Spotlight. To launch twapp from Spotlight, symlink the app bundle into `/Applications`:
-
-**Homebrew install:**
+Neither the Homebrew cellar nor `~/.config/twapp/` is indexed by Spotlight, and Spotlight ignores symlinked `.app` bundles. To launch twapp from Spotlight, create a lightweight wrapper app:
 
 ```bash
-ln -s "$(brew --prefix)/Cellar/twapp/$(brew list --versions twapp | awk '{print $2}')/twapp.app" /Applications/twapp.app
+osacompile -o ~/Applications/twapp.app -e 'do shell script "open ~/.config/twapp/twapp.app"'
 ```
 
-**Manual install:**
-
-```bash
-ln -s ~/.config/twapp/twapp.app /Applications/twapp.app
-```
-
-> **Note:** After a Homebrew upgrade the symlink will point to the old version. Re-run the command above to update it.
+This creates a real `.app` in `~/Applications` that Spotlight indexes. It just opens the actual twapp bundle, so updates are always picked up.
 
 ### Code Signing + Full Disk Access (Recommended)
 


### PR DESCRIPTION
## Summary

- Replaces symlink-based Spotlight instructions with `osacompile` wrapper approach
- Spotlight ignores symlinked `.app` bundles, so `ln -s` never actually worked

## What changed

**Before:** Instructions used `ln -s` to symlink `.app` into `/Applications` (separate Homebrew/manual variants, plus a note about stale symlinks after upgrades)

**After:** Single `osacompile` command that creates a real `.app` wrapper in `~/Applications`. Spotlight indexes it, and it always opens the current twapp bundle.

Fixes #9

## Test plan

- [ ] Run `osacompile -o ~/Applications/twapp.app -e 'do shell script "open ~/.config/twapp/twapp.app"'` and verify twapp appears in Spotlight