### PR TITLE
Fix missing Codex session IDs on launch and restart

### DIFF
--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -108,7 +108,12 @@ impl SessionData {
             && self.native_session_id(other_provider(preferred)).is_some()
     }
 
-    pub fn set_provider_session(&mut self, provider: AgentProvider, session_id: String, cwd: String) {
+    pub fn set_provider_session(
+        &mut self,
+        provider: AgentProvider,
+        session_id: String,
+        cwd: String,
+    ) {
         match provider {
             AgentProvider::Claude => {
                 self.session_id = session_id;
@@ -183,15 +188,18 @@ pub fn find_codex_session_file(session_id: &str) -> Option<PathBuf> {
     scan_codex_session_dirs(&root, session_id)
 }
 
-pub fn find_latest_codex_session_for_cwd(cwd: &str, started_at_rfc3339: &str) -> Option<String> {
-    let root = dirs::home_dir()?.join(".codex/sessions");
+fn find_latest_codex_session_for_cwd_in(
+    root: &Path,
+    cwd: &str,
+    started_at_rfc3339: &str,
+) -> Option<String> {
     if !root.exists() {
         return None;
     }
 
     let started_at = chrono::DateTime::parse_from_rfc3339(started_at_rfc3339).ok()?;
     let mut best: Option<(chrono::DateTime<chrono::FixedOffset>, String)> = None;
-    let mut stack = vec![root];
+    let mut stack = vec![root.to_path_buf()];
 
     while let Some(dir) = stack.pop() {
         let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -213,7 +221,12 @@ pub fn find_latest_codex_session_for_cwd(cwd: &str, started_at_rfc3339: &str) ->
             let mut line = String::new();
             let mut reader = std::io::BufReader::new(file);
             use std::io::BufRead;
-            if reader.read_line(&mut line).ok().filter(|n| *n > 0).is_none() {
+            if reader
+                .read_line(&mut line)
+                .ok()
+                .filter(|n| *n > 0)
+                .is_none()
+            {
                 continue;
             }
             let Ok(value) = serde_json::from_str::<serde_json::Value>(&line) else {
@@ -250,6 +263,11 @@ pub fn find_latest_codex_session_for_cwd(cwd: &str, started_at_rfc3339: &str) ->
     }
 
     best.map(|(_, id)| id)
+}
+
+pub fn find_latest_codex_session_for_cwd(cwd: &str, started_at_rfc3339: &str) -> Option<String> {
+    let root = dirs::home_dir()?.join(".codex/sessions");
+    find_latest_codex_session_for_cwd_in(&root, cwd, started_at_rfc3339)
 }
 
 /// Derive a filesystem-safe name from a session name.
@@ -292,8 +310,7 @@ pub fn read_session(work_dir: &Path) -> Result<SessionData, String> {
     }
     let content = std::fs::read_to_string(&session_file)
         .map_err(|e| format!("Failed to read session file: {}", e))?;
-    serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse session file: {}", e))
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse session file: {}", e))
 }
 
 /// Write session data back to the session file.
@@ -336,10 +353,7 @@ pub fn run_health_checks(work_dir: &Path, session_data: Option<&SessionData>) {
                         changed = true;
                     }
                     if !obj.contains_key("last_resumed") {
-                        obj.insert(
-                            "last_resumed".to_string(),
-                            serde_json::Value::Null,
-                        );
+                        obj.insert("last_resumed".to_string(), serde_json::Value::Null);
                         changed = true;
                     }
                     if !obj.contains_key("provider") {
@@ -368,9 +382,19 @@ pub fn run_health_checks(work_dir: &Path, session_data: Option<&SessionData>) {
             .ok()
             .and_then(|c| serde_json::from_str::<SessionData>(&c).ok())
             .map(|s| s.name)
-            .unwrap_or_else(|| work_dir.file_name().unwrap_or_default().to_string_lossy().to_string())
+            .unwrap_or_else(|| {
+                work_dir
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            })
     } else {
-        work_dir.file_name().unwrap_or_default().to_string_lossy().to_string()
+        work_dir
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string()
     };
     let safe_name = name.replace(' ', "-");
     let expected_notes = work_dir.join(format!(".twapp-notes-{}.json", safe_name));
@@ -389,6 +413,7 @@ pub fn run_health_checks(work_dir: &Path, session_data: Option<&SessionData>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn display_session_id_prefers_requested_provider() {
@@ -446,6 +471,83 @@ mod tests {
         data.codex_session_id = Some("codex-456".to_string());
         assert!(!data.needs_migration(AgentProvider::Codex));
     }
+
+    #[test]
+    fn find_latest_codex_session_for_cwd_uses_newest_matching_session_after_cutoff() {
+        let root = std::env::temp_dir().join(format!("twapp-codex-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(root.join("2026/04/07")).unwrap();
+
+        let write_session_meta = |name: &str, id: &str, timestamp: &str, cwd: &str| {
+            let path = root.join("2026/04/07").join(name);
+            let payload = serde_json::json!({
+                "timestamp": timestamp,
+                "type": "session_meta",
+                "payload": {
+                    "id": id,
+                    "timestamp": timestamp,
+                    "cwd": cwd,
+                }
+            });
+            fs::write(path, format!("{}\n", payload)).unwrap();
+        };
+
+        write_session_meta(
+            "older.jsonl",
+            "codex-older",
+            "2026-04-07T16:15:27.890Z",
+            "/tmp/demo",
+        );
+        write_session_meta(
+            "wrong-cwd.jsonl",
+            "codex-wrong",
+            "2026-04-07T16:15:28.890Z",
+            "/tmp/other",
+        );
+        write_session_meta(
+            "latest.jsonl",
+            "codex-latest",
+            "2026-04-07T16:15:29.890Z",
+            "/tmp/demo",
+        );
+
+        let found = find_latest_codex_session_for_cwd_in(
+            &root,
+            "/tmp/demo",
+            "2026-04-07T16:15:18.440327+00:00",
+        );
+
+        assert_eq!(found.as_deref(), Some("codex-latest"));
+
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn find_latest_codex_session_for_cwd_ignores_sessions_before_cutoff() {
+        let root = std::env::temp_dir().join(format!("twapp-codex-test-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(root.join("2026/04/07")).unwrap();
+
+        let path = root.join("2026/04/07/before-cutoff.jsonl");
+        let payload = serde_json::json!({
+            "timestamp": "2026-04-07T16:15:10.000Z",
+            "type": "session_meta",
+            "payload": {
+                "id": "codex-before",
+                "timestamp": "2026-04-07T16:15:10.000Z",
+                "cwd": "/tmp/demo",
+            }
+        });
+        fs::write(path, format!("{}\n", payload)).unwrap();
+
+        let found = find_latest_codex_session_for_cwd_in(
+            &root,
+            "/tmp/demo",
+            "2026-04-07T16:15:18.440327+00:00",
+        );
+
+        assert_eq!(found, None);
+
+        let _ = fs::remove_dir_all(root);
+    }
 }
 
 /// Pre-approve a directory in ~/.claude.json so Claude skips the trust prompt.
@@ -501,10 +603,10 @@ fn ensure_claude_settings(work_dir: &Path) {
             .as_object_mut()
             .unwrap()
             .insert("allowedTools".to_string(), serde_json::Value::Array(sorted));
-        project
-            .as_object_mut()
-            .unwrap()
-            .insert("hasTrustDialogAccepted".to_string(), serde_json::Value::Bool(true));
+        project.as_object_mut().unwrap().insert(
+            "hasTrustDialogAccepted".to_string(),
+            serde_json::Value::Bool(true),
+        );
 
         std::fs::write(&claude_json, serde_json::to_string_pretty(&data)?)?;
         Ok(())

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,22 +1,22 @@
-pub mod types;
-pub mod pty;
-pub mod notes;
-pub mod prompts;
-pub mod tickets;
-pub mod sessions;
-pub mod monitor;
 pub mod config;
 pub mod files;
+pub mod monitor;
+pub mod notes;
+pub mod prompts;
+pub mod pty;
+pub mod sessions;
 pub mod shell_env;
+pub mod tickets;
+pub mod types;
 
-pub use types::GuiArgs;
 pub use tickets::{extract_adf_text, truncate_str};
+pub use types::GuiArgs;
 
-use types::*;
 use parking_lot::Mutex;
 use std::sync::Arc;
-use tauri::{Emitter, Manager};
 use tauri::menu::{CheckMenuItemBuilder, PredefinedMenuItem, SubmenuBuilder};
+use tauri::{Emitter, Manager};
+use types::*;
 
 use crate::cli::monitor::MonitorRequest;
 
@@ -78,6 +78,7 @@ pub fn run(args: GuiArgs) {
             sessions::list_all_sessions,
             sessions::launch_session,
             sessions::start_codex_session_capture,
+            sessions::sync_codex_session_id,
             config::get_global_config,
             config::save_global_config,
             config::get_font_family_preference,
@@ -238,8 +239,7 @@ pub fn run(args: GuiArgs) {
                                 }
                             }
                             "stop" => {
-                                let monitor_state =
-                                    app_handle.state::<Arc<Mutex<MonitorState>>>();
+                                let monitor_state = app_handle.state::<Arc<Mutex<MonitorState>>>();
                                 let config = app_handle.state::<GuiArgs>();
                                 let _ = monitor::stop_monitor_internal(
                                     &app_handle,

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -1,12 +1,12 @@
+use super::tickets::{normalize_jtk_ticket, read_session_id, truncate_str};
 use super::types::*;
-use super::tickets::{read_session_id, truncate_str, normalize_jtk_ticket};
 use rand::Rng;
 use std::io::{BufRead, Seek, SeekFrom};
 use tauri::Emitter;
 
 use crate::cli::session::{
-    AgentProvider, SessionData, count_codex_conversation_messages, find_latest_codex_session_for_cwd,
-    other_provider, shell_escape_single,
+    count_codex_conversation_messages, find_latest_codex_session_for_cwd, other_provider,
+    shell_escape_single, AgentProvider, SessionData,
 };
 
 pub fn sanitize_instance_name(name: &str) -> String {
@@ -66,12 +66,19 @@ fn configured_provider() -> AgentProvider {
         .unwrap_or(AgentProvider::Claude)
 }
 
-fn count_messages_for_provider(session_data: &SessionData, provider: AgentProvider, work_dir: &std::path::Path) -> Option<u32> {
+fn count_messages_for_provider(
+    session_data: &SessionData,
+    provider: AgentProvider,
+    work_dir: &std::path::Path,
+) -> Option<u32> {
     match provider {
         AgentProvider::Claude => session_data
             .native_session_id(AgentProvider::Claude)
             .and_then(|session_id| {
-                count_conversation_messages(session_id, &session_data.native_cwd(AgentProvider::Claude, work_dir))
+                count_conversation_messages(
+                    session_id,
+                    &session_data.native_cwd(AgentProvider::Claude, work_dir),
+                )
             }),
         AgentProvider::Codex => session_data
             .native_session_id(AgentProvider::Codex)
@@ -85,9 +92,14 @@ fn launcher_session_from_data(
     preferred: AgentProvider,
 ) -> LauncherSession {
     let is_running = check_instance_running(&session_data.name);
-    let message_count = count_messages_for_provider(session_data, preferred, directory)
-        .or_else(|| count_messages_for_provider(session_data, other_provider(preferred), directory));
-    let last_active = session_data.last_resumed.clone().or_else(|| Some(session_data.created.clone()));
+    let message_count =
+        count_messages_for_provider(session_data, preferred, directory).or_else(|| {
+            count_messages_for_provider(session_data, other_provider(preferred), directory)
+        });
+    let last_active = session_data
+        .last_resumed
+        .clone()
+        .or_else(|| Some(session_data.created.clone()));
     let imported = session_data.imported.unwrap_or(false);
     let forked_from = session_data.forked_from.clone();
     let fallback_session_key = directory.to_string_lossy().to_string();
@@ -125,7 +137,11 @@ fn load_ticket_context(work_dir: &std::path::Path) -> Option<String> {
     if key.is_empty() && title.is_empty() {
         return None;
     }
-    Some(format!("Ticket: {} {} [{}]", key, title, status).trim().to_string())
+    Some(
+        format!("Ticket: {} {} [{}]", key, title, status)
+            .trim()
+            .to_string(),
+    )
 }
 
 fn load_note_context(work_dir: &std::path::Path) -> Vec<String> {
@@ -208,17 +224,23 @@ fn build_migration_prompt(
         AgentProvider::Claude => {
             if let Some(source_id) = session_data.native_session_id(AgentProvider::Claude) {
                 let home = dirs::home_dir().unwrap_or_default();
-                let encoded = session_data.native_cwd(AgentProvider::Claude, work_dir).replace('/', "-");
+                let encoded = session_data
+                    .native_cwd(AgentProvider::Claude, work_dir)
+                    .replace('/', "-");
                 let jsonl_path = home
                     .join(".claude/projects")
                     .join(encoded)
                     .join(format!("{}.jsonl", source_id));
-                let (summary, first_message, _, last_timestamp, _, _) = extract_jsonl_metadata(&jsonl_path);
+                let (summary, first_message, _, last_timestamp, _, _) =
+                    extract_jsonl_metadata(&jsonl_path);
                 if let Some(summary) = summary.or(first_message) {
                     sections.push(format!("Claude context summary: {}", summary));
                 }
                 if let Some(last_timestamp) = last_timestamp {
-                    sections.push(format!("Claude transcript last activity: {}", last_timestamp));
+                    sections.push(format!(
+                        "Claude transcript last activity: {}",
+                        last_timestamp
+                    ));
                 }
             }
         }
@@ -226,7 +248,10 @@ fn build_migration_prompt(
             if let Some(source_id) = session_data.native_session_id(AgentProvider::Codex) {
                 let prompts = recent_codex_prompts(source_id);
                 if !prompts.is_empty() {
-                    sections.push(format!("Recent Codex user requests:\n- {}", prompts.join("\n- ")));
+                    sections.push(format!(
+                        "Recent Codex user requests:\n- {}",
+                        prompts.join("\n- ")
+                    ));
                 }
             }
         }
@@ -251,7 +276,11 @@ fn build_provider_command(
     let prompt_suffix = prompt
         .map(|text| format!(" '{}'", shell_escape_single(text)))
         .unwrap_or_default();
-    let chrome_flag = if session_data.use_chrome.unwrap_or(false) { " --chrome" } else { "" };
+    let chrome_flag = if session_data.use_chrome.unwrap_or(false) {
+        " --chrome"
+    } else {
+        ""
+    };
 
     match provider {
         AgentProvider::Claude => {
@@ -281,13 +310,19 @@ fn build_provider_command(
                     String::new()
                 };
                 (
-                    format!("{}claude --resume {}{}{}", cd_prefix, current_id, chrome_flag, prompt_suffix),
+                    format!(
+                        "{}claude --resume {}{}{}",
+                        cd_prefix, current_id, chrome_flag, prompt_suffix
+                    ),
                     Some(current_id.to_string()),
                 )
             } else {
                 let new_id = uuid::Uuid::new_v4().to_string();
                 (
-                    format!("claude --session-id {}{}{}", new_id, chrome_flag, prompt_suffix),
+                    format!(
+                        "claude --session-id {}{}{}",
+                        new_id, chrome_flag, prompt_suffix
+                    ),
                     Some(new_id),
                 )
             };
@@ -299,10 +334,19 @@ fn build_provider_command(
                 let current_id = session_data
                     .native_session_id(AgentProvider::Codex)
                     .ok_or("No Codex session ID available to fork")?;
-                (format!("codex fork {} -C '{}'{}", current_id, escaped_dir, prompt_suffix), None)
+                (
+                    format!(
+                        "codex fork {} -C '{}'{}",
+                        current_id, escaped_dir, prompt_suffix
+                    ),
+                    None,
+                )
             } else if let Some(current_id) = session_data.native_session_id(AgentProvider::Codex) {
                 (
-                    format!("codex resume {} -C '{}'{}", current_id, escaped_dir, prompt_suffix),
+                    format!(
+                        "codex resume {} -C '{}'{}",
+                        current_id, escaped_dir, prompt_suffix
+                    ),
                     Some(current_id.to_string()),
                 )
             } else {
@@ -311,6 +355,40 @@ fn build_provider_command(
             Ok(command)
         }
     }
+}
+
+fn sync_codex_session_id_for_directory(
+    directory: &str,
+    started_at: Option<&str>,
+) -> Result<Option<String>, String> {
+    let work_dir = std::path::PathBuf::from(directory);
+    let mut session_data = crate::cli::session::read_session(&work_dir)?;
+
+    if let Some(existing_id) = session_data.native_session_id(AgentProvider::Codex) {
+        return Ok(Some(existing_id.to_string()));
+    }
+
+    let codex_cwd = session_data.native_cwd(AgentProvider::Codex, &work_dir);
+    let capture_started_at = started_at.unwrap_or(&session_data.created);
+    let Some(session_id) = find_latest_codex_session_for_cwd(&codex_cwd, capture_started_at) else {
+        return Ok(None);
+    };
+
+    session_data.set_provider_session(AgentProvider::Codex, session_id.clone(), codex_cwd);
+    session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
+    crate::cli::session::write_session(&work_dir, &session_data)?;
+
+    Ok(Some(session_id))
+}
+
+fn emit_provider_session_update(app: &tauri::AppHandle, provider: &str, session_id: &str) {
+    let _ = app.emit(
+        "session-provider-updated",
+        serde_json::json!({
+            "provider": provider,
+            "session_id": session_id,
+        }),
+    );
 }
 
 pub fn scan_and_emit(app: &tauri::AppHandle, dir: &std::path::Path, depth: usize) {
@@ -336,7 +414,10 @@ pub fn scan_and_emit(app: &tauri::AppHandle, dir: &std::path::Path, depth: usize
                         serde_json::from_str::<crate::cli::session::SessionData>(&content)
                     {
                         let preferred = configured_provider();
-                        let _ = app.emit("launcher:session", launcher_session_from_data(&data, &path, preferred));
+                        let _ = app.emit(
+                            "launcher:session",
+                            launcher_session_from_data(&data, &path, preferred),
+                        );
                     }
                 }
             }
@@ -376,7 +457,11 @@ pub async fn list_all_sessions() -> Result<LauncherResponse, String> {
 
     let mut results = Vec::new();
     for (data, dir) in sessions {
-        results.push(launcher_session_from_data(&data, &dir, global_config.agent_provider));
+        results.push(launcher_session_from_data(
+            &data,
+            &dir,
+            global_config.agent_provider,
+        ));
     }
 
     Ok(LauncherResponse {
@@ -422,12 +507,21 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
     } else {
         None
     };
-    let (command, provider_session_id) =
-        build_provider_command(preferred, &session_data, &work_dir, migration_prompt.as_deref(), false)?;
+    let (command, provider_session_id) = build_provider_command(
+        preferred,
+        &session_data,
+        &work_dir,
+        migration_prompt.as_deref(),
+        false,
+    )?;
 
     if preferred == AgentProvider::Claude {
         if let Some(provider_session_id) = provider_session_id.clone() {
-            session_data.set_provider_session(preferred, provider_session_id, work_dir.to_string_lossy().to_string());
+            session_data.set_provider_session(
+                preferred,
+                provider_session_id,
+                work_dir.to_string_lossy().to_string(),
+            );
         }
     } else if session_data.codex_cwd.is_none() {
         session_data.codex_cwd = Some(work_dir.to_string_lossy().to_string());
@@ -458,7 +552,11 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
         app_args.push("--session-id".to_string());
         app_args.push(provider_session_id);
     }
-    if preferred == AgentProvider::Codex && session_data.native_session_id(AgentProvider::Codex).is_none() {
+    if preferred == AgentProvider::Codex
+        && session_data
+            .native_session_id(AgentProvider::Codex)
+            .is_none()
+    {
         app_args.push("--capture-started-at".to_string());
         app_args.push(chrono::Utc::now().to_rfc3339());
     }
@@ -502,32 +600,28 @@ pub async fn start_codex_session_capture(
     started_at: String,
 ) -> Result<(), String> {
     std::thread::spawn(move || {
-        for _ in 0..30 {
-            std::thread::sleep(std::time::Duration::from_secs(1));
-            let Some(session_id) = find_latest_codex_session_for_cwd(&directory, &started_at) else {
-                continue;
-            };
-
-            let work_dir = std::path::PathBuf::from(&directory);
-            let Ok(mut session_data) = crate::cli::session::read_session(&work_dir) else {
-                return;
-            };
-            session_data.set_provider_session(AgentProvider::Codex, session_id.clone(), directory.clone());
-            session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
-            if crate::cli::session::write_session(&work_dir, &session_data).is_ok() {
-                let _ = app.emit(
-                    "session-provider-updated",
-                    serde_json::json!({
-                        "provider": "codex",
-                        "session_id": session_id,
-                    }),
-                );
+        for attempt in 0..120 {
+            if attempt > 0 {
+                std::thread::sleep(std::time::Duration::from_secs(1));
             }
-            return;
+
+            match sync_codex_session_id_for_directory(&directory, Some(&started_at)) {
+                Ok(Some(session_id)) => {
+                    emit_provider_session_update(&app, "codex", &session_id);
+                    return;
+                }
+                Ok(None) => continue,
+                Err(_) => return,
+            }
         }
     });
 
     Ok(())
+}
+
+#[tauri::command]
+pub async fn sync_codex_session_id(directory: String) -> Result<Option<String>, String> {
+    sync_codex_session_id_for_directory(&directory, None)
 }
 
 #[tauri::command]
@@ -585,9 +679,7 @@ pub async fn preflight_delete_session(directory: String) -> Result<DeletePreflig
             entries
                 .flatten()
                 .filter(|e| {
-                    e.file_name()
-                        .to_string_lossy()
-                        .starts_with(".twapp-notes")
+                    e.file_name().to_string_lossy().starts_with(".twapp-notes")
                         && e.file_name().to_string_lossy().ends_with(".json")
                 })
                 .filter_map(|e| std::fs::read_to_string(e.path()).ok())
@@ -605,9 +697,7 @@ pub async fn preflight_delete_session(directory: String) -> Result<DeletePreflig
             .join(".claude/projects")
             .join(&encoded)
             .join(format!("{}.jsonl", session_data.session_id));
-        std::fs::metadata(&jsonl_path)
-            .map(|m| m.len())
-            .unwrap_or(0)
+        std::fs::metadata(&jsonl_path).map(|m| m.len()).unwrap_or(0)
     };
 
     let last_active = session_data
@@ -711,8 +801,14 @@ pub async fn update_session_fields(
         data.name = n.clone();
     }
     if let Some(ref sid) = session_id {
-        if data.provider == Some(AgentProvider::Codex) || (data.session_id.is_empty() && data.codex_session_id.is_some()) {
-            data.codex_session_id = if sid.is_empty() { None } else { Some(sid.clone()) };
+        if data.provider == Some(AgentProvider::Codex)
+            || (data.session_id.is_empty() && data.codex_session_id.is_some())
+        {
+            data.codex_session_id = if sid.is_empty() {
+                None
+            } else {
+                Some(sid.clone())
+            };
         } else {
             data.session_id = sid.clone();
         }
@@ -721,7 +817,11 @@ pub async fn update_session_fields(
         data.claude_cwd = cwd.clone();
     }
     if let Some(ref tk) = ticket_key {
-        data.ticket_key = if tk.is_empty() { None } else { Some(tk.clone()) };
+        data.ticket_key = if tk.is_empty() {
+            None
+        } else {
+            Some(tk.clone())
+        };
     }
 
     crate::cli::session::write_session(&work_dir, &data)?;
@@ -811,7 +911,14 @@ pub async fn delete_session(directory: String, delete_everything: bool) -> Resul
 /// Reads only the tail (for summary) and head (for first message) of the file.
 pub fn extract_jsonl_metadata(
     path: &std::path::Path,
-) -> (Option<String>, Option<String>, Option<String>, Option<String>, Option<String>, u32) {
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    u32,
+) {
     // Returns: (summary, first_message, first_timestamp, last_timestamp, git_branch, message_count)
 
     let file = match std::fs::File::open(path) {
@@ -826,7 +933,11 @@ pub fn extract_jsonl_metadata(
     {
         let mut f = std::io::BufReader::new(&file);
         let tail_size: u64 = 256 * 1024; // 256KB
-        let seek_pos = if file_len > tail_size { file_len - tail_size } else { 0 };
+        let seek_pos = if file_len > tail_size {
+            file_len - tail_size
+        } else {
+            0
+        };
         let _ = f.seek(SeekFrom::Start(seek_pos));
 
         // If we seeked into the middle of a line, skip the partial line
@@ -882,11 +993,15 @@ pub fn extract_jsonl_metadata(
                     if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                         // First timestamp
                         if first_timestamp.is_none() {
-                            first_timestamp = v.get("timestamp").and_then(|t| t.as_str()).map(String::from);
+                            first_timestamp = v
+                                .get("timestamp")
+                                .and_then(|t| t.as_str())
+                                .map(String::from);
                         }
                         // Git branch
                         if git_branch.is_none() {
-                            git_branch = v.get("gitBranch")
+                            git_branch = v
+                                .get("gitBranch")
                                 .and_then(|b| b.as_str())
                                 .filter(|b| !b.is_empty())
                                 .map(String::from);
@@ -924,7 +1039,14 @@ pub fn extract_jsonl_metadata(
     // The head-only count is an undercount but acceptable for display.
     // If file is small enough (< 10MB), we already scanned everything above.
 
-    (summary, first_message, first_timestamp, last_timestamp, git_branch, message_count)
+    (
+        summary,
+        first_message,
+        first_timestamp,
+        last_timestamp,
+        git_branch,
+        message_count,
+    )
 }
 
 #[tauri::command]
@@ -955,7 +1077,11 @@ pub async fn discover_claude_sessions() -> Result<ImportPreview, String> {
         std::collections::HashMap::new();
 
     let Ok(project_dirs) = std::fs::read_dir(&projects_dir) else {
-        return Ok(ImportPreview { groups: Vec::new(), total_sessions: 0, work_directory });
+        return Ok(ImportPreview {
+            groups: Vec::new(),
+            total_sessions: 0,
+            work_directory,
+        });
     };
 
     for project_entry in project_dirs.flatten() {
@@ -996,16 +1122,20 @@ pub async fn discover_claude_sessions() -> Result<ImportPreview, String> {
             }
 
             // Skip very small files (< 1KB — likely empty or corrupt)
-            let file_size = std::fs::metadata(&file_path)
-                .map(|m| m.len())
-                .unwrap_or(0);
+            let file_size = std::fs::metadata(&file_path).map(|m| m.len()).unwrap_or(0);
             if file_size < 1024 {
                 continue;
             }
 
             // Extract metadata efficiently
-            let (summary, first_message, first_timestamp, last_timestamp, git_branch, message_count) =
-                extract_jsonl_metadata(&file_path);
+            let (
+                summary,
+                first_message,
+                first_timestamp,
+                last_timestamp,
+                git_branch,
+                message_count,
+            ) = extract_jsonl_metadata(&file_path);
 
             // Determine original_cwd: try to read from JSONL first message, fall back to decoding dir name
             let original_cwd = first_timestamp
@@ -1017,7 +1147,8 @@ pub async fn discover_claude_sessions() -> Result<ImportPreview, String> {
                     use std::io::BufRead;
                     for line in reader.lines().take(50) {
                         let Ok(line) = line else { continue };
-                        if line.contains("\"type\":\"user\"") || line.contains("\"type\":\"human\"") {
+                        if line.contains("\"type\":\"user\"") || line.contains("\"type\":\"human\"")
+                        {
                             if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
                                 if let Some(cwd) = v.get("cwd").and_then(|c| c.as_str()) {
                                     if !cwd.is_empty() {
@@ -1057,10 +1188,7 @@ pub async fn discover_claude_sessions() -> Result<ImportPreview, String> {
                 git_branch,
             };
 
-            groups_map
-                .entry(original_cwd)
-                .or_default()
-                .push(session);
+            groups_map.entry(original_cwd).or_default().push(session);
         }
     }
 
@@ -1115,7 +1243,12 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
                     jsonl_path = Some(candidate);
 
                     // Get original cwd from the first message
-                    let f = std::fs::File::open(&project_entry.path().join(format!("{}.jsonl", req.session_id))).ok();
+                    let f = std::fs::File::open(
+                        &project_entry
+                            .path()
+                            .join(format!("{}.jsonl", req.session_id)),
+                    )
+                    .ok();
                     if let Some(f) = f {
                         let reader = std::io::BufReader::new(f);
                         use std::io::BufRead;
@@ -1187,8 +1320,13 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
         }
 
         let session_dir = work_dir.join(&dir_name);
-        std::fs::create_dir_all(&session_dir)
-            .map_err(|e| format!("Failed to create directory {}: {}", session_dir.display(), e))?;
+        std::fs::create_dir_all(&session_dir).map_err(|e| {
+            format!(
+                "Failed to create directory {}: {}",
+                session_dir.display(),
+                e
+            )
+        })?;
 
         // Get first timestamp from JSONL for created field
         let (_, _, first_ts, _, _, _) = extract_jsonl_metadata(jsonl_path.as_ref().unwrap());
@@ -1252,7 +1390,8 @@ pub async fn fork_session(
 
     // Custom name takes priority over directory-derived name (ticket overrides both)
     if let Some(ref n) = name {
-        let filtered: String = n.chars()
+        let filtered: String = n
+            .chars()
             .filter(|c| c.is_alphanumeric() || c.is_whitespace() || *c == '-' || *c == '_')
             .collect();
         window_name = filtered.split_whitespace().collect::<Vec<_>>().join("-");
@@ -1264,7 +1403,8 @@ pub async fn fork_session(
         let output = super::shell_env::run_tool(
             &super::shell_env::TOOL_JTK,
             &["issues", "get", key, "-o", "json"],
-        ).await?;
+        )
+        .await?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1274,7 +1414,10 @@ pub async fn fork_session(
         let raw: serde_json::Value = serde_json::from_slice(&output.stdout)
             .map_err(|e| format!("Failed to parse jtk output: {}", e))?;
         let data = if raw.is_array() {
-            raw.as_array().and_then(|a| a.first()).cloned().unwrap_or(serde_json::Value::Null)
+            raw.as_array()
+                .and_then(|a| a.first())
+                .cloned()
+                .unwrap_or(serde_json::Value::Null)
         } else {
             raw
         };
@@ -1316,25 +1459,36 @@ pub async fn fork_session(
         None
     };
 
+    let created_at = chrono::Utc::now().to_rfc3339();
     let (command, session_id_for_app, mut session_data) = if provider == AgentProvider::Codex {
         let command = match &old_session_id {
-            Some(old_id) => format!("codex fork {} -C '{}'", old_id, shell_escape_single(&work_dir)),
+            Some(old_id) => format!(
+                "codex fork {} -C '{}'",
+                old_id,
+                shell_escape_single(&work_dir)
+            ),
             None => format!("codex -C '{}'", shell_escape_single(&work_dir)),
         };
         (
             command,
             None,
-            serde_json::json!({
-                "session_id": "",
-                "name": window_name,
-                "color": color.to_string(),
-                "ticket_key": ticket_key_for_session,
-                "claude_cwd": work_dir,
-                "codex_cwd": work_dir,
-                "created": chrono::Utc::now().to_rfc3339(),
-                "provider": "codex",
-                "forked_from": old_session_id,
-            }),
+            SessionData {
+                session_id: String::new(),
+                name: window_name.clone(),
+                color: color.to_string(),
+                ticket_key: ticket_key_for_session.clone(),
+                claude_cwd: work_dir.clone(),
+                created: created_at.clone(),
+                last_resumed: None,
+                provider: Some(AgentProvider::Codex),
+                codex_session_id: None,
+                codex_cwd: Some(work_dir.clone()),
+                forked_from: old_session_id.clone(),
+                imported: None,
+                imported_from: None,
+                use_chrome: None,
+                override_terminal_theme: None,
+            },
         )
     } else {
         let new_id = uuid::Uuid::new_v4().to_string();
@@ -1352,38 +1506,50 @@ pub async fn fork_session(
             }
             None => format!("claude --session-id {}{}", new_id, chrome_flag),
         };
-        let claude_cwd = if old_session_id.is_some() { &original_cwd } else { &work_dir };
+        let claude_cwd = if old_session_id.is_some() {
+            &original_cwd
+        } else {
+            &work_dir
+        };
         (
             command,
             Some(new_id.clone()),
-            serde_json::json!({
-                "session_id": new_id,
-                "name": window_name,
-                "color": color.to_string(),
-                "ticket_key": ticket_key_for_session,
-                "claude_cwd": claude_cwd,
-                "created": chrono::Utc::now().to_rfc3339(),
-                "provider": "claude",
-                "forked_from": old_session_id,
-            }),
+            SessionData {
+                session_id: new_id,
+                name: window_name.clone(),
+                color: color.to_string(),
+                ticket_key: ticket_key_for_session.clone(),
+                claude_cwd: claude_cwd.to_string(),
+                created: created_at.clone(),
+                last_resumed: None,
+                provider: Some(AgentProvider::Claude),
+                codex_session_id: None,
+                codex_cwd: None,
+                forked_from: old_session_id.clone(),
+                imported: None,
+                imported_from: None,
+                use_chrome: None,
+                override_terminal_theme: None,
+            },
         )
     };
 
     if chrome {
-        session_data["use_chrome"] = serde_json::json!(true);
+        session_data.use_chrome = Some(true);
     }
-    std::fs::write(
-        std::path::Path::new(&work_dir).join(".twapp-session.json"),
-        serde_json::to_string_pretty(&session_data).unwrap(),
-    )
-    .map_err(|e| format!("Failed to write session file: {}", e))?;
+    crate::cli::session::write_session(std::path::Path::new(&work_dir), &session_data)?;
 
     let mut app_args = vec![
-        "--name".to_string(), window_name.clone(),
-        "--color".to_string(), color.to_string(),
-        "--cwd".to_string(), work_dir,
-        "--command".to_string(), command,
-        "--provider".to_string(), provider.to_string(),
+        "--name".to_string(),
+        window_name.clone(),
+        "--color".to_string(),
+        color.to_string(),
+        "--cwd".to_string(),
+        work_dir,
+        "--command".to_string(),
+        command,
+        "--provider".to_string(),
+        provider.to_string(),
     ];
     if let Some(session_id_for_app) = session_id_for_app {
         app_args.push("--session-id".to_string());

--- a/src-tauri/src/gui/tickets.rs
+++ b/src-tauri/src/gui/tickets.rs
@@ -1,4 +1,5 @@
 use super::types::*;
+use crate::cli::session::AgentProvider;
 
 pub fn read_ticket_file(path: &std::path::Path) -> Result<Option<serde_json::Value>, String> {
     if !path.exists() {
@@ -43,14 +44,31 @@ pub fn read_session_id(config: &GuiArgs) -> Option<String> {
         std::fs::read_to_string(&path)
             .ok()
             .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
-            .and_then(|v| v["session_id"].as_str().map(String::from))
+            .and_then(|v| {
+                let claude_id = v
+                    .get("session_id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty());
+                let codex_id = v
+                    .get("codex_session_id")
+                    .and_then(|value| value.as_str())
+                    .filter(|value| !value.is_empty());
+
+                match config.provider {
+                    AgentProvider::Codex => codex_id.or(claude_id),
+                    AgentProvider::Claude => claude_id.or(codex_id),
+                }
+                .map(String::from)
+            })
     } else {
         None
     }
 }
 
 #[tauri::command]
-pub fn get_session_info(config: tauri::State<'_, GuiArgs>) -> Result<Option<serde_json::Value>, String> {
+pub fn get_session_info(
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<Option<serde_json::Value>, String> {
     let path = resolve_session_path(config.inner());
     if path.exists() {
         let content = std::fs::read_to_string(&path).map_err(|e| e.to_string())?;
@@ -62,7 +80,9 @@ pub fn get_session_info(config: tauri::State<'_, GuiArgs>) -> Result<Option<serd
 }
 
 #[tauri::command]
-pub fn get_ticket_info(config: tauri::State<'_, GuiArgs>) -> Result<Option<serde_json::Value>, String> {
+pub fn get_ticket_info(
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<Option<serde_json::Value>, String> {
     match resolve_ticket_path(config.inner()) {
         Some(path) => read_ticket_file(&path),
         None => Ok(None),
@@ -75,17 +95,29 @@ pub fn extract_adf_text(node: &serde_json::Value) -> String {
         serde_json::Value::Null => String::new(),
         serde_json::Value::Object(obj) => {
             if obj.get("type").and_then(|t| t.as_str()) == Some("text") {
-                return obj.get("text").and_then(|t| t.as_str()).unwrap_or("").to_string();
+                return obj
+                    .get("text")
+                    .and_then(|t| t.as_str())
+                    .unwrap_or("")
+                    .to_string();
             }
             if let Some(content) = obj.get("content").and_then(|c| c.as_array()) {
-                let parts: Vec<String> = content.iter().map(extract_adf_text).filter(|s| !s.is_empty()).collect();
+                let parts: Vec<String> = content
+                    .iter()
+                    .map(extract_adf_text)
+                    .filter(|s| !s.is_empty())
+                    .collect();
                 parts.join(" ")
             } else {
                 String::new()
             }
         }
         serde_json::Value::Array(arr) => {
-            let parts: Vec<String> = arr.iter().map(extract_adf_text).filter(|s| !s.is_empty()).collect();
+            let parts: Vec<String> = arr
+                .iter()
+                .map(extract_adf_text)
+                .filter(|s| !s.is_empty())
+                .collect();
             parts.join("\n")
         }
         _ => String::new(),
@@ -103,6 +135,49 @@ pub fn truncate_str(text: &str, max: usize) -> String {
         }
     }
     format!("{}...", truncated)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_session_id_prefers_codex_session_for_codex_windows() {
+        let dir = std::env::temp_dir().join(format!("twapp-ticket-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(".twapp-session.json"),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "session_id": "",
+                "name": "demo",
+                "claude_cwd": dir.to_string_lossy(),
+                "created": "2026-01-01T00:00:00Z",
+                "provider": "codex",
+                "codex_session_id": "codex-123",
+                "codex_cwd": dir.to_string_lossy(),
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let config = GuiArgs {
+            name: "demo".to_string(),
+            color: None,
+            cwd: Some(dir.to_string_lossy().to_string()),
+            command: None,
+            prefill: None,
+            ticket: None,
+            session_id: None,
+            provider: AgentProvider::Codex,
+            capture_started_at: None,
+            chrome: false,
+            override_terminal_theme: false,
+        };
+
+        assert_eq!(read_session_id(&config).as_deref(), Some("codex-123"));
+
+        let _ = std::fs::remove_dir_all(dir);
+    }
 }
 
 pub fn normalize_jtk_ticket(data: &serde_json::Value, key_hint: &str) -> serde_json::Value {
@@ -138,13 +213,17 @@ pub fn normalize_jtk_ticket(data: &serde_json::Value, key_hint: &str) -> serde_j
 }
 
 #[tauri::command]
-pub async fn link_ticket(key: String, config: tauri::State<'_, GuiArgs>) -> Result<serde_json::Value, String> {
+pub async fn link_ticket(
+    key: String,
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<serde_json::Value, String> {
     let cwd = config.cwd.as_deref().unwrap_or(".");
 
     let output = super::shell_env::run_tool(
         &super::shell_env::TOOL_JTK,
         &["issues", "get", &key, "-o", "json"],
-    ).await?;
+    )
+    .await?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -156,7 +235,10 @@ pub async fn link_ticket(key: String, config: tauri::State<'_, GuiArgs>) -> Resu
 
     // jtk may return an array with one element
     let data = if raw.is_array() {
-        raw.as_array().and_then(|a| a.first()).cloned().unwrap_or(serde_json::Value::Null)
+        raw.as_array()
+            .and_then(|a| a.first())
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
     } else {
         raw
     };
@@ -172,7 +254,9 @@ pub async fn link_ticket(key: String, config: tauri::State<'_, GuiArgs>) -> Resu
 }
 
 #[tauri::command]
-pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_json::Value, String> {
+pub async fn refresh_ticket(
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<serde_json::Value, String> {
     let cwd = config.cwd.as_deref().unwrap_or(".");
     let ticket_path = std::path::Path::new(cwd).join(".twapp-ticket.json");
 
@@ -199,21 +283,39 @@ pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_j
 
         let output = super::shell_env::run_tool(
             &super::shell_env::TOOL_GH,
-            &["issue", "view", number, "--repo", repo, "--json", "title,body,state,labels,milestone,assignees,number,url"],
-        ).await?;
+            &[
+                "issue",
+                "view",
+                number,
+                "--repo",
+                repo,
+                "--json",
+                "title,body,state,labels,milestone,assignees,number,url",
+            ],
+        )
+        .await?;
 
         if !output.status.success() {
-            return Err(format!("gh failed: {}", String::from_utf8_lossy(&output.stderr)));
+            return Err(format!(
+                "gh failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
         }
 
         let data: serde_json::Value = serde_json::from_slice(&output.stdout)
             .map_err(|e| format!("Failed to parse gh output: {}", e))?;
 
-        let labels: Vec<String> = data["labels"].as_array()
-            .map(|arr| arr.iter().filter_map(|l| l["name"].as_str().map(String::from)).collect())
+        let labels: Vec<String> = data["labels"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|l| l["name"].as_str().map(String::from))
+                    .collect()
+            })
             .unwrap_or_default();
 
-        let assignee = data["assignees"].as_array()
+        let assignee = data["assignees"]
+            .as_array()
             .and_then(|arr| arr.first())
             .and_then(|a| a["login"].as_str())
             .map(|s| serde_json::Value::String(s.to_string()))
@@ -240,17 +342,24 @@ pub async fn refresh_ticket(config: tauri::State<'_, GuiArgs>) -> Result<serde_j
         let output = super::shell_env::run_tool(
             &super::shell_env::TOOL_JTK,
             &["issues", "get", key, "-o", "json"],
-        ).await?;
+        )
+        .await?;
 
         if !output.status.success() {
-            return Err(format!("jtk failed: {}", String::from_utf8_lossy(&output.stderr)));
+            return Err(format!(
+                "jtk failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            ));
         }
 
         let raw: serde_json::Value = serde_json::from_slice(&output.stdout)
             .map_err(|e| format!("Failed to parse jtk output: {}", e))?;
 
         let data = if raw.is_array() {
-            raw.as_array().and_then(|a| a.first()).cloned().unwrap_or(serde_json::Value::Null)
+            raw.as_array()
+                .and_then(|a| a.first())
+                .cloned()
+                .unwrap_or(serde_json::Value::Null)
         } else {
             raw
         };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -523,7 +523,23 @@ function App() {
       }).catch(() => setAppVersion(tauriVersion));
     }).catch(console.error);
 
-    invoke<AppConfig>("get_app_config").then((config) => {
+    invoke<AppConfig>("get_app_config").then(async (initialConfig) => {
+      let config = initialConfig;
+
+      if (config.provider === "codex" && !config.session_id && config.cwd) {
+        const recoveredSessionId = await invoke<string | null>("sync_codex_session_id", {
+          directory: config.cwd,
+        }).catch(() => null);
+
+        if (recoveredSessionId) {
+          config = {
+            ...config,
+            session_id: recoveredSessionId,
+            command: buildResumeCommand("codex", recoveredSessionId, config.cwd),
+          };
+        }
+      }
+
       setAppConfig(config);
       // Update main tab name from session name
       if (config.name && config.name !== "twapp") {
@@ -540,9 +556,15 @@ function App() {
       fit.fit();
       const dims = fit.proposeDimensions();
 
+      const launchCommand = config.command || buildResumeCommand(
+        config.provider,
+        config.session_id,
+        config.cwd,
+      );
+
       invoke("spawn_shell", {
         cwd: config.cwd || null,
-        command: config.command || null,
+        command: launchCommand,
         prefill: config.prefill || null,
         rows: dims?.rows ?? null,
         cols: dims?.cols ?? null,
@@ -1072,9 +1094,12 @@ function App() {
   const loadSessionFields = () => {
     setSessionFieldsError(null);
     invoke<Record<string, unknown> | null>("get_session_info").then((data) => {
+      const providerSessionId = appConfig?.provider === "codex"
+        ? (data?.codex_session_id as string) || (data?.session_id as string) || appConfig?.session_id || ""
+        : (data?.session_id as string) || appConfig?.session_id || "";
       const fields: SessionFieldValues = {
         name: (data?.name as string) || appConfig?.name || "",
-        session_id: (data?.session_id as string) || appConfig?.session_id || "",
+        session_id: providerSessionId,
         claude_cwd: (data?.claude_cwd as string) || appConfig?.cwd || "",
         ticket_key: (data?.ticket_key as string) || "",
       };
@@ -1126,12 +1151,23 @@ function App() {
   };
 
   const handleRestartTerminal = async () => {
+    let resolvedSessionId = appConfig?.session_id || null;
+
+    if (appConfig?.provider === "codex" && !resolvedSessionId && appConfig.cwd) {
+      resolvedSessionId = await invoke<string | null>("sync_codex_session_id", {
+        directory: appConfig.cwd,
+      }).catch(() => null);
+      if (resolvedSessionId) {
+        setAppConfig((prev) => prev ? { ...prev, session_id: resolvedSessionId } : prev);
+      }
+    }
+
     await invoke("kill_pty");
     terminalInstance.current?.reset();
     const dims = fitAddon.current?.proposeDimensions();
     const resumeCmd = buildResumeCommand(
       appConfig?.provider || "claude",
-      appConfig?.session_id,
+      resolvedSessionId,
       appConfig?.cwd,
     );
     await invoke("spawn_shell", {
@@ -1141,6 +1177,13 @@ function App() {
       rows: dims?.rows ?? null,
       cols: dims?.cols ?? null,
     });
+
+    if (appConfig?.provider === "codex" && !resolvedSessionId && appConfig?.cwd) {
+      await invoke("start_codex_session_capture", {
+        directory: appConfig.cwd,
+        startedAt: new Date().toISOString(),
+      }).catch(console.error);
+    }
   };
 
   const [rebuildStatus, setRebuildStatus] = useState("");


### PR DESCRIPTION
## Summary
- recover missing Codex session ids by scanning Codex session metadata and persisting the native id back into the twapp session file
- make provider-specific session id reads consistent so Codex fork, resume, and restart paths use the Codex id instead of the legacy Claude field
- recover or recapture the Codex session id on app startup and terminal restart before spawning the shell

## Testing
- cargo test