### PR TITLE
Add shell tab completion (zsh, bash, fish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,24 @@ open ~/.config/twapp/twapp.app
 | `twapp install-gui <binary>` | Install or update the app bundle |
 | `twapp setup-cert` | Create code signing certificate |
 | `twapp dev-reload --pid <pid>` | Rebuild and relaunch (dev workflow) |
+| `twapp completions <shell>` | Generate shell completions (zsh, bash, fish) |
+
+### Shell Completions
+
+Tab completion for subcommands, flags, and arguments:
+
+```bash
+# zsh (default macOS shell)
+mkdir -p ~/.zfunc
+twapp completions zsh > ~/.zfunc/_twapp
+# Add to ~/.zshrc: fpath+=~/.zfunc; autoload -Uz compinit && compinit
+
+# bash
+twapp completions bash > "$(brew --prefix)/etc/bash_completion.d/twapp"
+
+# fish
+twapp completions fish > ~/.config/fish/completions/twapp.fish
+```
 
 ## Updating
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,4 +34,5 @@ uuid = { version = "1", features = ["v4"] }
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 plist = "1"
+clap_complete = "4"
 base64 = "0.22"

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -110,6 +110,12 @@ pub enum Commands {
         /// New session name
         name: String,
     },
+    /// Generate shell completions
+    #[command(name = "completions")]
+    Completions {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
     /// Rebuild, reinstall, relaunch (dev workflow)
     #[command(name = "dev-reload")]
     DevReload {
@@ -329,6 +335,15 @@ pub fn run(cmd: Commands) -> i32 {
             }
         }
         Commands::Rename { name } => cmd_rename(&name),
+        Commands::Completions { shell } => {
+            clap_complete::generate(
+                shell,
+                &mut <crate::Cli as clap::CommandFactory>::command(),
+                "twapp",
+                &mut std::io::stdout(),
+            );
+            0
+        }
         Commands::DevReload {
             pid,
             cwd,


### PR DESCRIPTION
## Summary

- Adds `twapp completions <shell>` subcommand using `clap_complete`
- Supports zsh (default macOS shell), bash, and fish
- Completions are derived from existing Clap command definitions — subcommands, flags, and arguments all work automatically
- Adds install instructions to README

Fixes #8

## Test plan

- [x] `cargo check` passes
- [ ] `twapp completions zsh` outputs valid zsh completion script
- [ ] `twapp completions bash` outputs valid bash completion script
- [ ] `twapp completions fish` outputs valid fish completion script
- [ ] Install zsh completions and verify `twapp <TAB>` completes subcommands
- [ ] Verify `twapp ticket <TAB>` completes nested subcommands