### PR TITLE
feat: spawn ergonomics — stop subcommand, --from-file, cwd pre-flight

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,11 +349,75 @@ The forked session gets a new twapp-managed session and carries Claude context f
 
 > Current limitation: unmanaged external import is Claude-only. Codex support currently targets twapp-managed sessions and provider switching inside twapp.
 
+## Spawning agent instances
+
+twapp works well as a terminal wrapper for *interactive* sessions, but it's
+also handy for spawning long-running agent or worker instances — for example,
+kicking off a Claude instance that reads a briefing file and runs to
+completion on its own.
+
+```bash
+# 1. Spawn a worker that reads a briefing file and executes it.
+twapp work --name "my-worker" \
+  --from-file /path/to/my-briefing.md
+
+# 2. Later, gracefully shut it down when the work is done.
+twapp stop --name "my-worker"
+
+# 3. If the graceful shutdown doesn't land, escalate to SIGKILL.
+twapp stop --name "my-worker" --force
+```
+
+### `--from-file` vs `--run`
+
+`--run` works for short, simple commands, but shell quoting becomes fragile
+when the embedded prompt is long or contains Unicode/backticks/quotes. Prefer
+`--from-file` whenever the prompt is longer than ~100 characters or contains
+special characters: twapp resolves the path to an absolute path, verifies
+it exists *before* spawning the terminal, and wraps the prompt as
+`claude --dangerously-skip-permissions 'Read <abs-path> and execute.'`.
+
+This keeps the caller side simple — just write the prompt into a markdown
+file and point twapp at it. Nothing to escape.
+
+### Pre-approving bypass permissions
+
+Agents spawned via `--from-file` typically want to run without
+permission prompts. Seed a per-worktree
+[`.claude/settings.local.json`](https://docs.anthropic.com/en/docs/claude-cli/settings)
+in the directory your worker will run in:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "allow": ["Bash(*)", "Write(**)", "Edit(**)", "Read(**)"]
+  }
+}
+```
+
+Adjust the allow list to fit your threat model. twapp itself doesn't touch
+this file — it's read by Claude on startup.
+
+### Pre-flight checks
+
+`twapp work` fails fast (before spawning the terminal) when:
+
+- `--from-file <path>` points at a file that doesn't exist (exit **2**).
+- `--claude-cwd <dir>` points at a directory that doesn't exist (exit **3**).
+- `--run` starts with `cd <dir> && ...` and `<dir>` doesn't exist (exit **3**).
+
+Without these checks, the spawned terminal would appear to launch fine and
+then silently fail inside the new window — a painful debug loop when
+automating spawns.
+
 ## CLI Reference
 
 | Command | Description |
 |---------|-------------|
 | `twapp work <ticket\|--name>` | Start a new work session using the configured provider |
+| `twapp work --from-file <path>` | Spawn a session whose prompt is `Read <path> and execute.` (safer than `--run` for long prompts) |
+| `twapp stop --name <name> [--force]` | Gracefully stop a running session (SIGTERM, optional SIGKILL escalation) |
 | `twapp resume [--fork]` | Resume or fork the current session using the configured provider |
 | `twapp sessions` | List all sessions with activity timestamps |
 | `twapp set-session <id>` | Update session metadata |

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod notes;
 pub mod permissions;
 pub mod prompts;
 pub mod session;
+pub mod stop;
 pub mod theme;
 pub mod ticket;
 
@@ -14,7 +15,7 @@ use session::{AgentProvider, shell_escape_single};
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Start a new work session
-    #[command(after_help = "Examples:\n  twapp work MON-1234                                    Start fresh session\n  twapp work --name \"research\"                           Start session without a ticket\n  twapp work MON-5678 -s abc123 --claude-cwd /old/dir    Fork existing session to new ticket")]
+    #[command(after_help = "Examples:\n  twapp work MON-1234                                    Start fresh session\n  twapp work --name \"research\"                           Start session without a ticket\n  twapp work --name worker --from-file /path/brief.md    Spawn agent to read a briefing file\n  twapp work MON-5678 -s abc123 --claude-cwd /old/dir    Fork existing session to new ticket\n\nShutdown: use `twapp stop --name <name>` to gracefully shut down a spawned instance.")]
     Work {
         /// Ticket ID (e.g. MON-1234, 1234, owner/repo#123)
         ticket: Option<String>,
@@ -24,6 +25,10 @@ pub enum Commands {
         /// Override startup command (default: claude)
         #[arg(long)]
         run: Option<String>,
+        /// Spawn claude with 'Read <path> and execute.' — safer than --run for
+        /// long prompts with special characters. Path must exist at spawn time.
+        #[arg(long)]
+        from_file: Option<String>,
         /// Force GitHub issue lookup
         #[arg(long, short = 'g')]
         github: bool,
@@ -36,6 +41,20 @@ pub enum Commands {
         /// Use Chrome instead of Claude desktop
         #[arg(long)]
         chrome: bool,
+    },
+    /// Stop a running session by name (SIGTERM claude child + twapp host).
+    ///
+    /// Used to cleanly shut down sessions started by `twapp work`, especially
+    /// long-running agent spawns. Pair with `twapp work --from-file` for a
+    /// scriptable spawn/stop lifecycle.
+    #[command(after_help = "Examples:\n  twapp stop --name my-worker           Graceful shutdown (SIGTERM, 3s grace)\n  twapp stop --name my-worker --force   Escalate to SIGKILL if SIGTERM doesn't land")]
+    Stop {
+        /// Session name (matches `--name` used at `twapp work` time)
+        #[arg(long, short = 'n')]
+        name: String,
+        /// Escalate to SIGKILL if SIGTERM doesn't land in ~3s
+        #[arg(long)]
+        force: bool,
     },
     /// Resume session in current directory
     #[command(after_help = "Examples:\n  twapp resume              Continue where you left off\n  twapp resume --fork       New session with context from current one")]
@@ -264,11 +283,13 @@ pub fn run(cmd: Commands) -> i32 {
             ticket,
             name,
             run,
+            from_file,
             github,
             session_id: fork_session_id,
             claude_cwd,
             chrome,
-        } => cmd_work(ticket, name, run, github, fork_session_id, claude_cwd, chrome),
+        } => cmd_work(ticket, name, run, from_file, github, fork_session_id, claude_cwd, chrome),
+        Commands::Stop { name, force } => stop::cmd_stop(&name, force),
         Commands::Resume { fork } => cmd_resume(fork),
         Commands::Sessions { path } => cmd_sessions(path),
         Commands::Ticket { command } => match command {
@@ -599,6 +620,7 @@ fn cmd_work(
     ticket_id: Option<String>,
     session_name: Option<String>,
     run_command: Option<String>,
+    from_file: Option<String>,
     github: bool,
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
@@ -611,12 +633,53 @@ fn cmd_work(
         return 1;
     }
 
+    if run_command.is_some() && from_file.is_some() {
+        eprintln!("Error: --run and --from-file are mutually exclusive.");
+        return 1;
+    }
+
+    // Feature: --from-file. Resolve to an absolute path and verify the file
+    // exists BEFORE launching any terminal, then wrap as a claude prompt.
+    let effective_run = match from_file {
+        Some(path) => match resolve_from_file(&path) {
+            Ok(cmd) => Some(cmd),
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                return 2;
+            }
+        },
+        None => run_command,
+    };
+
+    // Pre-flight: --claude-cwd must exist if supplied.
+    if let Some(ref cwd) = claude_cwd_arg {
+        if !std::path::Path::new(cwd).is_dir() {
+            eprintln!("Error: --claude-cwd does not exist or is not a directory: {}", cwd);
+            return 3;
+        }
+    }
+
+    // Pre-flight: if --run starts with `cd <dir> && ...`, verify <dir> exists.
+    // Keep the check surface-small — if the command is complex and doesn't
+    // start with `cd`, skip rather than parsing bash.
+    if let Some(ref cmd) = effective_run {
+        if let Some(cd_dir) = parse_cd_prefix(cmd) {
+            if !std::path::Path::new(&cd_dir).is_dir() {
+                eprintln!(
+                    "Error: --run starts with `cd {}` but that directory does not exist.",
+                    cd_dir
+                );
+                return 3;
+            }
+        }
+    }
+
     if let Err(e) = app_bundle::check_gui_installed() {
         eprintln!("{}", e);
         return 1;
     }
 
-    let result = match create_session_core(ticket_id, session_name, run_command, github, fork_session_id, claude_cwd_arg, chrome) {
+    let result = match create_session_core(ticket_id, session_name, effective_run, github, fork_session_id, claude_cwd_arg, chrome) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -1572,5 +1635,173 @@ fn cmd_dev_reload(pid: Option<u32>, cwd: &str, gui_src: Option<&str>) -> i32 {
             eprintln!("Error resuming: {}", e);
             1
         }
+    }
+}
+
+/// Translate `--from-file <path>` into the equivalent `--run` command.
+/// Resolves `<path>` to an absolute path so later `cd`s don't break it,
+/// and returns an error if the file does not exist.
+fn resolve_from_file(path: &str) -> Result<String, String> {
+    let raw = std::path::PathBuf::from(path);
+    let abs = if raw.is_absolute() {
+        raw
+    } else {
+        let cwd = std::env::current_dir()
+            .map_err(|e| format!("cannot resolve current directory: {}", e))?;
+        cwd.join(&raw)
+    };
+    let resolved = abs.canonicalize().unwrap_or(abs.clone());
+    if !resolved.is_file() {
+        return Err(format!(
+            "--from-file does not exist or is not a regular file: {}",
+            resolved.display()
+        ));
+    }
+    let abs_str = resolved.to_string_lossy();
+    // Single-quoted prompt; escape embedded single quotes the standard way.
+    let prompt = format!("Read {} and execute.", abs_str);
+    let escaped = session::shell_escape_single(&prompt);
+    Ok(format!(
+        "claude --dangerously-skip-permissions '{}'",
+        escaped
+    ))
+}
+
+/// If `cmd` begins with a `cd <dir> && ...` pattern, return the `<dir>`.
+/// Keeps parsing intentionally small: matches a leading `cd `, supports a
+/// single-quoted or unquoted bare-word directory, and requires ` && ` right
+/// after. Anything more complex is skipped rather than mis-parsed.
+pub fn parse_cd_prefix(cmd: &str) -> Option<String> {
+    let trimmed = cmd.trim_start();
+    let rest = trimmed.strip_prefix("cd ")?;
+    let rest = rest.trim_start();
+    let (dir, tail) = if let Some(after_quote) = rest.strip_prefix('\'') {
+        // Single-quoted path: take everything up to the next unescaped single quote.
+        // Bash literal single quotes can't be escaped, but callers sometimes
+        // use the `'\''` trick — treat that as part of the path.
+        let mut out = String::new();
+        let mut chars = after_quote.char_indices();
+        let mut end = None;
+        while let Some((i, c)) = chars.next() {
+            if c == '\'' {
+                // peek for the escape pattern '\''
+                let next = after_quote.get(i + 1..i + 4);
+                if next == Some("\\''") {
+                    out.push('\'');
+                    chars.next();
+                    chars.next();
+                    chars.next();
+                    continue;
+                }
+                end = Some(i);
+                break;
+            }
+            out.push(c);
+        }
+        let end = end?;
+        let tail = &after_quote[end + 1..];
+        (out, tail)
+    } else {
+        // Unquoted bare word: up to first whitespace.
+        let end = rest.find(char::is_whitespace)?;
+        (rest[..end].to_string(), &rest[end..])
+    };
+    let tail = tail.trim_start();
+    if tail.starts_with("&&") {
+        Some(dir)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod cd_prefix_tests {
+    use super::parse_cd_prefix;
+
+    #[test]
+    fn bare_word() {
+        assert_eq!(
+            parse_cd_prefix("cd /tmp/foo && claude").as_deref(),
+            Some("/tmp/foo")
+        );
+    }
+
+    #[test]
+    fn single_quoted() {
+        assert_eq!(
+            parse_cd_prefix("cd '/tmp/some dir' && claude").as_deref(),
+            Some("/tmp/some dir")
+        );
+    }
+
+    #[test]
+    fn no_cd() {
+        assert_eq!(parse_cd_prefix("claude --help"), None);
+    }
+
+    #[test]
+    fn cd_but_no_chain() {
+        assert_eq!(parse_cd_prefix("cd /tmp/foo"), None);
+    }
+
+    #[test]
+    fn leading_whitespace() {
+        assert_eq!(
+            parse_cd_prefix("   cd /tmp/bar && true").as_deref(),
+            Some("/tmp/bar")
+        );
+    }
+}
+
+#[cfg(test)]
+mod from_file_tests {
+    use super::resolve_from_file;
+
+    #[test]
+    fn missing_file_errors() {
+        let err = resolve_from_file("/tmp/definitely-not-a-real-twapp-test-file-xyz.md")
+            .err()
+            .expect("expected an error");
+        assert!(err.contains("does not exist"), "got: {}", err);
+    }
+
+    #[test]
+    fn existing_file_produces_claude_command_with_absolute_path() {
+        let tmp = std::env::temp_dir().join(format!(
+            "twapp-from-file-test-{}.md",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::write(&tmp, "briefing body").unwrap();
+        let canonical = tmp.canonicalize().unwrap();
+        let cmd = resolve_from_file(tmp.to_str().unwrap()).unwrap();
+        assert!(cmd.starts_with("claude --dangerously-skip-permissions '"));
+        assert!(
+            cmd.contains(&format!("Read {}", canonical.display())),
+            "got: {}",
+            cmd
+        );
+        assert!(cmd.trim_end().ends_with("and execute.'"));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn relative_path_is_resolved_to_absolute() {
+        let dir = std::env::temp_dir().join(format!(
+            "twapp-from-file-reldir-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let file = dir.join("brief.md");
+        std::fs::write(&file, "x").unwrap();
+        let prev_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&dir).unwrap();
+        let cmd = resolve_from_file("brief.md").unwrap();
+        std::env::set_current_dir(prev_cwd).unwrap();
+        assert!(
+            cmd.contains("/brief.md"),
+            "expected absolute path in command, got: {}",
+            cmd
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src-tauri/src/cli/stop.rs
+++ b/src-tauri/src/cli/stop.rs
@@ -1,0 +1,155 @@
+use std::process::Command;
+use std::thread::sleep;
+use std::time::{Duration, Instant};
+
+use super::session;
+
+/// Stop a running twapp session by name.
+///
+/// Finds the twapp host process via its per-instance `.app` bundle path,
+/// then sends SIGTERM to the claude child (if any) and the host.
+/// Waits up to 3 seconds for graceful shutdown. With `--force`, escalates
+/// to SIGKILL for anything still running.
+///
+/// Exit codes:
+///   0 — at least one process was stopped
+///   1 — nothing was found
+pub fn cmd_stop(name: &str, force: bool) -> i32 {
+    let safe = session::safe_name(name);
+    let marker = format!(".config/twapp/instances/{}.app", safe);
+
+    let host_pids = pgrep_full(&marker);
+    let mut claude_pids: Vec<u32> = Vec::new();
+    for pid in &host_pids {
+        for child in pgrep_children(*pid) {
+            if process_name(child).as_deref() == Some("claude") {
+                claude_pids.push(child);
+            }
+        }
+    }
+
+    if host_pids.is_empty() && claude_pids.is_empty() {
+        println!("not running: {}", name);
+        return 1;
+    }
+
+    for pid in &claude_pids {
+        send_signal(*pid, "TERM");
+    }
+    for pid in &host_pids {
+        send_signal(*pid, "TERM");
+    }
+
+    let timeout = Duration::from_secs(3);
+    wait_for_exit(&claude_pids, timeout);
+    wait_for_exit(&host_pids, timeout);
+
+    if force {
+        for pid in claude_pids.iter().chain(host_pids.iter()) {
+            if process_exists(*pid) {
+                send_signal(*pid, "KILL");
+            }
+        }
+        let short = Duration::from_secs(1);
+        wait_for_exit(&claude_pids, short);
+        wait_for_exit(&host_pids, short);
+    }
+
+    println!(
+        "stopped: {} (claude pid={}, twapp pid={})",
+        name,
+        format_pids(&claude_pids),
+        format_pids(&host_pids),
+    );
+    0
+}
+
+fn format_pids(pids: &[u32]) -> String {
+    if pids.is_empty() {
+        "none".to_string()
+    } else {
+        pids.iter()
+            .map(|p| p.to_string())
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+fn pgrep_full(pattern: &str) -> Vec<u32> {
+    let output = Command::new("pgrep").args(["-f", pattern]).output();
+    match output {
+        Ok(o) if o.status.success() => parse_pids(&o.stdout),
+        _ => Vec::new(),
+    }
+}
+
+fn pgrep_children(ppid: u32) -> Vec<u32> {
+    let output = Command::new("pgrep")
+        .args(["-P", &ppid.to_string()])
+        .output();
+    match output {
+        Ok(o) if o.status.success() => parse_pids(&o.stdout),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_pids(bytes: &[u8]) -> Vec<u32> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .filter_map(|l| l.trim().parse::<u32>().ok())
+        .collect()
+}
+
+/// Returns the short process name (e.g. "claude") for a PID, or None if
+/// the process is gone.
+fn process_name(pid: u32) -> Option<String> {
+    let output = Command::new("ps")
+        .args(["-o", "comm=", "-p", &pid.to_string()])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if raw.is_empty() {
+        return None;
+    }
+    // `ps -o comm=` returns the full executable path on macOS; take the basename.
+    let name = raw
+        .rsplit('/')
+        .next()
+        .unwrap_or(&raw)
+        .trim()
+        .to_string();
+    Some(name)
+}
+
+fn send_signal(pid: u32, signal: &str) {
+    let _ = Command::new("kill")
+        .args([&format!("-{}", signal), &pid.to_string()])
+        .status();
+}
+
+fn process_exists(pid: u32) -> bool {
+    Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn wait_for_exit(pids: &[u32], timeout: Duration) {
+    if pids.is_empty() {
+        return;
+    }
+    let start = Instant::now();
+    loop {
+        if pids.iter().all(|p| !process_exists(*p)) {
+            return;
+        }
+        if start.elapsed() >= timeout {
+            return;
+        }
+        sleep(Duration::from_millis(100));
+    }
+}


### PR DESCRIPTION
## Summary

Three ergonomic fixes for spawning long-running agent/worker instances via `twapp work`:

- **`twapp stop --name <name>`** — graceful shutdown (SIGTERM claude child + twapp host, 3s grace). `--force` escalates to SIGKILL. Replaces the `kill -TERM <pid>` dance at scale.
- **`twapp work --from-file <path>`** — wraps the prompt as `claude --dangerously-skip-permissions 'Read <abs-path> and execute.'`. Safer than `--run` for long prompts with Unicode/quotes/backslashes. Path is resolved to absolute and verified *before* spawning — missing file exits **2**.
- **cwd pre-flight** — `--claude-cwd <dir>` and a leading `cd <dir> && ...` in `--run` are verified before spawning. Missing directory exits **3** rather than silently failing inside the new terminal.

Plus: README "Spawning agent instances" section documenting the pattern + the `.claude/settings.local.json` bypass-permissions idiom, and `twapp work --help` / `twapp stop --help` cross-reference each other.

## Backwards compatibility

- `create_session_core()` signature unchanged — GUI callers are untouched.
- Existing `twapp work` / `twapp resume` / `twapp sessions` behavior is unchanged when none of the new flags are passed.
- `--run` and `--from-file` are mutually exclusive; passing both exits 1.

## Test plan

- [x] `cargo test` — 13 passing (5 new `parse_cd_prefix` cases, 3 new `resolve_from_file` cases, all existing).
- [x] `cargo check` clean.
- [x] Manual: `twapp work --name x --from-file /tmp/missing.md` → exit 2, error to stderr, no terminal.
- [x] Manual: `twapp work --name x --run "cd /tmp/nope && true"` → exit 3, error to stderr, no terminal.
- [x] Manual: `twapp stop --name definitely-not-running` → "not running: …", exit 1.
- [x] `--help` rendering inspected for both `work` and `stop`; cross-refs present.

Out of scope (per briefing): auto-archive of worktrees, `twapp status` liveness dashboard, changes to `dev-reload`/`setup-cert`/`install-gui`.