### PR TITLE
Detect stale Claude session IDs + session history audit log

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -744,6 +744,13 @@ fn cmd_resume(fork: bool) -> i32 {
         }
         build_and_launch(&work_dir, &window_name, &color, Some(&session_id), &command, chrome, provider, None)
     } else {
+        if let Some((old_id, event)) = session::maybe_sync_session_id(&work_dir, &mut session_data)
+        {
+            eprintln!(
+                "Detected {} — updating stored session id: {} -> {}",
+                event, old_id, session_data.session_id
+            );
+        }
         session_id = session_data.session_id.clone();
         let command = format!("{}claude --resume {}{}", cd_prefix, session_id, chrome_flag);
         session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -648,3 +648,122 @@ fn scan_recursive(dir: &Path, results: &mut Vec<(SessionData, PathBuf)>, depth: 
         }
     }
 }
+
+// ---------- Session History Audit Log ----------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionHistoryEvent {
+    pub timestamp: String,
+    pub event: String, // "compacted" | "cleared" | "manual_edit"
+    pub old_session_id: String,
+    pub new_session_id: String,
+}
+
+pub fn read_history(work_dir: &Path) -> Vec<SessionHistoryEvent> {
+    let history_file = work_dir.join(".twapp-session-history.json");
+    if !history_file.exists() {
+        return Vec::new();
+    }
+    let Ok(content) = std::fs::read_to_string(&history_file) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+pub fn append_history(work_dir: &Path, event: SessionHistoryEvent) -> Result<(), String> {
+    let mut events = read_history(work_dir);
+    events.push(event);
+    let history_file = work_dir.join(".twapp-session-history.json");
+    let content = serde_json::to_string_pretty(&events)
+        .map_err(|e| format!("Failed to serialize history: {}", e))?;
+    std::fs::write(&history_file, content)
+        .map_err(|e| format!("Failed to write history file: {}", e))
+}
+
+fn claude_projects_dir(claude_cwd: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let encoded = claude_cwd.replace('/', "-");
+    Some(home.join(".claude/projects").join(encoded))
+}
+
+/// Scan ~/.claude/projects/<encoded>/*.jsonl and return the session_id of the
+/// file with the newest mtime. Returns None if no JSONL files exist.
+pub fn find_latest_claude_session_id(claude_cwd: &str) -> Option<String> {
+    let dir = claude_projects_dir(claude_cwd)?;
+    if !dir.exists() {
+        return None;
+    }
+    let entries = std::fs::read_dir(&dir).ok()?;
+    let mut best: Option<(std::time::SystemTime, String)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Ok(meta) = path.metadata() else { continue };
+        let Ok(mtime) = meta.modified() else { continue };
+        match &best {
+            Some((best_mtime, _)) if mtime <= *best_mtime => {}
+            _ => best = Some((mtime, stem.to_string())),
+        }
+    }
+    best.map(|(_, id)| id)
+}
+
+/// Peek at the head of a JSONL file to decide whether the new session came
+/// from `/compact` (carries a continuity summary near the top) or `/clear`
+/// (fresh session with no summary).
+pub fn classify_session_change(claude_cwd: &str, new_session_id: &str) -> &'static str {
+    let Some(dir) = claude_projects_dir(claude_cwd) else {
+        return "cleared";
+    };
+    let path = dir.join(format!("{}.jsonl", new_session_id));
+    let Ok(file) = std::fs::File::open(&path) else {
+        return "cleared";
+    };
+    use std::io::BufRead;
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines().take(20).filter_map(|l| l.ok()) {
+        if line.contains("\"type\":\"summary\"") || line.contains("\"isCompactSummary\":true") {
+            return "compacted";
+        }
+    }
+    "cleared"
+}
+
+/// If Claude created a newer session (via /compact or /clear), update the stored
+/// session_id, write the session file, append a history event, and return the
+/// old id + event type for logging. Returns None if no change was made.
+pub fn maybe_sync_session_id(
+    work_dir: &Path,
+    session_data: &mut SessionData,
+) -> Option<(String, &'static str)> {
+    let claude_cwd = if session_data.claude_cwd.is_empty() {
+        work_dir.to_string_lossy().to_string()
+    } else {
+        session_data.claude_cwd.clone()
+    };
+    let latest = find_latest_claude_session_id(&claude_cwd)?;
+    if latest == session_data.session_id || latest.is_empty() {
+        return None;
+    }
+    let old_id = session_data.session_id.clone();
+    let event_type = classify_session_change(&claude_cwd, &latest);
+    session_data.session_id = latest.clone();
+    if write_session(work_dir, session_data).is_err() {
+        return None;
+    }
+    let _ = append_history(
+        work_dir,
+        SessionHistoryEvent {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            event: event_type.to_string(),
+            old_session_id: old_id.clone(),
+            new_session_id: latest,
+        },
+    );
+    Some((old_id, event_type))
+}

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -94,6 +94,7 @@ pub fn run(args: GuiArgs) {
             sessions::rename_session,
             sessions::update_session_color,
             sessions::update_session_fields,
+            sessions::get_session_history,
             sessions::delete_session,
             sessions::discover_claude_sessions,
             sessions::import_sessions,

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -490,6 +490,11 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
         return Ok(());
     }
 
+    // Detect Claude session reset (from /compact or /clear) and update stored id
+    if preferred == AgentProvider::Claude {
+        let _ = crate::cli::session::maybe_sync_session_id(&work_dir, &mut session_data);
+    }
+
     // Update last_resumed
     session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
     session_data.provider = Some(preferred);
@@ -796,6 +801,7 @@ pub async fn update_session_fields(
 ) -> Result<(), String> {
     let work_dir = std::path::PathBuf::from(&directory);
     let mut data = crate::cli::session::read_session(&work_dir)?;
+    let old_claude_session_id = data.session_id.clone();
 
     if let Some(ref n) = name {
         data.name = n.clone();
@@ -825,7 +831,28 @@ pub async fn update_session_fields(
     }
 
     crate::cli::session::write_session(&work_dir, &data)?;
+
+    if data.session_id != old_claude_session_id {
+        let _ = crate::cli::session::append_history(
+            &work_dir,
+            crate::cli::session::SessionHistoryEvent {
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                event: "manual_edit".to_string(),
+                old_session_id: old_claude_session_id,
+                new_session_id: data.session_id.clone(),
+            },
+        );
+    }
+
     Ok(())
+}
+
+#[tauri::command]
+pub async fn get_session_history(
+    directory: String,
+) -> Result<Vec<crate::cli::session::SessionHistoryEvent>, String> {
+    let work_dir = std::path::PathBuf::from(&directory);
+    Ok(crate::cli::session::read_history(&work_dir))
 }
 
 #[tauri::command]

--- a/src/App.css
+++ b/src/App.css
@@ -907,6 +907,104 @@ body,
   padding-bottom: 0;
 }
 
+/* Compaction indicator + history modal */
+.compaction-indicator {
+  margin-top: 6px;
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-muted);
+  font-size: 10px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.compaction-indicator:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.history-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 20px 0;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.history-item {
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+}
+
+.history-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.history-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.history-badge-compacted {
+  background: #f59e0b;
+}
+
+.history-badge-cleared {
+  background: #ef4444;
+}
+
+.history-badge-manual_edit {
+  background: #3b82f6;
+}
+
+.history-timestamp {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.history-ids {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.history-id-label {
+  color: var(--text-muted);
+}
+
+.history-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 1px 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.history-id:hover {
+  border-color: var(--accent);
+}
+
 .session-settings-label {
   font-size: 11px;
   color: var(--text-muted);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import yaml from "js-yaml";
 import "@xterm/xterm/css/xterm.css";
 import "./App.css";
 import { applyThemeColor, getDarkModeAccentColor } from "./color";
-import type { AppConfig, TicketInfo, Note, QuickPrompt, MonitorStatusInfo, MonitorLogEntry, PromptSection, PromptStore, TabInfo, ThemeMode } from "./types";
+import type { AppConfig, TicketInfo, Note, QuickPrompt, MonitorStatusInfo, MonitorLogEntry, PromptSection, PromptStore, TabInfo, ThemeMode, SessionHistoryEvent } from "./types";
 import { lightTheme, darkTheme, getLightTheme, getDarkTheme } from "./types";
 import { formatTicketBadge, formatTime } from "./utils/format";
 import { isYamlFile, isHtmlFile, isImageFile, imageMimeType, isFilePath, isLikelyPreviewableHref, normalizeFilePathCandidate, isAbsolutePath } from "./utils/file";
@@ -77,6 +77,10 @@ function App() {
   const [sessionFieldsOriginal, setSessionFieldsOriginal] = useState<SessionFieldValues | null>(null);
   const [sessionFieldsSaving, setSessionFieldsSaving] = useState(false);
   const [sessionFieldsError, setSessionFieldsError] = useState<string | null>(null);
+
+  // Session history state
+  const [sessionHistory, setSessionHistory] = useState<SessionHistoryEvent[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
 
   // Quick Prompts state
   const [globalPrompts, setGlobalPrompts] = useState<PromptStore>({ sections: [] });
@@ -585,6 +589,13 @@ function App() {
       invoke<TicketInfo | null>("get_ticket_info")
         .then((info) => { if (info) setTicket(info); })
         .catch(console.error);
+
+      // Load session history audit log
+      if (config.cwd) {
+        invoke<SessionHistoryEvent[]>("get_session_history", { directory: config.cwd })
+          .then(setSessionHistory)
+          .catch(() => setSessionHistory([]));
+      }
 
       // Check for updates after a brief delay
       setTimeout(() => checkForUpdate(), 5000);
@@ -1143,11 +1154,20 @@ function App() {
         setAppConfig((prev) => prev ? { ...prev, session_id: args.session_id } : prev);
       }
       setSessionFieldsOriginal({ ...sessionFields });
+      // Refresh history in case we logged a manual_edit event
+      loadSessionHistory();
     } catch (err) {
       setSessionFieldsError(String(err));
     } finally {
       setSessionFieldsSaving(false);
     }
+  };
+
+  const loadSessionHistory = () => {
+    if (!appConfig?.cwd) return;
+    invoke<SessionHistoryEvent[]>("get_session_history", { directory: appConfig.cwd })
+      .then(setSessionHistory)
+      .catch(() => setSessionHistory([]));
   };
 
   const handleRestartTerminal = async () => {
@@ -2269,6 +2289,15 @@ function App() {
               </button>
             </div>
           )}
+          {sessionHistory.length > 0 && (
+            <button
+              className="compaction-indicator"
+              onClick={() => setHistoryOpen(true)}
+              title="View session history"
+            >
+              Compactions ({sessionHistory.filter((e) => e.event === "compacted" || e.event === "cleared").length})
+            </button>
+          )}
         </div>
 
         {/* Fork Dialog */}
@@ -2610,6 +2639,56 @@ function App() {
         </div>
 
       </div>
+
+      {/* Session History Modal */}
+      {historyOpen && (
+        <div className="config-overlay" onClick={() => setHistoryOpen(false)}>
+          <div className="config-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="config-header">
+              <span className="config-title">Session History</span>
+              <button className="config-close" onClick={() => setHistoryOpen(false)}>&times;</button>
+            </div>
+            <div className="config-body">
+              {sessionHistory.length === 0 ? (
+                <div className="history-empty">No history events yet.</div>
+              ) : (
+                <div className="history-list">
+                  {[...sessionHistory].reverse().map((ev, idx) => (
+                    <div className="history-item" key={idx}>
+                      <div className="history-item-header">
+                        <span className={`history-badge history-badge-${ev.event}`}>
+                          {ev.event === "manual_edit" ? "edited" : ev.event}
+                        </span>
+                        <span className="history-timestamp">
+                          {new Date(ev.timestamp).toLocaleString()}
+                        </span>
+                      </div>
+                      <div className="history-ids">
+                        <span className="history-id-label">from</span>
+                        <code
+                          className="history-id"
+                          title={ev.old_session_id ? `${ev.old_session_id}\n(click to copy)` : "(none)"}
+                          onClick={() => ev.old_session_id && navigator.clipboard.writeText(ev.old_session_id)}
+                        >
+                          {ev.old_session_id ? ev.old_session_id.slice(0, 8) : "(none)"}
+                        </code>
+                        <span className="history-id-label">→</span>
+                        <code
+                          className="history-id"
+                          title={ev.new_session_id ? `${ev.new_session_id}\n(click to copy)` : "(none)"}
+                          onClick={() => ev.new_session_id && navigator.clipboard.writeText(ev.new_session_id)}
+                        >
+                          {ev.new_session_id ? ev.new_session_id.slice(0, 8) : "(none)"}
+                        </code>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Session Config Modal */}
       {sessionSettingsOpen && (

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,13 @@ export interface ImportResult {
   directories_created: string[];
 }
 
+export interface SessionHistoryEvent {
+  timestamp: string;
+  event: "compacted" | "cleared" | "manual_edit";
+  old_session_id: string;
+  new_session_id: string;
+}
+
 export interface DeletePreflight {
   session_name: string;
   session_color: string;


### PR DESCRIPTION
## Problem

When the user runs \`/compact\` or \`/clear\` inside Claude, Claude spawns a new session with a new ID. twapp keeps the stale ID in \`.twapp-session.json\`, so the next resume tries \`claude --resume <stale_id>\` and fails (or resumes the wrong older session).

## Fix

- **Auto-detect on resume** (CLI \`cmd_resume\` and GUI \`launch_session\`): scan \`~/.claude/projects/<encoded_claude_cwd>/*.jsonl\` for the file with the newest \`mtime\`. If its session ID != stored one, update the stored id transparently.
- **Classify the change**: peek the new JSONL's head for a \`\"type\":\"summary\"\` / \`\"isCompactSummary\":true\` entry. Present → \`compacted\`; absent → \`cleared\`. (Best-effort; user can always override via the config modal.)
- **Audit log**: append each change as an event to a new \`.twapp-session-history.json\` file. Manual edits via the config modal (when they change \`session_id\`) also append a \`manual_edit\` event.
- **UI**: small \"Compactions (N)\" pill under the session badge (counts \`compacted\`+\`cleared\`). Click opens a modal listing every event with a color-coded badge (orange/red/blue), localized timestamp, and truncated IDs that copy the full UUID on click (full ID shown on hover).

## Files

- \`src-tauri/src/cli/session.rs\` — \`SessionHistoryEvent\`, \`read_history\`, \`append_history\`, \`find_latest_claude_session_id\`, \`classify_session_change\`, \`maybe_sync_session_id\`
- \`src-tauri/src/cli/mod.rs\` — call \`maybe_sync_session_id\` in \`cmd_resume\`
- \`src-tauri/src/gui/sessions.rs\` — call \`maybe_sync_session_id\` in \`launch_session\`, log \`manual_edit\` in \`update_session_fields\`, new \`get_session_history\` command
- \`src-tauri/src/gui/mod.rs\` — register command
- \`src/types.ts\` — \`SessionHistoryEvent\` type
- \`src/App.tsx\` — history state, sidebar indicator, history modal
- \`src/App.css\` — indicator + history modal styles

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`cargo check\` clean
- [x] Modal renders correctly against a seeded \`.twapp-session-history.json\` (verified in dev build)
- [ ] Run \`/compact\` in a real session, exit, \`twapp resume\` — confirm stored id updates and event is logged
- [ ] Same for \`/clear\`
- [ ] Edit \`Session ID\` in the config modal — confirm \`manual_edit\` event appears

## Follow-ups (not in scope)

- Live watcher for running sessions (currently reactive on resume only)