### PR TITLE
Fix jtk/gh not found when linking tickets from GUI

### DIFF
--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -38,6 +38,11 @@ fn get_app_config(config: tauri::State<'_, GuiArgs>) -> GuiArgs {
 }
 
 pub fn run(args: GuiArgs) {
+    // Set PATH early so all child processes (jtk, gh, sh, etc.) can find
+    // tools installed in user-local directories. Without this, macOS GUI
+    // apps inherit only /usr/bin:/bin:/usr/sbin:/sbin.
+    std::env::set_var("PATH", gui_path_env());
+
     let pty_state = Arc::new(Mutex::new(PtyState::default()));
     let monitor_state = Arc::new(Mutex::new(MonitorState::default()));
 

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -913,7 +913,6 @@ pub async fn fork_session(
         // Fetch ticket via jtk
         let output = tokio::process::Command::new("jtk")
             .args(["issues", "get", key, "-o", "json"])
-            .env("PATH", super::gui_path_env())
             .output()
             .await
             .map_err(|e| format!("Failed to run jtk: {}", e))?;

--- a/src-tauri/src/gui/tickets.rs
+++ b/src-tauri/src/gui/tickets.rs
@@ -136,10 +136,8 @@ pub fn normalize_jtk_ticket(data: &serde_json::Value, key_hint: &str) -> serde_j
 pub async fn link_ticket(key: String, config: tauri::State<'_, GuiArgs>) -> Result<serde_json::Value, String> {
     let cwd = config.cwd.as_deref().unwrap_or(".");
 
-    // Run jtk with explicit PATH for macOS GUI apps
     let output = tokio::process::Command::new("jtk")
         .args(["issues", "get", &key, "-o", "json"])
-        .env("PATH", super::gui_path_env())
         .output()
         .await
         .map_err(|e| format!("Failed to run jtk: {}", e))?;
@@ -186,8 +184,6 @@ pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_j
     let source = old["source"].as_str().unwrap_or("jira");
     let key = old["key"].as_str().ok_or("No ticket key in file")?;
 
-    let path_env = super::gui_path_env();
-
     let ticket = if source == "github" {
         // gh issue view
         let parts: Vec<&str> = key.splitn(2, '#').collect();
@@ -203,7 +199,6 @@ pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_j
                 "--repo", repo,
                 "--json", "title,body,state,labels,milestone,assignees,number,url",
             ])
-            .env("PATH", &path_env)
             .output()
             .await
             .map_err(|e| format!("Failed to run gh: {}", e))?;
@@ -245,7 +240,6 @@ pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_j
         // Jira via jtk
         let output = tokio::process::Command::new("jtk")
             .args(["issues", "get", key, "-o", "json"])
-            .env("PATH", &path_env)
             .output()
             .await
             .map_err(|e| format!("Failed to run jtk: {}", e))?;


### PR DESCRIPTION
<img width="325" height="251" alt="image" src="https://github.com/user-attachments/assets/6de1573e-c2ca-4803-bfe6-cc3589834668" />

## Summary
- macOS GUI apps inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that doesn't include `~/.local/bin` where `jtk` is installed, causing "No such file or directory" errors when linking Jira tickets from the sidebar
- Added a `gui_path_env()` helper that includes `~/.local/bin` and `~/.config/twapp/bin` alongside the existing `/opt/homebrew/bin` and `/usr/local/bin`
- Set PATH once at GUI startup in `run()` so all child processes inherit it — covers `jtk`, `gh`, monitor's `sh -c`, and the CLI ticket functions called via `create_session_core()`
- Removed the per-call-site `.env("PATH", ...)` overrides since they're now redundant

## Test plan
- [ ] Open twapp from Spotlight (GUI mode, not CLI)
- [ ] Enter a Jira ticket key in the sidebar and click Link — should fetch successfully
- [ ] Click Refresh on a linked ticket — should update
- [ ] Create a new session with a ticket key from the launcher — should resolve the ticket
- [ ] Start a monitor command that uses a tool in `~/.local/bin` — should work