### PR TITLE
Add npm test to CI PR check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,6 @@ jobs:
           workspaces: src-tauri
       - run: npm ci
       - run: npx tsc --noEmit
+      - run: npm test
       - run: cargo check --manifest-path src-tauri/Cargo.toml
       - run: cargo check --manifest-path src-tauri/Cargo.toml --target x86_64-apple-darwin


### PR DESCRIPTION
## Summary

- Adds `npm test` step to the PR check workflow
- 66 Vitest tests exist but weren't being run in CI

## Test plan

- [x] CI should now run tests on this PR itself