### PR TITLE
Add per-session appearance customization

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -496,6 +496,9 @@ pub fn create_session_core(
         imported: None,
         imported_from: None,
         use_chrome: if chrome { Some(true) } else { None },
+        terminal_bg: None,
+        sidebar_bg: None,
+        text_color: None,
     };
     session::write_session(&work_dir, &session_data)?;
 
@@ -660,6 +663,9 @@ fn cmd_resume(fork: bool) -> i32 {
             imported: None,
             imported_from: None,
             use_chrome: if chrome { Some(true) } else { None },
+            terminal_bg: None,
+            sidebar_bg: None,
+            text_color: None,
         };
         session_id = new_id;
         // Write the forked session file

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -23,6 +23,12 @@ pub struct SessionData {
     pub imported_from: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub use_chrome: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal_bg: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sidebar_bg: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub text_color: Option<String>,
 }
 
 /// Derive a filesystem-safe name from a session name.

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -91,6 +91,7 @@ pub fn run(args: GuiArgs) {
             sessions::delete_session,
             sessions::discover_claude_sessions,
             sessions::import_sessions,
+            sessions::update_session_appearance,
             monitor::start_monitor,
             monitor::stop_monitor,
             monitor::get_monitor_status,

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -228,10 +228,39 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
     if session_data.use_chrome.unwrap_or(false) {
         app_args.push("--chrome".to_string());
     }
+    if let Some(ref bg) = session_data.terminal_bg {
+        app_args.push("--terminal-bg".to_string());
+        app_args.push(bg.clone());
+    }
+    if let Some(ref bg) = session_data.sidebar_bg {
+        app_args.push("--sidebar-bg".to_string());
+        app_args.push(bg.clone());
+    }
+    if let Some(ref tc) = session_data.text_color {
+        app_args.push("--text-color".to_string());
+        app_args.push(tc.clone());
+    }
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&session_data.name)?;
     crate::cli::app_bundle::launch_gui(&instance_app, &app_args)?;
 
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_session_appearance(
+    config: tauri::State<'_, super::types::GuiArgs>,
+    terminal_bg: Option<String>,
+    sidebar_bg: Option<String>,
+    text_color: Option<String>,
+) -> Result<(), String> {
+    let cwd = config.cwd.as_deref().ok_or("No working directory")?;
+    let work_dir = std::path::PathBuf::from(cwd);
+    let mut session_data = crate::cli::session::read_session(&work_dir)?;
+    session_data.terminal_bg = terminal_bg;
+    session_data.sidebar_bg = sidebar_bg;
+    session_data.text_color = text_color;
+    crate::cli::session::write_session(&work_dir, &session_data)?;
     Ok(())
 }
 
@@ -878,6 +907,9 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
             imported: Some(true),
             imported_from: Some(original_cwd),
             use_chrome: None,
+            terminal_bg: None,
+            sidebar_bg: None,
+            text_color: None,
         };
         crate::cli::session::write_session(&session_dir, &session_data)?;
 

--- a/src-tauri/src/gui/types.rs
+++ b/src-tauri/src/gui/types.rs
@@ -34,6 +34,18 @@ pub struct GuiArgs {
     /// Use Chrome instead of Claude desktop
     #[arg(long)]
     pub chrome: bool,
+
+    /// Custom terminal background color (hex, e.g. "#1a1a2e")
+    #[arg(long)]
+    pub terminal_bg: Option<String>,
+
+    /// Custom sidebar background color (hex, e.g. "#ffe0e0")
+    #[arg(long)]
+    pub sidebar_bg: Option<String>,
+
+    /// Custom text color (hex, e.g. "#eeeeee")
+    #[arg(long)]
+    pub text_color: Option<String>,
 }
 
 // Per-tab PTY state

--- a/src/App.css
+++ b/src/App.css
@@ -807,6 +807,84 @@ body,
   margin: 4px 0;
 }
 
+/* Color Panel Popover */
+.color-panel-dropdown {
+  position: relative;
+}
+
+.color-panel-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px !important;
+}
+
+.color-circle {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1px solid var(--border-color);
+}
+
+.color-panel {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 4px;
+  width: 200px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+  padding: 8px 12px;
+}
+
+.color-panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.color-panel-reset {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.color-panel-reset:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.color-panel-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.color-panel-row input[type="color"] {
+  width: 28px;
+  height: 20px;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  cursor: pointer;
+  background: none;
+}
+
 /* Notes Section Header (collapsible) */
 .notes-section-header {
   padding: 8px 16px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import "@xterm/xterm/css/xterm.css";
 import "./App.css";
 import { applyThemeColor } from "./color";
 import type { AppConfig, TicketInfo, Note, QuickPrompt, MonitorStatusInfo, MonitorLogEntry, PromptSection, PromptStore, TabInfo, ThemeMode } from "./types";
-import { lightTheme, darkTheme } from "./types";
+import { lightTheme, darkTheme, getLightTheme, getDarkTheme } from "./types";
 import { formatTicketBadge, formatTime } from "./utils/format";
 import { isYamlFile, isHtmlFile, isImageFile, imageMimeType, isFilePath } from "./utils/file";
 import { isNewerVersion } from "./utils/version";
@@ -102,6 +102,10 @@ function App() {
   // Actions dropdown
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsRef = useRef<HTMLDivElement>(null);
+
+  // Color popover
+  const [colorPanelOpen, setColorPanelOpen] = useState(false);
+  const colorPanelRef = useRef<HTMLDivElement>(null);
 
   // Monitor state
   const [monitorStatus, setMonitorStatus] = useState<MonitorStatusInfo | null>(null);
@@ -665,7 +669,7 @@ function App() {
     return () => document.removeEventListener("mousedown", handler);
   }, [monitorFloat, monitorExpanded]);
 
-  // Apply theme whenever themeMode or accent color changes
+  // Apply theme whenever themeMode or accent/custom colors change
   useEffect(() => {
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
 
@@ -674,18 +678,37 @@ function App() {
 
       document.documentElement.classList.toggle("dark", isDark);
 
+      const termBg = appConfig?.terminal_bg ?? undefined;
+      const textCol = appConfig?.text_color ?? undefined;
+      const theme = isDark ? getDarkTheme(termBg, textCol) : getLightTheme(termBg, textCol);
+
       if (terminalInstance.current) {
-        terminalInstance.current.options.theme = isDark ? darkTheme : lightTheme;
+        terminalInstance.current.options.theme = theme;
       }
       if (monitorTerm.current) {
-        monitorTerm.current.options.theme = isDark ? darkTheme : lightTheme;
+        monitorTerm.current.options.theme = theme;
       }
       // Apply theme to all tab terminals
       tabInstances.current.forEach((tab) => {
-        if (tab.term) tab.term.options.theme = isDark ? darkTheme : lightTheme;
+        if (tab.term) tab.term.options.theme = theme;
       });
 
-      if (appConfig?.color) {
+      // Set CSS variables for terminal background and text
+      if (appConfig?.terminal_bg) {
+        document.documentElement.style.setProperty("--bg-terminal", appConfig.terminal_bg);
+      } else {
+        document.documentElement.style.removeProperty("--bg-terminal");
+      }
+      if (appConfig?.text_color) {
+        document.documentElement.style.setProperty("--text-terminal", appConfig.text_color);
+      } else {
+        document.documentElement.style.removeProperty("--text-terminal");
+      }
+
+      // Apply sidebar color: custom sidebar_bg takes precedence over session accent
+      if (appConfig?.sidebar_bg) {
+        applyThemeColor(appConfig.sidebar_bg, isDark);
+      } else if (appConfig?.color) {
         applyThemeColor(appConfig.color, isDark);
       }
     };
@@ -696,7 +719,7 @@ function App() {
     const handler = () => applyTheme();
     mediaQuery.addEventListener("change", handler);
     return () => mediaQuery.removeEventListener("change", handler);
-  }, [themeMode, appConfig?.color]);
+  }, [themeMode, appConfig?.color, appConfig?.terminal_bg, appConfig?.sidebar_bg, appConfig?.text_color]);
 
   // Refit terminal when sidebar changes (debounced to avoid mid-stream reflow)
   useEffect(() => {
@@ -739,6 +762,18 @@ function App() {
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [actionsOpen]);
+
+  // Close color popover on outside click
+  useEffect(() => {
+    if (!colorPanelOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (colorPanelRef.current && !colorPanelRef.current.contains(e.target as Node)) {
+        setColorPanelOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [colorPanelOpen]);
 
   // Close monitor logs dropdown on outside click
   useEffect(() => {
@@ -945,6 +980,18 @@ function App() {
     if (marks[newIndex]) {
       marks[newIndex].classList.add("search-highlight-active");
       marks[newIndex].scrollIntoView({ block: "center", behavior: "smooth" });
+    }
+  };
+
+  const handleAppearanceChange = (fields: Partial<Record<"terminal_bg" | "sidebar_bg" | "text_color", string | null>>) => {
+    setAppConfig((prev) => prev ? { ...prev, ...fields } : prev);
+    if (appConfig) {
+      const updated = {
+        terminalBg: "terminal_bg" in fields ? fields.terminal_bg ?? null : appConfig.terminal_bg,
+        sidebarBg: "sidebar_bg" in fields ? fields.sidebar_bg ?? null : appConfig.sidebar_bg,
+        textColor: "text_color" in fields ? fields.text_color ?? null : appConfig.text_color,
+      };
+      invoke("update_session_appearance", updated).catch(console.error);
     }
   };
 
@@ -1944,6 +1991,52 @@ function App() {
                     >
                       {reloading ? "Building..." : "Rebuild"}
                     </button>
+                  </div>
+                )}
+              </div>
+              <div className="color-panel-dropdown" ref={colorPanelRef}>
+                <button
+                  className="sidebar-action-button color-panel-trigger"
+                  onClick={() => setColorPanelOpen(!colorPanelOpen)}
+                  title="Customize colors"
+                  style={appConfig?.terminal_bg || appConfig?.sidebar_bg || appConfig?.text_color ? {
+                    borderColor: "var(--accent-indicator, var(--border-hover))",
+                  } : undefined}
+                >
+                  <span className="color-circle" style={{ background: appConfig?.terminal_bg || appConfig?.sidebar_bg || "var(--text-secondary)" }} />
+                </button>
+                {colorPanelOpen && (
+                  <div className="color-panel">
+                    <div className="color-panel-header">
+                      <span>Appearance</span>
+                      <button className="color-panel-reset" onClick={() => {
+                        handleAppearanceChange({ terminal_bg: null, sidebar_bg: null, text_color: null });
+                      }}>Reset</button>
+                    </div>
+                    <label className="color-panel-row">
+                      <span>Terminal</span>
+                      <input
+                        type="color"
+                        value={appConfig?.terminal_bg || (document.documentElement.classList.contains("dark") ? "#1a1a2e" : "#f5f5f7")}
+                        onChange={(e) => handleAppearanceChange({ terminal_bg: e.target.value })}
+                      />
+                    </label>
+                    <label className="color-panel-row">
+                      <span>Sidebar</span>
+                      <input
+                        type="color"
+                        value={appConfig?.sidebar_bg || appConfig?.color || (document.documentElement.classList.contains("dark") ? "#16162a" : "#f5f5f7")}
+                        onChange={(e) => handleAppearanceChange({ sidebar_bg: e.target.value })}
+                      />
+                    </label>
+                    <label className="color-panel-row">
+                      <span>Text</span>
+                      <input
+                        type="color"
+                        value={appConfig?.text_color || (document.documentElement.classList.contains("dark") ? "#eeeeee" : "#1d1d1f")}
+                        onChange={(e) => handleAppearanceChange({ text_color: e.target.value })}
+                      />
+                    </label>
                   </div>
                 )}
               </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,9 @@ export interface AppConfig {
   prefill: string | null;
   ticket: string | null;
   session_id: string | null;
+  terminal_bg: string | null;
+  sidebar_bg: string | null;
+  text_color: string | null;
 }
 
 export interface TicketInfo {
@@ -63,53 +66,60 @@ export interface PromptStore {
   sections: PromptSection[];
 }
 
-export const lightTheme = {
-  background: "#f5f5f7",
-  foreground: "#1d1d1f",
-  cursor: "#1d1d1f",
-  cursorAccent: "#f5f5f7",
-  selectionBackground: "#b4d7ff",
-  black: "#1d1d1f",
-  red: "#c41a16",
-  green: "#007400",
-  yellow: "#826b28",
-  blue: "#0451a5",
-  magenta: "#a626a4",
-  cyan: "#0997b3",
-  white: "#d4d4d4",
-  brightBlack: "#86868b",
-  brightRed: "#ff3b30",
-  brightGreen: "#34c759",
-  brightYellow: "#ffcc00",
-  brightBlue: "#007aff",
-  brightMagenta: "#af52de",
-  brightCyan: "#5ac8fa",
-  brightWhite: "#ffffff",
-};
+export function getLightTheme(bg?: string, fg?: string) {
+  return {
+    background: bg ?? "#f5f5f7",
+    foreground: fg ?? "#1d1d1f",
+    cursor: fg ?? "#1d1d1f",
+    cursorAccent: bg ?? "#f5f5f7",
+    selectionBackground: "#b4d7ff",
+    black: "#1d1d1f",
+    red: "#c41a16",
+    green: "#007400",
+    yellow: "#826b28",
+    blue: "#0451a5",
+    magenta: "#a626a4",
+    cyan: "#0997b3",
+    white: "#d4d4d4",
+    brightBlack: "#86868b",
+    brightRed: "#ff3b30",
+    brightGreen: "#34c759",
+    brightYellow: "#ffcc00",
+    brightBlue: "#007aff",
+    brightMagenta: "#af52de",
+    brightCyan: "#5ac8fa",
+    brightWhite: "#ffffff",
+  };
+}
 
-export const darkTheme = {
-  background: "#1a1a2e",
-  foreground: "#eee",
-  cursor: "#eee",
-  cursorAccent: "#1a1a2e",
-  selectionBackground: "#3a3a5e",
-  black: "#1a1a2e",
-  red: "#ff6b6b",
-  green: "#69db7c",
-  yellow: "#ffd43b",
-  blue: "#4dabf7",
-  magenta: "#da77f2",
-  cyan: "#66d9e8",
-  white: "#eee",
-  brightBlack: "#495057",
-  brightRed: "#ff8787",
-  brightGreen: "#8ce99a",
-  brightYellow: "#ffe066",
-  brightBlue: "#74c0fc",
-  brightMagenta: "#e599f7",
-  brightCyan: "#99e9f2",
-  brightWhite: "#fff",
-};
+export function getDarkTheme(bg?: string, fg?: string) {
+  return {
+    background: bg ?? "#1a1a2e",
+    foreground: fg ?? "#eee",
+    cursor: fg ?? "#eee",
+    cursorAccent: bg ?? "#1a1a2e",
+    selectionBackground: "#3a3a5e",
+    black: "#1a1a2e",
+    red: "#ff6b6b",
+    green: "#69db7c",
+    yellow: "#ffd43b",
+    blue: "#4dabf7",
+    magenta: "#da77f2",
+    cyan: "#66d9e8",
+    white: "#eee",
+    brightBlack: "#495057",
+    brightRed: "#ff8787",
+    brightGreen: "#8ce99a",
+    brightYellow: "#ffe066",
+    brightBlue: "#74c0fc",
+    brightMagenta: "#e599f7",
+    brightCyan: "#99e9f2",
+    brightWhite: "#fff",
+  };
+}
+
+export const lightTheme = getLightTheme();
+export const darkTheme = getDarkTheme();
 
 export interface LauncherSession {
   session_id: string;


### PR DESCRIPTION
<img width="1071" height="855" alt="image" src="https://github.com/user-attachments/assets/25e1a567-d9ce-42c0-b191-5b2c42588008" />

<img width="1071" height="855" alt="image" src="https://github.com/user-attachments/assets/175cfe2c-fd8f-4193-8437-0ca951d13883" />


## Summary
- Adds a color panel in the sidebar for customizing terminal background, sidebar background, and text color per session
- Colors persist to session JSON and propagate through session launch args (CLI/GUI parity)
- Fixes stale-closure bug where Reset only cleared the last color field (batched into single state update + invoke call)
- Scopes custom text color to `--text-terminal` CSS variable instead of overriding `--text-primary` globally (which was bleeding into sidebar, modals, badges)

## Test plan
- [x] Open a session, click the color circle in the sidebar to open the appearance panel
- [x] Change terminal background, sidebar background, and text color — verify each applies correctly
- [x] Click Reset — verify all three colors revert (not just the last one)
- [x] Close and reopen the session — verify colors persisted
- [x] Set a custom text color and verify sidebar/modal text is NOT affected