### PR TITLE
fix: session-id attribution via chain-of-descent (supersedes #35)

### DIFF
--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod notes;
 pub mod permissions;
 pub mod prompts;
 pub mod session;
+pub mod session_attribution;
 pub mod stop;
 pub mod theme;
 pub mod ticket;
@@ -807,6 +808,50 @@ fn cmd_resume(fork: bool) -> i32 {
         }
         build_and_launch(&work_dir, &window_name, &color, Some(&session_id), &command, chrome, provider, None)
     } else {
+        // Attribution: did /compact or /clear swap in a new jsonl since the
+        // last resume? Adopt only when the chain-of-descent signal is
+        // unambiguous; otherwise prompt the user rather than silently
+        // overwriting. Runs before bumping last_resumed so the "since"
+        // filter uses the prior resume's timestamp.
+        match session_attribution::maybe_sync_session_id(&work_dir, &mut session_data) {
+            session_attribution::SessionSyncOutcome::NoChange => {}
+            session_attribution::SessionSyncOutcome::Adopted {
+                old_id,
+                new_id,
+                event,
+                ..
+            } => {
+                println!(
+                    "Detected /{event} — adopted session id {} → {} (chain-of-descent confirmed)",
+                    short_id(&old_id),
+                    short_id(&new_id),
+                );
+            }
+            session_attribution::SessionSyncOutcome::NeedsConfirmation {
+                old_id,
+                candidates,
+            } => {
+                if let Some(chosen) = prompt_session_adoption(&old_id, &candidates) {
+                    match session_attribution::adopt_candidate_confirmed(
+                        &work_dir,
+                        &mut session_data,
+                        &chosen,
+                    ) {
+                        Ok(_) => println!(
+                            "Adopted session id {} → {} (user-confirmed)",
+                            short_id(&old_id),
+                            short_id(&chosen.session_id),
+                        ),
+                        Err(e) => eprintln!("Warning: could not record adoption: {}", e),
+                    }
+                } else {
+                    println!(
+                        "Keeping stored session id {}. (Edit via the session config modal or `twapp set-session` if Claude fails to resume.)",
+                        short_id(&old_id),
+                    );
+                }
+            }
+        }
         session_id = session_data.session_id.clone();
         let command = format!("{}claude --resume {}{}", cd_prefix, session_id, chrome_flag);
         session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
@@ -816,6 +861,72 @@ fn cmd_resume(fork: bool) -> i32 {
         }
         build_and_launch(&work_dir, &window_name, &color, Some(&session_id), &command, chrome, provider, None)
     }
+}
+
+fn short_id(id: &str) -> String {
+    if id.len() <= 8 {
+        id.to_string()
+    } else {
+        format!("{}…", &id[..8])
+    }
+}
+
+/// Interactive fallback for `cmd_resume` when attribution can't auto-resolve.
+/// Returns the candidate the user selected, or `None` to keep the stored id.
+fn prompt_session_adoption(
+    old_id: &str,
+    candidates: &[session_attribution::SessionCandidate],
+) -> Option<session_attribution::SessionCandidate> {
+    use std::io::{BufRead, Write};
+
+    // Skip the prompt when stdin isn't a tty (CI, scripted resumes) — safer
+    // to leave the stored id untouched and let the user fix it manually.
+    if !atty_stdin() {
+        return None;
+    }
+
+    eprintln!();
+    eprintln!(
+        "Claude wrote {} jsonl file(s) since the last resume of {} that don't clearly descend from it:",
+        candidates.len(),
+        short_id(old_id),
+    );
+    // Newest first.
+    let mut sorted = candidates.to_vec();
+    sorted.sort_by(|a, b| b.mtime.cmp(&a.mtime));
+    for (idx, c) in sorted.iter().enumerate() {
+        eprintln!(
+            "  [{}] {} ({})",
+            idx + 1,
+            short_id(&c.session_id),
+            c.event
+        );
+    }
+    eprint!(
+        "Pick a number to adopt that id, or press Enter to keep {}: ",
+        short_id(old_id),
+    );
+    let _ = std::io::stderr().flush();
+
+    let stdin = std::io::stdin();
+    let mut line = String::new();
+    if stdin.lock().read_line(&mut line).is_err() {
+        return None;
+    }
+    let choice = line.trim();
+    if choice.is_empty() {
+        return None;
+    }
+    let pick: usize = choice.parse().ok()?;
+    if pick == 0 || pick > sorted.len() {
+        return None;
+    }
+    Some(sorted.into_iter().nth(pick - 1).unwrap())
+}
+
+fn atty_stdin() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdin().is_terminal()
 }
 
 /// Build app args, prepare instance app, and launch GUI.

--- a/src-tauri/src/cli/session_attribution.rs
+++ b/src-tauri/src/cli/session_attribution.rs
@@ -1,0 +1,800 @@
+//! Claude session-ID attribution for twapp.
+//!
+//! The problem: `~/.claude/projects/<encoded_cwd>/` is scoped per working
+//! directory, not per session. Multiple twapp sessions rooted at the same
+//! directory share that directory. Picking the newest-mtime jsonl as the
+//! replacement for a stored session id can mis-attribute a file written by
+//! session A to session B.
+//!
+//! Resolution precedence:
+//! 1. **Chain-of-descent.** A jsonl created by `/compact` carries a
+//!    `compact_boundary` line near the top whose `sessionId` field is the
+//!    parent session's id. If a candidate descends from our stored id via a
+//!    short chain of such boundaries, adopt it.
+//! 2. **Cross-session exclusion.** Any jsonl whose id is already claimed by
+//!    another `.twapp-session.json` is not ours to adopt — skip it.
+//! 3. **`last_resumed` narrowing.** Only jsonls modified since the last
+//!    successful resume are considered, which excludes long-dead history.
+//! 4. **Interactive fallback.** If the above doesn't resolve a clear winner,
+//!    surface the candidates to the caller so the user (CLI prompt or GUI
+//!    dialog) can confirm. `cmd_resume` never silently overwrites on this
+//!    path.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use super::session::{SessionData, list_sessions, write_session};
+
+/// A single entry in `.twapp-session-history.json`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionHistoryEvent {
+    pub timestamp: String,
+    /// One of: `"compacted"`, `"cleared"`, `"manual_edit"`.
+    pub event: String,
+    pub old_session_id: String,
+    pub new_session_id: String,
+    /// Set when the adoption was not unambiguous (e.g. user-confirmed via the
+    /// interactive fallback). Older entries have this absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ambiguous: Option<bool>,
+    /// Free-form label identifying the path that led to adoption:
+    /// `"descent_chain"`, `"user_confirmed"`, `"manual_edit"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+pub fn read_history(work_dir: &Path) -> Vec<SessionHistoryEvent> {
+    let history_file = work_dir.join(".twapp-session-history.json");
+    if !history_file.exists() {
+        return Vec::new();
+    }
+    let Ok(content) = std::fs::read_to_string(&history_file) else {
+        return Vec::new();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+pub fn append_history(work_dir: &Path, event: SessionHistoryEvent) -> Result<(), String> {
+    let mut events = read_history(work_dir);
+    events.push(event);
+    let history_file = work_dir.join(".twapp-session-history.json");
+    let content = serde_json::to_string_pretty(&events)
+        .map_err(|e| format!("Failed to serialize history: {}", e))?;
+    std::fs::write(&history_file, content)
+        .map_err(|e| format!("Failed to write history file: {}", e))
+}
+
+/// Map `claude_cwd` to its `~/.claude/projects/<encoded>/` directory.
+pub fn claude_projects_dir(claude_cwd: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    let encoded = claude_cwd.replace('/', "-");
+    Some(home.join(".claude/projects").join(encoded))
+}
+
+/// Peek at the head of a JSONL file to decide whether the new session came
+/// from `/compact` (carries a continuity summary near the top) or `/clear`
+/// (fresh session with no summary). Best-effort; defaults to "cleared".
+pub fn classify_session_change(claude_cwd: &str, new_session_id: &str) -> &'static str {
+    let Some(dir) = claude_projects_dir(claude_cwd) else {
+        return "cleared";
+    };
+    let path = dir.join(format!("{}.jsonl", new_session_id));
+    classify_session_change_at(&path)
+}
+
+fn classify_session_change_at(path: &Path) -> &'static str {
+    let Ok(file) = std::fs::File::open(path) else {
+        return "cleared";
+    };
+    use std::io::BufRead;
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines().take(20).filter_map(|l| l.ok()) {
+        if line.contains("\"subtype\":\"compact_boundary\"")
+            || line.contains("\"isCompactSummary\":true")
+            || line.contains("\"type\":\"summary\"")
+        {
+            return "compacted";
+        }
+    }
+    "cleared"
+}
+
+/// Lightweight snapshot of the head of a Claude jsonl file.
+#[derive(Debug, Clone)]
+struct JsonlHead {
+    /// Session id from the filename stem.
+    session_id: String,
+    mtime: SystemTime,
+    /// Present iff a `compact_boundary` line was found in the head *and* the
+    /// `sessionId` on that line names a different session than the file stem
+    /// (i.e. the compact spawned a new jsonl rather than continuing in place).
+    compact_parent_session_id: Option<String>,
+    /// Any compact / clear continuity marker was seen in the head.
+    looks_compacted: bool,
+}
+
+const JSONL_HEAD_SCAN_LINES: usize = 20;
+
+fn read_jsonl_head(path: &Path) -> Option<JsonlHead> {
+    let meta = path.metadata().ok()?;
+    let mtime = meta.modified().ok()?;
+    let stem = path.file_stem()?.to_str()?.to_string();
+
+    let file = std::fs::File::open(path).ok()?;
+    use std::io::BufRead;
+    let reader = std::io::BufReader::new(file);
+
+    let mut compact_parent: Option<String> = None;
+    let mut looks_compacted = false;
+
+    for line in reader
+        .lines()
+        .take(JSONL_HEAD_SCAN_LINES)
+        .filter_map(|l| l.ok())
+    {
+        if line.contains("\"subtype\":\"compact_boundary\"") {
+            looks_compacted = true;
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) {
+                if let Some(parent) = v.get("sessionId").and_then(|x| x.as_str()) {
+                    if parent != stem {
+                        compact_parent = Some(parent.to_string());
+                    }
+                }
+            }
+            break;
+        }
+        if !looks_compacted
+            && (line.contains("\"isCompactSummary\":true") || line.contains("\"type\":\"summary\""))
+        {
+            looks_compacted = true;
+        }
+    }
+
+    Some(JsonlHead {
+        session_id: stem,
+        mtime,
+        compact_parent_session_id: compact_parent,
+        looks_compacted,
+    })
+}
+
+/// Candidate jsonl considered as a potential replacement for `stored_id`.
+/// Returned by `find_session_candidates` and surfaced to the interactive
+/// fallback so the caller can display a list.
+#[derive(Debug, Clone)]
+pub struct SessionCandidate {
+    pub session_id: String,
+    pub mtime: SystemTime,
+    /// `"compacted"` if continuity markers present in the head, else `"cleared"`.
+    pub event: &'static str,
+    /// True iff the candidate descends from `stored_id` via a short chain of
+    /// `compact_boundary` parent links (up to `MAX_DESCENT_DEPTH`).
+    pub descends_from_stored: bool,
+}
+
+const MAX_DESCENT_DEPTH: usize = 8;
+
+/// Walk `candidate`'s `compact_boundary` parent chain. Returns `true` iff we
+/// hit `stored_id` within `MAX_DESCENT_DEPTH` hops. Each hop reads one file's
+/// head only; the walk terminates as soon as:
+///   - we reach `stored_id` (descent confirmed), or
+///   - a hop has no `compact_parent_session_id` (chain ended), or
+///   - the parent file is missing from `project_dir`, or
+///   - we revisit a session id (cycle guard), or
+///   - we exceed `MAX_DESCENT_DEPTH`.
+fn descends_from(
+    project_dir: &Path,
+    candidate: &JsonlHead,
+    stored_id: &str,
+) -> bool {
+    if stored_id.is_empty() {
+        return false;
+    }
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut cursor = candidate.clone();
+    for _ in 0..MAX_DESCENT_DEPTH {
+        let Some(parent_id) = cursor.compact_parent_session_id.clone() else {
+            return false;
+        };
+        if parent_id == stored_id {
+            return true;
+        }
+        if !seen.insert(parent_id.clone()) {
+            return false;
+        }
+        let parent_path = project_dir.join(format!("{}.jsonl", parent_id));
+        let Some(parent_head) = read_jsonl_head(&parent_path) else {
+            return false;
+        };
+        cursor = parent_head;
+    }
+    false
+}
+
+/// Scan the project directory for candidate jsonls that could replace
+/// `stored_id`. Applies:
+///   - `session_id != stored_id`
+///   - `session_id` not in `excluded_ids`
+///   - `mtime >= since` (when `since` is set)
+/// Annotates each candidate with `descends_from_stored` so callers can
+/// separate confirmed descendants from merely-unclaimed mtime matches.
+pub fn find_session_candidates(
+    stored_id: &str,
+    claude_cwd: &str,
+    since: Option<SystemTime>,
+    excluded_ids: &HashSet<String>,
+) -> Vec<SessionCandidate> {
+    let Some(project_dir) = claude_projects_dir(claude_cwd) else {
+        return Vec::new();
+    };
+    if !project_dir.exists() {
+        return Vec::new();
+    }
+    let Ok(entries) = std::fs::read_dir(&project_dir) else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(head) = read_jsonl_head(&path) else {
+            continue;
+        };
+        if head.session_id == stored_id {
+            continue;
+        }
+        if excluded_ids.contains(&head.session_id) {
+            continue;
+        }
+        if let Some(since) = since {
+            if head.mtime < since {
+                continue;
+            }
+        }
+        let event = if head.looks_compacted {
+            "compacted"
+        } else {
+            "cleared"
+        };
+        let descends = descends_from(&project_dir, &head, stored_id);
+        candidates.push(SessionCandidate {
+            session_id: head.session_id,
+            mtime: head.mtime,
+            event,
+            descends_from_stored: descends,
+        });
+    }
+    candidates
+}
+
+/// Resolve a replacement session id for `stored_id`, if one is unambiguous.
+/// Returns `(Some((new_id, event)), all_candidates)` when exactly one
+/// candidate descends from the stored id; otherwise `(None, all_candidates)`
+/// and the caller decides whether to prompt the user.
+pub fn find_descendant_session_id(
+    stored_id: &str,
+    claude_cwd: &str,
+    since: Option<SystemTime>,
+    excluded_ids: &HashSet<String>,
+) -> (Option<(String, &'static str)>, Vec<SessionCandidate>) {
+    let candidates = find_session_candidates(stored_id, claude_cwd, since, excluded_ids);
+    let resolved = candidates
+        .iter()
+        .filter(|c| c.descends_from_stored)
+        .max_by_key(|c| c.mtime)
+        .map(|c| (c.session_id.clone(), c.event));
+    (resolved, candidates)
+}
+
+/// Collect session ids claimed by other `.twapp-session.json` files that the
+/// user has on disk, so we never adopt a jsonl already owned by a sibling
+/// session. Scan root comes from the global `work_directory` config and
+/// falls back to `current_work_dir`'s parent.
+pub fn collect_other_claimed_ids(current_work_dir: &Path) -> HashSet<String> {
+    let scan_roots: Vec<PathBuf> = match crate::cli::config::GlobalConfig::load() {
+        Ok(cfg) => vec![cfg.work_directory],
+        Err(_) => current_work_dir
+            .parent()
+            .map(|p| vec![p.to_path_buf()])
+            .unwrap_or_default(),
+    };
+
+    let current_canonical = std::fs::canonicalize(current_work_dir)
+        .unwrap_or_else(|_| current_work_dir.to_path_buf());
+
+    let mut ids = HashSet::new();
+    for root in scan_roots {
+        for (data, dir) in list_sessions(&root) {
+            let dir_canonical = std::fs::canonicalize(&dir).unwrap_or(dir);
+            if dir_canonical == current_canonical {
+                continue;
+            }
+            if !data.session_id.is_empty() {
+                ids.insert(data.session_id);
+            }
+            if let Some(codex_id) = data.codex_session_id {
+                if !codex_id.is_empty() {
+                    ids.insert(codex_id);
+                }
+            }
+        }
+    }
+    ids
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdoptionReason {
+    /// Resolved through the compact_boundary chain-of-descent signal.
+    DescentChain,
+}
+
+impl AdoptionReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::DescentChain => "descent_chain",
+        }
+    }
+}
+
+pub enum SessionSyncOutcome {
+    /// Stored id is still the current one.
+    NoChange,
+    /// Confidently adopted a replacement id; session file + audit log updated.
+    Adopted {
+        old_id: String,
+        new_id: String,
+        event: &'static str,
+        reason: AdoptionReason,
+    },
+    /// Unclaimed candidate(s) exist in the window but descent couldn't be
+    /// confirmed. Caller must decide (interactive prompt in CLI, or no-op in
+    /// non-interactive contexts). Session file is NOT modified.
+    NeedsConfirmation {
+        old_id: String,
+        candidates: Vec<SessionCandidate>,
+    },
+}
+
+fn parse_rfc3339_as_systemtime(ts: &str) -> Option<SystemTime> {
+    let dt = chrono::DateTime::parse_from_rfc3339(ts).ok()?;
+    let secs = dt.timestamp();
+    let nanos = dt.timestamp_subsec_nanos();
+    if secs >= 0 {
+        Some(
+            SystemTime::UNIX_EPOCH
+                + std::time::Duration::new(secs as u64, nanos),
+        )
+    } else {
+        None
+    }
+}
+
+/// Core resolver. Only adopts when the chain-of-descent signal is
+/// unambiguous. Never silently overwrites on mtime alone. If unresolvable
+/// candidates remain in the window, returns them for the caller to handle.
+pub fn maybe_sync_session_id(
+    work_dir: &Path,
+    session_data: &mut SessionData,
+) -> SessionSyncOutcome {
+    let claude_cwd = if session_data.claude_cwd.is_empty() {
+        work_dir.to_string_lossy().to_string()
+    } else {
+        session_data.claude_cwd.clone()
+    };
+    let stored_id = session_data.session_id.clone();
+    if stored_id.is_empty() {
+        return SessionSyncOutcome::NoChange;
+    }
+
+    let since = session_data
+        .last_resumed
+        .as_deref()
+        .and_then(parse_rfc3339_as_systemtime);
+    let excluded = collect_other_claimed_ids(work_dir);
+
+    let (resolved, candidates) =
+        find_descendant_session_id(&stored_id, &claude_cwd, since, &excluded);
+
+    if let Some((new_id, event)) = resolved {
+        let old_id = stored_id;
+        session_data.session_id = new_id.clone();
+        if write_session(work_dir, session_data).is_err() {
+            return SessionSyncOutcome::NoChange;
+        }
+        let _ = append_history(
+            work_dir,
+            SessionHistoryEvent {
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                event: event.to_string(),
+                old_session_id: old_id.clone(),
+                new_session_id: new_id.clone(),
+                ambiguous: None,
+                reason: Some(AdoptionReason::DescentChain.as_str().to_string()),
+            },
+        );
+        return SessionSyncOutcome::Adopted {
+            old_id,
+            new_id,
+            event,
+            reason: AdoptionReason::DescentChain,
+        };
+    }
+
+    if candidates.is_empty() {
+        return SessionSyncOutcome::NoChange;
+    }
+    SessionSyncOutcome::NeedsConfirmation {
+        old_id: stored_id,
+        candidates,
+    }
+}
+
+/// Apply a user-confirmed candidate. Writes the session file, appends an
+/// audit entry flagged `ambiguous: true` so the non-chain adoption is
+/// traceable.
+pub fn adopt_candidate_confirmed(
+    work_dir: &Path,
+    session_data: &mut SessionData,
+    candidate: &SessionCandidate,
+) -> Result<SessionHistoryEvent, String> {
+    let old_id = session_data.session_id.clone();
+    session_data.session_id = candidate.session_id.clone();
+    write_session(work_dir, session_data)?;
+    let event = SessionHistoryEvent {
+        timestamp: chrono::Utc::now().to_rfc3339(),
+        event: candidate.event.to_string(),
+        old_session_id: old_id,
+        new_session_id: candidate.session_id.clone(),
+        ambiguous: Some(true),
+        reason: Some("user_confirmed".to_string()),
+    };
+    append_history(work_dir, event.clone())?;
+    Ok(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::session::{AgentProvider, SessionData, write_session};
+    use std::fs;
+    use std::time::{Duration, SystemTime};
+
+    fn mk_session(id: &str, claude_cwd: &str, last_resumed: Option<&str>) -> SessionData {
+        SessionData {
+            session_id: id.to_string(),
+            name: "t".to_string(),
+            color: String::new(),
+            ticket_key: None,
+            claude_cwd: claude_cwd.to_string(),
+            created: "2026-01-01T00:00:00Z".to_string(),
+            last_resumed: last_resumed.map(String::from),
+            provider: Some(AgentProvider::Claude),
+            codex_session_id: None,
+            codex_cwd: None,
+            forked_from: None,
+            imported: None,
+            imported_from: None,
+            use_chrome: None,
+            override_terminal_theme: None,
+        }
+    }
+
+    fn write_fresh_jsonl(path: &Path, session_id: &str) {
+        let body = format!(
+            "{{\"type\":\"permission-mode\",\"sessionId\":\"{sid}\"}}\n\
+             {{\"parentUuid\":null,\"type\":\"user\",\"sessionId\":\"{sid}\",\"uuid\":\"msg-{sid}\"}}\n",
+            sid = session_id
+        );
+        fs::write(path, body).unwrap();
+    }
+
+    fn write_compacted_jsonl(path: &Path, session_id: &str, parent_session_id: &str) {
+        // Mirrors the real shape: file-history-snapshot lines, then a
+        // compact_boundary whose sessionId is the parent and whose file stem
+        // is the new session id.
+        let body = format!(
+            "{{\"type\":\"file-history-snapshot\"}}\n\
+             {{\"parentUuid\":null,\"logicalParentUuid\":\"leaf-{parent}\",\"type\":\"system\",\"subtype\":\"compact_boundary\",\"sessionId\":\"{parent}\",\"uuid\":\"boundary-{sid}\"}}\n\
+             {{\"parentUuid\":\"boundary-{sid}\",\"type\":\"user\",\"isCompactSummary\":true,\"sessionId\":\"{sid}\",\"uuid\":\"summary-{sid}\"}}\n",
+            sid = session_id,
+            parent = parent_session_id
+        );
+        fs::write(path, body).unwrap();
+    }
+
+    /// Sleep long enough for sequential writes to have strictly increasing
+    /// mtimes, even on filesystems with coarse mtime resolution (HFS+ is 1s).
+    fn bump_mtime() {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+
+    /// Set up a fake `~/.claude/projects/<encoded>/` rooted at `tmp_home`.
+    /// Returns the encoded project dir path and the fake `claude_cwd`.
+    fn fake_claude_projects(tmp_home: &Path, cwd_leaf: &str) -> (PathBuf, String) {
+        let claude_cwd = format!("{}/{}", tmp_home.display(), cwd_leaf);
+        let encoded = claude_cwd.replace('/', "-");
+        let dir = tmp_home.join(".claude/projects").join(encoded);
+        fs::create_dir_all(&dir).unwrap();
+        (dir, claude_cwd)
+    }
+
+    struct HomeGuard {
+        prev: Option<std::ffi::OsString>,
+        tmp: PathBuf,
+    }
+
+    impl HomeGuard {
+        fn new() -> Self {
+            let tmp = std::env::temp_dir().join(format!(
+                "twapp-attr-{}",
+                uuid::Uuid::new_v4()
+            ));
+            fs::create_dir_all(&tmp).unwrap();
+            let prev = std::env::var_os("HOME");
+            unsafe {
+                std::env::set_var("HOME", &tmp);
+            }
+            Self { prev, tmp }
+        }
+    }
+
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.prev {
+                Some(v) => unsafe { std::env::set_var("HOME", v) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+            let _ = fs::remove_dir_all(&self.tmp);
+        }
+    }
+
+    // NB: the HOME mutation has to be serialized across tests in this file.
+    // Rust's test harness runs tests in parallel within a binary, so we
+    // serialize by one mutex.
+    use std::sync::Mutex;
+    static HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn happy_path_chain_of_descent_adopts_compacted_id() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projA");
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_compacted_jsonl(&project_dir.join("A2.jsonl"), "A2", "A1");
+
+        let (resolved, cands) = find_descendant_session_id(
+            "A1",
+            &claude_cwd,
+            None,
+            &HashSet::new(),
+        );
+        assert_eq!(resolved.as_ref().map(|(id, _)| id.as_str()), Some("A2"));
+        assert_eq!(resolved.unwrap().1, "compacted");
+        assert!(cands.iter().any(|c| c.session_id == "A2" && c.descends_from_stored));
+    }
+
+    #[test]
+    fn misattribution_guard_does_not_adopt_sibling_sessions_compact() {
+        // Reproducer from twapp-reviewer's comment:
+        //   Session A: stored A1, compacts → A2 in shared dir.
+        //   Session B: stored B1. `twapp resume` in B must NOT adopt A2.
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "shared");
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_fresh_jsonl(&project_dir.join("B1.jsonl"), "B1");
+        bump_mtime();
+        write_compacted_jsonl(&project_dir.join("A2.jsonl"), "A2", "A1");
+
+        let (resolved, cands) = find_descendant_session_id(
+            "B1",
+            &claude_cwd,
+            None,
+            &HashSet::new(),
+        );
+        assert!(resolved.is_none(), "B must not adopt A's compacted child");
+        // A2 shows up as a candidate but is *not* marked as descending from B1.
+        let a2 = cands.iter().find(|c| c.session_id == "A2").unwrap();
+        assert!(!a2.descends_from_stored);
+    }
+
+    #[test]
+    fn cleared_unrelated_session_returns_needs_confirmation_not_auto_adopt() {
+        // Stored A1; the user ran `/clear` and Claude wrote a fresh A3 with
+        // no continuity marker. We must NOT silently adopt A3.
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projA");
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_fresh_jsonl(&project_dir.join("A3.jsonl"), "A3");
+
+        let (resolved, cands) = find_descendant_session_id(
+            "A1",
+            &claude_cwd,
+            None,
+            &HashSet::new(),
+        );
+        assert!(resolved.is_none(), "no descent chain → no silent adoption");
+        let a3 = cands.iter().find(|c| c.session_id == "A3").unwrap();
+        assert_eq!(a3.event, "cleared");
+        assert!(!a3.descends_from_stored);
+    }
+
+    #[test]
+    fn cross_session_exclusion_skips_other_claimed_ids() {
+        // A2 descends from C1 via compact, but another twapp session has
+        // already claimed A2 as its own stored id. `C1`'s resume must not
+        // adopt a jsonl the coordinator says belongs elsewhere.
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "shared2");
+
+        write_compacted_jsonl(&project_dir.join("A2.jsonl"), "A2", "C1");
+
+        let mut excluded = HashSet::new();
+        excluded.insert("A2".to_string());
+
+        let (resolved, cands) = find_descendant_session_id(
+            "C1",
+            &claude_cwd,
+            None,
+            &excluded,
+        );
+        assert!(resolved.is_none(), "excluded id must not be adopted");
+        assert!(cands.is_empty(), "excluded id is dropped from candidate list");
+    }
+
+    #[test]
+    fn last_resumed_at_narrowing_excludes_old_jsonls() {
+        // A2 is a valid descent from A1, but its mtime predates our
+        // last_resumed → the user already resumed past it. We should not
+        // even consider it a candidate.
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projA2");
+
+        let a2_path = project_dir.join("A2.jsonl");
+        write_compacted_jsonl(&a2_path, "A2", "A1");
+        // Cutoff 1 hour after the file's mtime → must exclude it.
+        let a2_mtime = a2_path.metadata().unwrap().modified().unwrap();
+        let since = Some(a2_mtime + Duration::from_secs(3600));
+
+        let (resolved, cands) = find_descendant_session_id(
+            "A1",
+            &claude_cwd,
+            since,
+            &HashSet::new(),
+        );
+        assert!(resolved.is_none());
+        assert!(
+            cands.is_empty(),
+            "jsonls older than last_resumed must not appear as candidates"
+        );
+    }
+
+    #[test]
+    fn chain_of_two_compactions_still_resolves() {
+        // A1 → A2 (compact) → A3 (compact). Stored A1, newest is A3.
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projChain");
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_compacted_jsonl(&project_dir.join("A2.jsonl"), "A2", "A1");
+        bump_mtime();
+        write_compacted_jsonl(&project_dir.join("A3.jsonl"), "A3", "A2");
+
+        let (resolved, _) = find_descendant_session_id(
+            "A1",
+            &claude_cwd,
+            None,
+            &HashSet::new(),
+        );
+        assert_eq!(resolved.as_ref().map(|(id, _)| id.as_str()), Some("A3"));
+    }
+
+    #[test]
+    fn maybe_sync_writes_session_and_history_on_adoption() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projSync");
+
+        let work_dir = home.tmp.join("work_projSync");
+        fs::create_dir_all(&work_dir).unwrap();
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_compacted_jsonl(&project_dir.join("A2.jsonl"), "A2", "A1");
+
+        let mut data = mk_session("A1", &claude_cwd, None);
+        write_session(&work_dir, &data).unwrap();
+
+        let outcome = maybe_sync_session_id(&work_dir, &mut data);
+        match outcome {
+            SessionSyncOutcome::Adopted { new_id, event, .. } => {
+                assert_eq!(new_id, "A2");
+                assert_eq!(event, "compacted");
+            }
+            _ => panic!("expected Adopted"),
+        }
+        assert_eq!(data.session_id, "A2");
+        let history = read_history(&work_dir);
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].reason.as_deref(), Some("descent_chain"));
+        assert_eq!(history[0].ambiguous, None);
+    }
+
+    #[test]
+    fn maybe_sync_returns_needs_confirmation_on_cleared_unrelated() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projClear");
+
+        let work_dir = home.tmp.join("work_projClear");
+        fs::create_dir_all(&work_dir).unwrap();
+
+        write_fresh_jsonl(&project_dir.join("A1.jsonl"), "A1");
+        bump_mtime();
+        write_fresh_jsonl(&project_dir.join("A3.jsonl"), "A3");
+
+        let mut data = mk_session("A1", &claude_cwd, None);
+        write_session(&work_dir, &data).unwrap();
+
+        let outcome = maybe_sync_session_id(&work_dir, &mut data);
+        match outcome {
+            SessionSyncOutcome::NeedsConfirmation { candidates, .. } => {
+                assert!(candidates.iter().any(|c| c.session_id == "A3"));
+            }
+            _ => panic!("expected NeedsConfirmation"),
+        }
+        // session_data must NOT be overwritten.
+        assert_eq!(data.session_id, "A1");
+        assert_eq!(read_history(&work_dir).len(), 0);
+    }
+
+    #[test]
+    fn adopt_candidate_confirmed_flags_ambiguous_in_audit() {
+        let _guard = HOME_LOCK.lock().unwrap();
+        let home = HomeGuard::new();
+        let (_project_dir, claude_cwd) =
+            fake_claude_projects(&home.tmp, "projConfirm");
+
+        let work_dir = home.tmp.join("work_projConfirm");
+        fs::create_dir_all(&work_dir).unwrap();
+
+        let mut data = mk_session("A1", &claude_cwd, None);
+        write_session(&work_dir, &data).unwrap();
+
+        let candidate = SessionCandidate {
+            session_id: "A3".to_string(),
+            mtime: SystemTime::UNIX_EPOCH + Duration::from_secs(2_000),
+            event: "cleared",
+            descends_from_stored: false,
+        };
+        let event = adopt_candidate_confirmed(&work_dir, &mut data, &candidate).unwrap();
+        assert_eq!(data.session_id, "A3");
+        assert_eq!(event.event, "cleared");
+        assert_eq!(event.ambiguous, Some(true));
+        assert_eq!(event.reason.as_deref(), Some("user_confirmed"));
+    }
+}

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -94,6 +94,7 @@ pub fn run(args: GuiArgs) {
             sessions::rename_session,
             sessions::update_session_color,
             sessions::update_session_fields,
+            sessions::get_session_history,
             sessions::delete_session,
             sessions::discover_claude_sessions,
             sessions::import_sessions,

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -8,6 +8,7 @@ use crate::cli::session::{
     count_codex_conversation_messages, find_latest_codex_session_for_cwd, other_provider,
     shell_escape_single, AgentProvider, SessionData,
 };
+use crate::cli::session_attribution;
 
 pub fn sanitize_instance_name(name: &str) -> String {
     let safe: String = name
@@ -490,12 +491,30 @@ pub async fn launch_session(_session_id: String, directory: String) -> Result<()
         return Ok(());
     }
 
-    // Update last_resumed
-    session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
-    session_data.provider = Some(preferred);
-
     // Run health checks
     crate::cli::session::run_health_checks(&work_dir, Some(&session_data));
+
+    // Attribution: adopt a compacted session id when chain-of-descent is
+    // unambiguous. Ambiguous cases are deliberately NOT auto-adopted from
+    // the GUI — the user can confirm via the session config modal, which
+    // flows through `update_session_fields` and logs a manual_edit event.
+    if preferred == AgentProvider::Claude {
+        if let session_attribution::SessionSyncOutcome::Adopted { old_id, new_id, event, .. } =
+            session_attribution::maybe_sync_session_id(&work_dir, &mut session_data)
+        {
+            log::info!(
+                "attribution: adopted {} → {} via {} (descent_chain)",
+                old_id,
+                new_id,
+                event,
+            );
+        }
+    }
+
+    // Update last_resumed (after attribution, so the attribution window uses
+    // the *previous* resume's timestamp).
+    session_data.last_resumed = Some(chrono::Utc::now().to_rfc3339());
+    session_data.provider = Some(preferred);
 
     let migration_prompt = if session_data.needs_migration(preferred) {
         Some(build_migration_prompt(
@@ -796,6 +815,8 @@ pub async fn update_session_fields(
 ) -> Result<(), String> {
     let work_dir = std::path::PathBuf::from(&directory);
     let mut data = crate::cli::session::read_session(&work_dir)?;
+    let prior_claude_id = data.session_id.clone();
+    let prior_codex_id = data.codex_session_id.clone().unwrap_or_default();
 
     if let Some(ref n) = name {
         data.name = n.clone();
@@ -825,7 +846,40 @@ pub async fn update_session_fields(
     }
 
     crate::cli::session::write_session(&work_dir, &data)?;
+
+    // Audit-log any manual change to a session id. Distinct from automatic
+    // /compact or /clear adoption, so users can tell "I changed this" from
+    // "twapp adopted this".
+    let new_claude_id = data.session_id.clone();
+    let new_codex_id = data.codex_session_id.clone().unwrap_or_default();
+    if new_claude_id != prior_claude_id || new_codex_id != prior_codex_id {
+        let (old_id, new_id) = if new_claude_id != prior_claude_id {
+            (prior_claude_id, new_claude_id)
+        } else {
+            (prior_codex_id, new_codex_id)
+        };
+        let _ = session_attribution::append_history(
+            &work_dir,
+            session_attribution::SessionHistoryEvent {
+                timestamp: chrono::Utc::now().to_rfc3339(),
+                event: "manual_edit".to_string(),
+                old_session_id: old_id,
+                new_session_id: new_id,
+                ambiguous: None,
+                reason: Some("manual_edit".to_string()),
+            },
+        );
+    }
+
     Ok(())
+}
+
+#[tauri::command]
+pub async fn get_session_history(
+    directory: String,
+) -> Result<Vec<session_attribution::SessionHistoryEvent>, String> {
+    let work_dir = std::path::PathBuf::from(&directory);
+    Ok(session_attribution::read_history(&work_dir))
 }
 
 #[tauri::command]

--- a/src/App.css
+++ b/src/App.css
@@ -907,6 +907,112 @@ body,
   padding-bottom: 0;
 }
 
+/* Compaction indicator + session-history modal. */
+.compaction-indicator {
+  margin-top: 6px;
+  padding: 2px 8px;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  color: var(--text-muted);
+  font-size: 10px;
+  cursor: pointer;
+  align-self: flex-start;
+}
+
+.compaction-indicator:hover {
+  color: var(--text-primary);
+  border-color: var(--text-muted);
+}
+
+.history-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  padding: 20px 0;
+}
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.history-item {
+  padding: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+}
+
+.history-item-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.history-item-header .history-timestamp {
+  margin-left: auto;
+}
+
+.history-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #fff;
+}
+
+.history-badge-compacted {
+  background: #f59e0b;
+}
+
+.history-badge-cleared {
+  background: #ef4444;
+}
+
+.history-badge-manual_edit {
+  background: #3b82f6;
+}
+
+.history-badge-ambiguous {
+  background: #6b7280;
+}
+
+.history-timestamp {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.history-ids {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.history-id-label {
+  color: var(--text-muted);
+}
+
+.history-id {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 1px 4px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 3px;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.history-id:hover {
+  border-color: var(--accent);
+}
+
 .session-settings-label {
   font-size: 11px;
   color: var(--text-muted);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import yaml from "js-yaml";
 import "@xterm/xterm/css/xterm.css";
 import "./App.css";
 import { applyThemeColor, getDarkModeAccentColor } from "./color";
-import type { AppConfig, TicketInfo, Note, QuickPrompt, MonitorStatusInfo, MonitorLogEntry, PromptSection, PromptStore, TabInfo, ThemeMode } from "./types";
+import type { AppConfig, TicketInfo, Note, QuickPrompt, MonitorStatusInfo, MonitorLogEntry, PromptSection, PromptStore, TabInfo, ThemeMode, SessionHistoryEvent } from "./types";
 import { lightTheme, darkTheme, getLightTheme, getDarkTheme } from "./types";
 import { formatTicketBadge, formatTime } from "./utils/format";
 import { isYamlFile, isHtmlFile, isImageFile, imageMimeType, isFilePath, isLikelyPreviewableHref, normalizeFilePathCandidate, isAbsolutePath } from "./utils/file";
@@ -47,6 +47,9 @@ function App() {
   const fitAddon = useRef<FitAddon | null>(null);
 
   const [notes, setNotes] = useState<Note[]>([]);
+  // Session history audit log (.twapp-session-history.json) — compact / clear / manual_edit events.
+  const [sessionHistory, setSessionHistory] = useState<SessionHistoryEvent[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
   const [newNote, setNewNote] = useState("");
   const [editingNoteId, setEditingNoteId] = useState<string | null>(null);
   const [editingText, setEditingText] = useState("");
@@ -186,6 +189,14 @@ function App() {
         notesLoaded.current = true;
       })
       .catch(console.error);
+  };
+
+  const loadSessionHistory = (cwd?: string | null) => {
+    const directory = cwd ?? appConfig?.cwd;
+    if (!directory) return;
+    invoke<SessionHistoryEvent[]>("get_session_history", { directory })
+      .then((events) => setSessionHistory(events ?? []))
+      .catch(() => setSessionHistory([]));
   };
 
   const reloadPrompts = () => {
@@ -580,6 +591,7 @@ function App() {
       // Load persisted notes and prompts
       reloadNotes();
       reloadPrompts();
+      loadSessionHistory(config.cwd);
 
       // Fetch ticket info if available
       invoke<TicketInfo | null>("get_ticket_info")
@@ -1143,6 +1155,8 @@ function App() {
         setAppConfig((prev) => prev ? { ...prev, session_id: args.session_id } : prev);
       }
       setSessionFieldsOriginal({ ...sessionFields });
+      // A session_id change writes a `manual_edit` audit entry — refresh.
+      loadSessionHistory();
     } catch (err) {
       setSessionFieldsError(String(err));
     } finally {
@@ -2269,6 +2283,15 @@ function App() {
               </button>
             </div>
           )}
+          {sessionHistory.length > 0 && (
+            <button
+              className="compaction-indicator"
+              onClick={() => setHistoryOpen(true)}
+              title="View session history"
+            >
+              Compactions ({sessionHistory.filter((e) => e.event === "compacted" || e.event === "cleared").length})
+            </button>
+          )}
         </div>
 
         {/* Fork Dialog */}
@@ -2846,6 +2869,64 @@ function App() {
                 </div>
               ) : (
                 <pre className="file-preview-code">{previewFile?.content}</pre>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Session History Modal */}
+      {historyOpen && (
+        <div className="config-overlay" onClick={() => setHistoryOpen(false)}>
+          <div className="config-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="config-header">
+              <span className="config-title">Session History</span>
+              <button className="config-close" onClick={() => setHistoryOpen(false)}>&times;</button>
+            </div>
+            <div className="config-body">
+              {sessionHistory.length === 0 ? (
+                <div className="history-empty">No history events yet.</div>
+              ) : (
+                <div className="history-list">
+                  {[...sessionHistory].reverse().map((ev, idx) => (
+                    <div className="history-item" key={idx}>
+                      <div className="history-item-header">
+                        <span className={`history-badge history-badge-${ev.event}`}>
+                          {ev.event === "manual_edit" ? "edited" : ev.event}
+                        </span>
+                        {ev.ambiguous && (
+                          <span
+                            className="history-badge history-badge-ambiguous"
+                            title="Adopted without a chain-of-descent signal — user-confirmed."
+                          >
+                            ambiguous
+                          </span>
+                        )}
+                        <span className="history-timestamp">
+                          {new Date(ev.timestamp).toLocaleString()}
+                        </span>
+                      </div>
+                      <div className="history-ids">
+                        <span className="history-id-label">from</span>
+                        <code
+                          className="history-id"
+                          title={ev.old_session_id ? `${ev.old_session_id}\n(click to copy)` : "(none)"}
+                          onClick={() => ev.old_session_id && navigator.clipboard.writeText(ev.old_session_id)}
+                        >
+                          {ev.old_session_id ? ev.old_session_id.slice(0, 8) : "(none)"}
+                        </code>
+                        <span className="history-id-label">&rarr;</span>
+                        <code
+                          className="history-id"
+                          title={ev.new_session_id ? `${ev.new_session_id}\n(click to copy)` : "(none)"}
+                          onClick={() => ev.new_session_id && navigator.clipboard.writeText(ev.new_session_id)}
+                        >
+                          {ev.new_session_id ? ev.new_session_id.slice(0, 8) : "(none)"}
+                        </code>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               )}
             </div>
           </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -186,6 +186,15 @@ export interface DeletePreflight {
   forked_from: string | null;
 }
 
+export interface SessionHistoryEvent {
+  timestamp: string;
+  event: "compacted" | "cleared" | "manual_edit";
+  old_session_id: string;
+  new_session_id: string;
+  ambiguous?: boolean | null;
+  reason?: string | null;
+}
+
 export type SortMode = "recent" | "alpha";
 
 export type LauncherView = "sessions" | "settings" | "new-session" | "import";


### PR DESCRIPTION
## Problem

When `/compact` or `/clear` spawns a new Claude session jsonl, twapp's stored
`session_id` goes stale. PR #35 detected this by picking the newest-mtime
jsonl in `~/.claude/projects/<encoded-cwd>/` — but that directory is scoped
per working directory, **not** per session. Two twapp sessions rooted at the
same `claude_cwd` share it, so mtime alone mis-attributes work across
sessions.

Reproducer (from twapp-reviewer's comment on #35):
1. Session A (stored `A1`) runs `/compact` → Claude writes `A2.jsonl`.
2. Session B (stored `B1`) is fine, still pointing at the older jsonl.
3. User runs `twapp resume` in B's worktree.
4. Newest-mtime scan returns `A2` → B's stored id is overwritten to `A2`.
5. B's next resume attaches to A's history. Silent data mixing.

## Fix

`find_descendant_session_id` uses the compact-boundary's `sessionId` field
as the primary attribution signal. A candidate jsonl is only adopted when
its chain of `compact_boundary` parent links walks back to our stored id
(up to 8 hops). mtime is kept as a candidate-generator but never as the
arbitration signal.

Resolution precedence:

1. **Chain-of-descent.** Candidate's `compact_boundary` line names the
   parent session id. Walk the chain; if we hit stored id, adopt.
2. **Cross-session exclusion.** Any jsonl already claimed as the
   `session_id` of another `.twapp-session.json` is dropped from the
   candidate list (belt-and-suspenders; the chain check alone already
   rejects them).
3. **`last_resumed` narrowing.** Candidates older than the previous
   successful resume never enter the pool — excludes ancient history by
   construction.
4. **Interactive fallback.** Unresolvable candidates (e.g. `/clear`,
   which leaves no parent pointer) surface through
   `SessionSyncOutcome::NeedsConfirmation`. CLI prompts stdin; GUI
   declines to auto-adopt (users still reach the same code path via the
   session config modal, which logs a `manual_edit` event with the
   existing precedent from PR #35). `cmd_resume` **never** silently
   overwrites.

Audit entries gain two optional fields:
  * `ambiguous: true` — set on user-confirmed adoptions from the
    interactive fallback.
  * `reason: "descent_chain" | "user_confirmed" | "manual_edit"` —
    lets future consumers tell automatic adoption from manual edits.

`classify_session_change` is unchanged (it's correct for known
transitions, per briefing).

## Files

- `src-tauri/src/cli/session_attribution.rs` — new module: header
  parsing, descent walk, candidate selection, `maybe_sync_session_id`,
  `adopt_candidate_confirmed`, history log helpers, 9 unit tests.
- `src-tauri/src/cli/mod.rs` — `cmd_resume` calls the resolver before
  bumping `last_resumed`; prints a one-line notice on adoption; prompts
  via stdin on ambiguity (skipped when stdin isn't a tty).
- `src-tauri/src/gui/sessions.rs` — `launch_session` calls the
  resolver (adopts only when unambiguous); `update_session_fields`
  logs `manual_edit` events; new `get_session_history` command.
- `src-tauri/src/gui/mod.rs` — register `get_session_history`.
- `src/types.ts`, `src/App.tsx`, `src/App.css` — session-history
  state, "Compactions (N)" pill, modal (ambiguous badge added).

## Test plan

- [x] `cargo test` — 22/22 pass (9 new attribution tests).
- [x] `npx tsc --noEmit` — clean.
- Encoded the reviewer's reproducer as
  `misattribution_guard_does_not_adopt_sibling_sessions_compact`.
- Table of scenarios:
  - Happy path: stored A1 → A2 compacted, adopted via descent chain.
  - Misattribution guard: B's resume ignores A's compacted A2 (no descent).
  - Clear / unrelated: fresh A3 with no parent → `NeedsConfirmation`, no silent overwrite.
  - Cross-session exclusion: A2 claimed elsewhere → dropped from candidates.
  - `last_resumed` narrowing: jsonls older than cutoff excluded.
  - Two-hop chain: A1 → A2 → A3, stored A1 → adopts A3.
  - `maybe_sync_session_id` adopt path writes session + history.
  - `maybe_sync_session_id` ambiguous path leaves session alone.
  - `adopt_candidate_confirmed` flags `ambiguous: true` + `reason: "user_confirmed"` in the audit log.

## Follow-ups (out of scope)

- Live watcher for running sessions (deferred, same as #35).
- GUI dialog for the ambiguous path (currently falls through to the
  session config modal's manual-edit flow, which already logs).

## Relationship to #35

Supersedes #35. PR #35's branch is off an older main and deletes work
that has since landed, so this is a fresh branch off current main.
Keeps the audit log format (three event types intact), the sidebar
"Compactions (N)" pill, the history modal, and the `manual_edit` path
in `update_session_fields`. Rewrote the attribution core.

Closes #35 on merge.