### PR TITLE
Add --chrome flag support for Claude sessions

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -32,6 +32,9 @@ pub enum Commands {
         /// Directory where the original session was started
         #[arg(long)]
         claude_cwd: Option<String>,
+        /// Use Chrome instead of Claude desktop
+        #[arg(long)]
+        chrome: bool,
     },
     /// Resume session in current directory
     #[command(after_help = "Examples:\n  twapp resume              Continue where you left off\n  twapp resume --fork       New session with context from current one")]
@@ -257,7 +260,8 @@ pub fn run(cmd: Commands) -> i32 {
             github,
             session_id: fork_session_id,
             claude_cwd,
-        } => cmd_work(ticket, name, run, github, fork_session_id, claude_cwd),
+            chrome,
+        } => cmd_work(ticket, name, run, github, fork_session_id, claude_cwd, chrome),
         Commands::Resume { fork } => cmd_resume(fork),
         Commands::Sessions { path } => cmd_sessions(path),
         Commands::Ticket { command } => match command {
@@ -375,6 +379,7 @@ pub fn create_session_core(
     github: bool,
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
+    chrome: bool,
 ) -> Result<SessionCreationResult, String> {
     if ticket_id.is_none() && session_name.is_none() {
         return Err("Provide a ticket or session name".to_string());
@@ -475,9 +480,11 @@ pub fn create_session_core(
         forked_from: fork_session_id.clone(),
         imported: None,
         imported_from: None,
+        use_chrome: if chrome { Some(true) } else { None },
     };
     session::write_session(&work_dir, &session_data)?;
 
+    let chrome_flag = if chrome { " --chrome" } else { "" };
     let command = if let Some(ref custom) = run_command {
         custom.clone()
     } else if let Some(ref old_id) = fork_session_id {
@@ -487,11 +494,11 @@ pub fn create_session_core(
             String::new()
         };
         format!(
-            "{}claude --resume {} --fork-session --session-id {}",
-            cd_prefix, old_id, session_id
+            "{}claude --resume {} --fork-session --session-id {}{}",
+            cd_prefix, old_id, session_id, chrome_flag
         )
     } else {
-        format!("claude --session-id {}", session_id)
+        format!("claude --session-id {}{}", session_id, chrome_flag)
     };
 
     let prefill = if let Some(ref ti) = ticket_info {
@@ -524,6 +531,9 @@ pub fn create_session_core(
         app_args.push("--ticket".to_string());
         app_args.push(tf.to_string_lossy().to_string());
     }
+    if chrome {
+        app_args.push("--chrome".to_string());
+    }
 
     Ok(SessionCreationResult {
         name: window_name,
@@ -538,6 +548,7 @@ fn cmd_work(
     github: bool,
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
+    chrome: bool,
 ) -> i32 {
     if ticket_id.is_none() && session_name.is_none() {
         eprintln!("Error: Provide a ticket or --name for the session.");
@@ -551,7 +562,7 @@ fn cmd_work(
         return 1;
     }
 
-    let result = match create_session_core(ticket_id, session_name, run_command, github, fork_session_id, claude_cwd_arg) {
+    let result = match create_session_core(ticket_id, session_name, run_command, github, fork_session_id, claude_cwd_arg, chrome) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -612,12 +623,15 @@ fn cmd_resume(fork: bool) -> i32 {
         String::new()
     };
 
+    let chrome = session_data.use_chrome.unwrap_or(false);
+    let chrome_flag = if chrome { " --chrome" } else { "" };
+
     let session_id;
     if fork {
         let new_id = uuid::Uuid::new_v4().to_string();
         let command = format!(
-            "{}claude --resume {} --fork-session --session-id {}",
-            cd_prefix, session_data.session_id, new_id
+            "{}claude --resume {} --fork-session --session-id {}{}",
+            cd_prefix, session_data.session_id, new_id, chrome_flag
         );
         session_data = session::SessionData {
             session_id: new_id.clone(),
@@ -630,6 +644,7 @@ fn cmd_resume(fork: bool) -> i32 {
             forked_from: Some(session_data.session_id),
             imported: None,
             imported_from: None,
+            use_chrome: if chrome { Some(true) } else { None },
         };
         session_id = new_id;
         // Write the forked session file
@@ -637,16 +652,16 @@ fn cmd_resume(fork: bool) -> i32 {
             eprintln!("Error: {}", e);
             return 1;
         }
-        build_and_launch(&work_dir, &window_name, &color, &session_id, &command)
+        build_and_launch(&work_dir, &window_name, &color, &session_id, &command, chrome)
     } else {
         session_id = session_data.session_id.clone();
-        let command = format!("{}claude --resume {}", cd_prefix, session_id);
+        let command = format!("{}claude --resume {}{}", cd_prefix, session_id, chrome_flag);
         session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
         if let Err(e) = session::write_session(&work_dir, &session_data) {
             eprintln!("Error: {}", e);
             return 1;
         }
-        build_and_launch(&work_dir, &window_name, &color, &session_id, &command)
+        build_and_launch(&work_dir, &window_name, &color, &session_id, &command, chrome)
     }
 }
 
@@ -657,6 +672,7 @@ fn build_and_launch(
     color: &str,
     session_id: &str,
     command: &str,
+    chrome: bool,
 ) -> i32 {
     let mut app_args = vec![
         "--name".to_string(),
@@ -675,6 +691,9 @@ fn build_and_launch(
     if ticket_file.exists() {
         app_args.push("--ticket".to_string());
         app_args.push(ticket_file.to_string_lossy().to_string());
+    }
+    if chrome {
+        app_args.push("--chrome".to_string());
     }
 
     let instance_app = match app_bundle::prepare_instance_app(window_name) {

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -21,6 +21,8 @@ pub struct SessionData {
     pub imported: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub imported_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_chrome: Option<bool>,
 }
 
 /// Derive a filesystem-safe name from a session name.

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -198,7 +198,8 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
     } else {
         String::new()
     };
-    let command = format!("{}claude --resume {}", cd_prefix, session_data.session_id);
+    let chrome_flag = if session_data.use_chrome.unwrap_or(false) { " --chrome" } else { "" };
+    let command = format!("{}claude --resume {}{}", cd_prefix, session_data.session_id, chrome_flag);
 
     let color = if session_data.color.is_empty() {
         crate::cli::theme::random_color().to_string()
@@ -224,6 +225,9 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
         app_args.push("--ticket".to_string());
         app_args.push(ticket_file.to_string_lossy().to_string());
     }
+    if session_data.use_chrome.unwrap_or(false) {
+        app_args.push("--chrome".to_string());
+    }
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&session_data.name)?;
     crate::cli::app_bundle::launch_gui(&instance_app, &app_args)?;
@@ -236,8 +240,9 @@ pub async fn create_and_launch_session(
     ticket: Option<String>,
     name: Option<String>,
     github: bool,
+    chrome: bool,
 ) -> Result<(), String> {
-    let result = crate::cli::create_session_core(ticket, name, None, github, None, None)?;
+    let result = crate::cli::create_session_core(ticket, name, None, github, None, None, chrome)?;
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&result.name)?;
     crate::cli::app_bundle::launch_gui(&instance_app, &result.app_args)?;
@@ -872,6 +877,7 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
             forked_from: None,
             imported: Some(true),
             imported_from: Some(original_cwd),
+            use_chrome: None,
         };
         crate::cli::session::write_session(&session_dir, &session_data)?;
 
@@ -957,16 +963,18 @@ pub async fn fork_session(
     let new_id = uuid::Uuid::new_v4().to_string();
 
     // Build command — always use --fork-session for proper session isolation
+    let chrome = config.chrome;
+    let chrome_flag = if chrome { " --chrome" } else { "" };
     let command = match &old_session_id {
         Some(old_id) => format!(
-            "claude --resume {} --fork-session --session-id {}",
-            old_id, new_id
+            "claude --resume {} --fork-session --session-id {}{}",
+            old_id, new_id, chrome_flag
         ),
-        None => format!("claude --session-id {}", new_id),
+        None => format!("claude --session-id {}{}", new_id, chrome_flag),
     };
 
     // Write .twapp-session.json in the new work directory
-    let session_data = serde_json::json!({
+    let mut session_data = serde_json::json!({
         "session_id": new_id,
         "name": window_name,
         "color": color.to_string(),
@@ -975,6 +983,9 @@ pub async fn fork_session(
         "created": chrono::Utc::now().to_rfc3339(),
         "forked_from": old_session_id,
     });
+    if chrome {
+        session_data["use_chrome"] = serde_json::json!(true);
+    }
     std::fs::write(
         std::path::Path::new(&work_dir).join(".twapp-session.json"),
         serde_json::to_string_pretty(&session_data).unwrap(),
@@ -999,6 +1010,9 @@ pub async fn fork_session(
     if let Some(ref tf) = ticket_file {
         app_args.push("--ticket".to_string());
         app_args.push(tf.clone());
+    }
+    if chrome {
+        app_args.push("--chrome".to_string());
     }
 
     // Use 'open -n' to allow multiple instances on macOS

--- a/src-tauri/src/gui/types.rs
+++ b/src-tauri/src/gui/types.rs
@@ -30,6 +30,10 @@ pub struct GuiArgs {
     /// Claude session ID (for display in UI when resuming)
     #[arg(long)]
     pub session_id: Option<String>,
+
+    /// Use Chrome instead of Claude desktop
+    #[arg(long)]
+    pub chrome: bool,
 }
 
 // Per-tab PTY state

--- a/src/components/SessionLauncher.tsx
+++ b/src/components/SessionLauncher.tsx
@@ -32,6 +32,7 @@ function SessionLauncher({ appVersion }: { appVersion: string | null }) {
   const [newSessionTicket, setNewSessionTicket] = useState("");
   const [newSessionName, setNewSessionName] = useState("");
   const [newSessionGithub, setNewSessionGithub] = useState(false);
+  const [newSessionChrome, setNewSessionChrome] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
 
@@ -421,11 +422,13 @@ function SessionLauncher({ appVersion }: { appVersion: string | null }) {
         ticket: ticket || null,
         name: name || null,
         github: newSessionGithub,
+        chrome: newSessionChrome,
       });
       setLauncherView("sessions");
       setNewSessionTicket("");
       setNewSessionName("");
       setNewSessionGithub(false);
+      setNewSessionChrome(false);
       setTimeout(loadSessions, 1000);
     } catch (e) {
       setCreateError(String(e));
@@ -1206,6 +1209,14 @@ function SessionLauncher({ appVersion }: { appVersion: string | null }) {
               onChange={(e) => setNewSessionGithub(e.target.checked)}
             />
             <span>GitHub issue</span>
+          </label>
+          <label className="launcher-checkbox-field">
+            <input
+              type="checkbox"
+              checked={newSessionChrome}
+              onChange={(e) => setNewSessionChrome(e.target.checked)}
+            />
+            <span>Use Chrome</span>
           </label>
         </div>
         {createError && <div className="launcher-create-error">{createError}</div>}


### PR DESCRIPTION
## Summary

- Adds `--chrome` flag to `twapp work` CLI command
- Persists preference as `use_chrome` in `.twapp-session.json`
- Resume and fork sessions automatically inherit the chrome setting
- Adds "Use Chrome" checkbox in the GUI session launcher's new session form
- Passes `--chrome` through app args so GUI-launched sessions also use it

## Data flow

```
CLI: twapp work --name "test" --chrome
  → create_session_core(chrome: true)
  → writes use_chrome: true to .twapp-session.json
  → appends --chrome to claude command string
  → passes --chrome in app_args to GUI window

GUI: "Use Chrome" checkbox checked
  → invoke("create_and_launch_session", { chrome: true })
  → same create_session_core path

Resume: twapp resume
  → reads session_data.use_chrome
  → appends --chrome to claude --resume command
```

Fixes #6

## Test plan

- [x] `cargo check` — compiles clean
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — all 66 tests pass
- [ ] `twapp work --name "test" --chrome` launches claude with `--chrome` flag
- [ ] Resume that session — should still use `--chrome`
- [ ] Fork that session — new session inherits chrome preference
- [ ] GUI: new session form shows "Use Chrome" checkbox, creates session with flag