### PR TITLE
feat: session metadata — role + provenance fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ defaults:
 
 | File | Location | Purpose |
 |------|----------|---------|
-| `.twapp-session.json` | Working dir | Session metadata, provider handles, fork ancestry |
+| `.twapp-session.json` | Working dir | Session metadata, provider handles, fork ancestry, role + provenance |
 | `.twapp-notes-{name}.json` | Working dir | Session notes |
 | `.twapp-prompts-{name}.json` | Working dir | Project-scoped quick prompts |
 | `.twapp-ticket.json` | Working dir | Linked ticket metadata |

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -10,7 +10,7 @@ The long-running orchestration loop that wraps around many agent launches.
 
 This skill teaches a Claude instance how to act as a **coordinator** — managing the lifecycle of two or more twapp-hosted worker agents, reviewing their work, merging their PRs, and keeping a shared mailbox tidy.
 
-For launching a single agent, use the [`spawn-agent`](../spawn-agent/SKILL.md) skill (coming in a related PR if not yet present). This skill assumes you already know how to spawn one agent; it covers what to do when you have many.
+For launching a single agent, use the [`spawn-agent`](../spawn-agent/SKILL.md) skill. This skill assumes you already know how to spawn one agent; it covers what to do when you have many.
 
 ## 1. When to use
 
@@ -54,7 +54,11 @@ offboard shape, hard rules.>
 sync via mailbox before touching shared files.>
 
 ## Worktree
-<Copy-paste `git worktree add` block + `.claude/settings.local.json` seed.>
+<Copy-paste `git worktree add` block + `.claude/settings.local.json` seed +
+the `twapp work --name <handle> --role <role> --from-file <briefing>` command
+the coordinator will run to spawn this worker. `--role` is the §13 archetype
+for this worker; `--from-file` auto-tags the session as agent-spawned so UI
+and `twapp sessions` can distinguish it from human-driven sessions.>
 
 ## Domain facts (if units / money / safety are involved)
 <Explicit statements of the domain model the worker must internalize before
@@ -249,8 +253,8 @@ The worker reads it on the next poll, archives, and stops. If the worker's `/loo
 ### Coordinator cleanup post-offboard
 
 ```
-twapp stop --name <handle>                 # graceful host shutdown (coming in a related PR)
-kill -TERM $(pgrep -f "twapp --name <handle>")   # fallback today
+twapp stop --name <handle>                 # graceful host shutdown
+twapp stop --name <handle> --force         # SIGKILL fallback if SIGTERM doesn't land
 git worktree remove <path>                 # optional, keeps repo lean
 ```
 
@@ -368,10 +372,17 @@ Each briefing follows §2. Worker A owns `src/parser.ts`; worker B owns `src/ren
 
 ### 2. Coordinator spawns both workers
 
-Using the `spawn-agent` skill's file-reference pattern (see that skill for the full command), one call per worker. Then:
+Using the `spawn-agent` skill's file-reference pattern, one call per worker. Tag each with its §13 role so `twapp sessions` and later UI can distinguish implementer workers from the coordinator / reviewer:
 
 ```
-twapp sessions                                   # both instances appear
+twapp work --name worker-a --role implementer --from-file /tmp/collab/briefings/worker-a.md
+twapp work --name worker-b --role implementer --from-file /tmp/collab/briefings/worker-b.md
+```
+
+`--from-file` auto-sets `provenance=spawned` — no need to pass `--spawned` alongside it. Then:
+
+```
+twapp sessions                                   # both instances appear, role column shows [impl] spawned
 ls /tmp/collab/mailbox/inbox/ | grep -E "worker-a|worker-b"
 ```
 
@@ -409,13 +420,13 @@ gh pr merge <N> --merge --delete-branch
 Each worker posts its offboard message (§7a) and archives its read mail. The coordinator acknowledges in the mailbox, then:
 
 ```
-kill -TERM $(pgrep -f "twapp --name worker-a")
-kill -TERM $(pgrep -f "twapp --name worker-b")
+twapp stop --name worker-a
+twapp stop --name worker-b
 git worktree remove /path/to/worker-a-worktree
 git worktree remove /path/to/worker-b-worktree
 ```
 
-(When `twapp stop --name <handle>` lands in a related PR, prefer it over `kill -TERM`.)
+`twapp stop` SIGTERMs the host and the child Claude; add `--force` to escalate to SIGKILL if the host didn't exit within ~3s.
 
 ### 7. Coordinator stays alive
 

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -26,13 +26,13 @@ Inline prompts in `--run` are shell-fragile. A long prompt with curly quotes, `-
 
 **Rule: write the briefing to a markdown file first, then reference it.**
 
-Preferred (once the `--from-file` flag ships — see [Coming soon](#coming-soon)):
+Preferred:
 
 ```bash
 twapp work --name my-agent --from-file /absolute/path/to/briefing.md
 ```
 
-Manual equivalent that works on any current twapp version:
+Manual equivalent on a twapp build that predates `--from-file`:
 
 ```bash
 twapp work --name my-agent \
@@ -44,6 +44,34 @@ Notes:
 - Use an **absolute** path to the briefing. A relative path breaks the moment you combine it with `--cwd` or `cd`.
 - The `Read <path> and execute.` wrapper is deliberately short — every character is literal text the shell must carry intact to Claude. Keep what's in the markdown file.
 - Treat the briefing file as the contract. Put acceptance criteria, protocol, and a handle name in it. Don't try to squeeze those into `--run`.
+
+## Role + provenance
+
+Tag each spawned session with its **role** and mark it as **agent-spawned** so later UI, dashboards, and sessions-list output can distinguish workers from the human-driven session you're typing into.
+
+```bash
+twapp work --name my-agent \
+  --role implementer \
+  --from-file /absolute/path/to/briefing.md
+```
+
+What each flag does:
+
+- **`--role <role>`** — a free-form string stored in `.twapp-session.json`. Use the archetype names from `skills/agent-coordinator/SKILL.md §12` (e.g. `coordinator`, `implementer`, `reviewer`, `auditor`, `log-watcher`, `architect`, `qa`, `area-owner`, `designer`). Empty string is rejected. Passing an unknown token is fine — validation lives in the UI layer, not the CLI.
+- **`--from-file`** automatically implies `provenance=spawned` — a human caller would be typing `twapp work` directly, so if a briefing file is involved, it's almost always an agent launch. No need to pass `--spawned` alongside it.
+- **`--spawned`** — the explicit form; use it when spawning without `--from-file` (e.g. a `--run` spawn of a one-shot helper).
+- **`--provenance <user|spawned>`** — escape hatch. Wins over `--spawned` and over the `--from-file` auto-default. Pass `--provenance user` to mark an otherwise-spawned session as user-initiated.
+
+The role shows up in `twapp sessions` output as a bracketed 4-char tag plus a `spawned` marker when relevant:
+
+```
+Name              Ticket       Session ID        Last Active            Role              Directory
+my-agent          -            abc123def456...   2026-04-20 22:00:00    [impl] spawned    /path/to/worktree
+```
+
+Sessions created without `--role` / `--spawned` simply show `-` in that column, so pre-existing workflows aren't visually disturbed.
+
+Include the role in your briefing so the agent knows what archetype it's operating as — it influences tone, scope, and which skills it loads.
 
 ## Worktree permission pre-approval
 
@@ -117,14 +145,12 @@ If both look healthy but no hello lands within 2 min, assume the agent is blocke
 
 ## Shutdown
 
-Once `twapp stop` ships (see [Coming soon](#coming-soon)):
-
 ```bash
 twapp stop --name my-agent              # graceful
 twapp stop --name my-agent --force      # SIGKILL fallback
 ```
 
-Manual equivalent that works on any current twapp version:
+Manual equivalent on a twapp build that predates `twapp stop`:
 
 ```bash
 kill -TERM $(pgrep -f 'twapp --name my-agent')
@@ -172,10 +198,11 @@ cat > ../example-repo_my-feature-fix/.claude/settings.local.json <<'EOF'
 {"permissions":{"defaultMode":"bypassPermissions","allow":["Bash(*)","Write(**)","Edit(**)","Read(**)"]}}
 EOF
 
-# 4. Spawn.
+# 4. Spawn. --from-file auto-sets provenance=spawned; --role tags it as an implementer.
 twapp work --name my-feature-fix \
   --cwd /path/to/example-repo_my-feature-fix \
-  --run "claude --dangerously-skip-permissions 'Read /tmp/briefings/my-feature-fix.md and execute.'"
+  --role implementer \
+  --from-file /tmp/briefings/my-feature-fix.md
 
 # 5. Verify.
 twapp sessions | grep my-feature-fix
@@ -216,10 +243,11 @@ cat > "$WORKDIR/.claude/settings.local.json" <<'EOF'
 {"permissions":{"defaultMode":"bypassPermissions","allow":["Bash(*)","Write(**)","Read(**)"]}}
 EOF
 
-# 3. Spawn.
+# 3. Spawn with a reviewer role.
 twapp work --name my-reviewer \
   --cwd "$WORKDIR" \
-  --run "claude --dangerously-skip-permissions 'Read /tmp/briefings/my-reviewer.md and execute.'"
+  --role reviewer \
+  --from-file /tmp/briefings/my-reviewer.md
 
 # 4. Verify liveness.
 twapp sessions | grep my-reviewer
@@ -230,12 +258,3 @@ kill -TERM "$(pgrep -f 'twapp --name my-reviewer')"
 ```
 
 Replace `my-*` / `example-*` with your own names. Neither example assumes a particular project, language, or toolchain.
-
-## Coming soon
-
-Two ergonomic improvements are tracked in a sibling PR on this repo:
-
-- **`twapp stop --name <name>`** — graceful shutdown, with `--force` as SIGKILL fallback. Replaces the `kill -TERM $(pgrep ...)` dance above.
-- **`twapp work --from-file <path>`** — resolves `<path>` to absolute, verifies it exists before spawn, and wraps it in `Read <path> and execute.` for you. Replaces the hand-rolled `--run "claude --dangerously-skip-permissions 'Read ... and execute.'"`.
-
-Once those land, prefer the flagged forms shown at the top of each section. Until then, the manual equivalents work on any current twapp build.

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -43,6 +43,19 @@ pub enum Commands {
         /// Use Chrome instead of Claude desktop
         #[arg(long)]
         chrome: bool,
+        /// Set the role archetype for this session (e.g., coordinator,
+        /// implementer, reviewer). Stored in .twapp-session.json for later UI tagging.
+        #[arg(long)]
+        role: Option<String>,
+        /// Mark this session as agent-spawned (not user-initiated).
+        /// Use when launching this session from another twapp session
+        /// programmatically (e.g., via --from-file).
+        #[arg(long)]
+        spawned: bool,
+        /// Explicit provenance override ("user" or "spawned"). Wins over
+        /// --spawned and over the implicit default from --from-file.
+        #[arg(long)]
+        provenance: Option<String>,
     },
     /// Stop a running session by name (SIGTERM claude child + twapp host).
     ///
@@ -301,7 +314,22 @@ pub fn run(cmd: Commands) -> i32 {
             session_id: fork_session_id,
             claude_cwd,
             chrome,
-        } => cmd_work(ticket, name, run, from_file, github, fork_session_id, claude_cwd, chrome),
+            role,
+            spawned,
+            provenance,
+        } => cmd_work(
+            ticket,
+            name,
+            run,
+            from_file,
+            github,
+            fork_session_id,
+            claude_cwd,
+            chrome,
+            role,
+            spawned,
+            provenance,
+        ),
         Commands::Stop { name, force } => stop::cmd_stop(&name, force),
         Commands::Resume { fork } => cmd_resume(fork),
         Commands::Sessions { path } => cmd_sessions(path),
@@ -466,6 +494,8 @@ pub fn create_session_core(
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
     chrome: bool,
+    role: Option<String>,
+    provenance: Option<String>,
 ) -> Result<SessionCreationResult, String> {
     if ticket_id.is_none() && session_name.is_none() {
         return Err("Provide a ticket or session name".to_string());
@@ -581,6 +611,8 @@ pub fn create_session_core(
         imported_from: None,
         use_chrome: if chrome { Some(true) } else { None },
         override_terminal_theme: None,
+        role,
+        provenance,
     };
     session::write_session(&work_dir, &session_data)?;
 
@@ -673,6 +705,9 @@ fn cmd_work(
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
     chrome: bool,
+    role: Option<String>,
+    spawned: bool,
+    provenance_arg: Option<String>,
 ) -> i32 {
     if ticket_id.is_none() && session_name.is_none() {
         eprintln!("Error: Provide a ticket or --name for the session.");
@@ -685,6 +720,22 @@ fn cmd_work(
         eprintln!("Error: --run and --from-file are mutually exclusive.");
         return 1;
     }
+
+    let role = match validate_role(role) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let provenance = match resolve_provenance(provenance_arg, spawned, from_file.is_some()) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
 
     // Feature: --from-file. Resolve to an absolute path and verify the file
     // exists BEFORE launching any terminal, then wrap as a claude prompt.
@@ -727,7 +778,17 @@ fn cmd_work(
         return 1;
     }
 
-    let result = match create_session_core(ticket_id, session_name, effective_run, github, fork_session_id, claude_cwd_arg, chrome) {
+    let result = match create_session_core(
+        ticket_id,
+        session_name,
+        effective_run,
+        github,
+        fork_session_id,
+        claude_cwd_arg,
+        chrome,
+        role,
+        Some(provenance),
+    ) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {}", e);
@@ -847,6 +908,8 @@ fn cmd_resume(fork: bool) -> i32 {
             imported_from: None,
             use_chrome: if chrome { Some(true) } else { None },
             override_terminal_theme: None,
+            role: session_data.role.clone(),
+            provenance: session_data.provenance.clone(),
         };
         session_id = new_id;
         if let Err(e) = session::write_session(&work_dir, &session_data) {
@@ -955,10 +1018,10 @@ fn cmd_sessions(path: Option<String>) -> i32 {
     }
 
     println!(
-        "{:<25} {:<12} {:<16} {:<20} {}",
-        "Name", "Ticket", "Session ID", "Last Active", "Directory"
+        "{:<25} {:<12} {:<16} {:<20} {:<16} {}",
+        "Name", "Ticket", "Session ID", "Last Active", "Role", "Directory"
     );
-    println!("{}", "-".repeat(100));
+    println!("{}", "-".repeat(116));
     for (s, dir) in &sessions {
         let name = &s.name[..s.name.len().min(24)];
         let ticket = s.ticket_key.as_deref().unwrap_or("-");
@@ -970,16 +1033,42 @@ fn cmd_sessions(path: Option<String>) -> i32 {
             .or(Some(s.created.as_str()))
             .unwrap_or("?");
         let last = last[..last.len().min(19)].replace('T', " ");
+        let role_cell = format_role_cell(s.role.as_deref(), s.provenance.as_deref());
         println!(
-            "{:<25} {:<12} {:<16} {:<20} {}",
+            "{:<25} {:<12} {:<16} {:<20} {:<16} {}",
             name,
             ticket,
             sid,
             last,
+            role_cell,
             dir.display()
         );
     }
     0
+}
+
+/// Format the role + provenance cell for `twapp sessions` output.
+/// Returns e.g. `[impl] spawned`, `[coor]`, `spawned`, or `-`.
+/// Role is shown as the first 4 chars in brackets; `spawned` only shown for
+/// provenance == "spawned" (user-provenance is the common case, so elided).
+pub fn format_role_cell(role: Option<&str>, provenance: Option<&str>) -> String {
+    let role_part = role
+        .map(|r| r.trim())
+        .filter(|r| !r.is_empty())
+        .map(|r| {
+            let short: String = r.chars().take(4).collect();
+            format!("[{}]", short)
+        });
+    let prov_part = match provenance {
+        Some("spawned") => Some("spawned"),
+        _ => None,
+    };
+    match (role_part, prov_part) {
+        (Some(r), Some(p)) => format!("{} {}", r, p),
+        (Some(r), None) => r,
+        (None, Some(p)) => p.to_string(),
+        (None, None) => "-".to_string(),
+    }
 }
 
 fn cmd_ticket_link(ticket_key: &str, dir: Option<&str>, github: bool) -> i32 {
@@ -1686,6 +1775,44 @@ fn cmd_dev_reload(pid: Option<u32>, cwd: &str, gui_src: Option<&str>) -> i32 {
     }
 }
 
+/// Normalize a `--role` argument: reject empty/whitespace-only, otherwise pass through.
+pub fn validate_role(role: Option<String>) -> Result<Option<String>, String> {
+    match role {
+        Some(r) if r.trim().is_empty() => Err("--role cannot be empty.".to_string()),
+        other => Ok(other),
+    }
+}
+
+/// Decide the provenance value for a new session given the CLI flags.
+///
+/// Precedence: explicit `--provenance` wins; then `--spawned` → `"spawned"`;
+/// then `--from-file` implies `"spawned"`; otherwise `"user"`.
+/// Errors if `--provenance` and `--spawned` are both set with disagreeing values.
+pub fn resolve_provenance(
+    provenance_arg: Option<String>,
+    spawned_flag: bool,
+    has_from_file: bool,
+) -> Result<String, String> {
+    if let Some(p) = provenance_arg {
+        let trimmed = p.trim();
+        if trimmed.is_empty() {
+            return Err("--provenance cannot be empty.".to_string());
+        }
+        if spawned_flag && trimmed != "spawned" {
+            return Err(format!(
+                "--spawned and --provenance {} disagree; pass only one.",
+                trimmed
+            ));
+        }
+        return Ok(trimmed.to_string());
+    }
+    if spawned_flag || has_from_file {
+        Ok("spawned".to_string())
+    } else {
+        Ok("user".to_string())
+    }
+}
+
 /// Translate `--from-file <path>` into the equivalent `--run` command.
 /// Resolves `<path>` to an absolute path so later `cd`s don't break it,
 /// and returns an error if the file does not exist.
@@ -1851,5 +1978,115 @@ mod from_file_tests {
             cmd
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+#[cfg(test)]
+mod provenance_tests {
+    use super::{format_role_cell, resolve_provenance, validate_role};
+
+    #[test]
+    fn empty_role_errors() {
+        let err = validate_role(Some("".to_string())).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn whitespace_role_errors() {
+        let err = validate_role(Some("   ".to_string())).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn populated_role_passes_through_verbatim() {
+        assert_eq!(
+            validate_role(Some("coordinator".to_string())).unwrap(),
+            Some("coordinator".to_string())
+        );
+    }
+
+    #[test]
+    fn missing_role_is_none() {
+        assert_eq!(validate_role(None).unwrap(), None);
+    }
+
+    #[test]
+    fn direct_work_defaults_to_user() {
+        assert_eq!(resolve_provenance(None, false, false).unwrap(), "user");
+    }
+
+    #[test]
+    fn spawned_flag_sets_spawned() {
+        assert_eq!(resolve_provenance(None, true, false).unwrap(), "spawned");
+    }
+
+    #[test]
+    fn from_file_implies_spawned_provenance() {
+        assert_eq!(resolve_provenance(None, false, true).unwrap(), "spawned");
+    }
+
+    #[test]
+    fn explicit_provenance_user_overrides_from_file_default() {
+        assert_eq!(
+            resolve_provenance(Some("user".to_string()), false, true).unwrap(),
+            "user"
+        );
+    }
+
+    #[test]
+    fn explicit_provenance_verbatim_passes_through() {
+        assert_eq!(
+            resolve_provenance(Some("audit".to_string()), false, false).unwrap(),
+            "audit"
+        );
+    }
+
+    #[test]
+    fn empty_provenance_errors() {
+        let err = resolve_provenance(Some("  ".to_string()), false, false).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn provenance_and_spawned_disagreement_errors() {
+        let err = resolve_provenance(Some("user".to_string()), true, false).unwrap_err();
+        assert!(err.contains("disagree"), "got: {}", err);
+    }
+
+    #[test]
+    fn provenance_spawned_plus_spawned_flag_is_fine() {
+        assert_eq!(
+            resolve_provenance(Some("spawned".to_string()), true, false).unwrap(),
+            "spawned"
+        );
+    }
+
+    #[test]
+    fn role_cell_both_set() {
+        assert_eq!(
+            format_role_cell(Some("implementer"), Some("spawned")),
+            "[impl] spawned"
+        );
+    }
+
+    #[test]
+    fn role_cell_short_role_preserved() {
+        assert_eq!(format_role_cell(Some("qa"), Some("spawned")), "[qa] spawned");
+    }
+
+    #[test]
+    fn role_cell_role_only() {
+        assert_eq!(format_role_cell(Some("coordinator"), Some("user")), "[coor]");
+    }
+
+    #[test]
+    fn role_cell_none_shown_as_dash() {
+        assert_eq!(format_role_cell(None, None), "-");
+        assert_eq!(format_role_cell(None, Some("user")), "-");
+    }
+
+    #[test]
+    fn role_cell_provenance_only() {
+        assert_eq!(format_role_cell(None, Some("spawned")), "spawned");
     }
 }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1788,6 +1788,13 @@ pub fn validate_role(role: Option<String>) -> Result<Option<String>, String> {
 /// Precedence: explicit `--provenance` wins; then `--spawned` → `"spawned"`;
 /// then `--from-file` implies `"spawned"`; otherwise `"user"`.
 /// Errors if `--provenance` and `--spawned` are both set with disagreeing values.
+///
+/// Accepts any non-empty string for `--provenance` (not allow-listed). The
+/// current consumers (`format_role_cell`, UI) treat the two known values
+/// `"user"` and `"spawned"` specially and render anything else as
+/// not-spawned. Keeping this free-form leaves room for later provenance
+/// kinds (e.g. `"imported"`) without a schema bump; typos like
+/// `--provenance spawnd` will ship verbatim and render as not-spawned.
 pub fn resolve_provenance(
     provenance_arg: Option<String>,
     spawned_flag: bool,

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -54,6 +54,16 @@ pub struct SessionData {
     pub use_chrome: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub override_terminal_theme: Option<bool>,
+    /// Role archetype for this session (e.g. "coordinator", "implementer", "reviewer").
+    /// Free-form — not enum-enforced at this layer; UI does any validation.
+    /// `None` means never set; treat as generic worker in UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    /// How the session was created: `"user"` (human ran `twapp work`) or
+    /// `"spawned"` (another twapp session invoked us, e.g. via `--from-file`).
+    /// `None` on legacy session files predating this field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
 }
 
 impl SessionData {
@@ -415,6 +425,99 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn base_session() -> SessionData {
+        SessionData {
+            session_id: "claude-123".to_string(),
+            name: "demo".to_string(),
+            color: String::new(),
+            ticket_key: None,
+            claude_cwd: "/tmp/demo".to_string(),
+            created: "2026-01-01T00:00:00Z".to_string(),
+            last_resumed: None,
+            provider: Some(AgentProvider::Claude),
+            codex_session_id: None,
+            codex_cwd: None,
+            forked_from: None,
+            imported: None,
+            imported_from: None,
+            use_chrome: None,
+            override_terminal_theme: None,
+            role: None,
+            provenance: None,
+        }
+    }
+
+    #[test]
+    fn session_serde_roundtrip_with_role_and_provenance() {
+        let mut data = base_session();
+        data.role = Some("implementer".to_string());
+        data.provenance = Some("spawned".to_string());
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(json.contains("\"role\":\"implementer\""));
+        assert!(json.contains("\"provenance\":\"spawned\""));
+        let back: SessionData = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.role.as_deref(), Some("implementer"));
+        assert_eq!(back.provenance.as_deref(), Some("spawned"));
+    }
+
+    #[test]
+    fn session_serde_roundtrip_omits_absent_role_and_provenance() {
+        let data = base_session();
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(
+            !json.contains("\"role\""),
+            "role should be skipped when None: {}",
+            json
+        );
+        assert!(
+            !json.contains("\"provenance\""),
+            "provenance should be skipped when None: {}",
+            json
+        );
+        let back: SessionData = serde_json::from_str(&json).unwrap();
+        assert!(back.role.is_none());
+        assert!(back.provenance.is_none());
+    }
+
+    #[test]
+    fn write_then_list_sessions_preserves_role_and_provenance() {
+        let root = std::env::temp_dir().join(format!("twapp-sess-role-{}", uuid::Uuid::new_v4()));
+        let session_dir = root.join("worker");
+        fs::create_dir_all(&session_dir).unwrap();
+
+        let mut data = base_session();
+        data.name = "worker".to_string();
+        data.role = Some("coordinator".to_string());
+        data.provenance = Some("spawned".to_string());
+        write_session(&session_dir, &data).unwrap();
+
+        let listed = list_sessions(&root);
+        assert_eq!(listed.len(), 1);
+        let (loaded, _) = &listed[0];
+        assert_eq!(loaded.role.as_deref(), Some("coordinator"));
+        assert_eq!(loaded.provenance.as_deref(), Some("spawned"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn legacy_session_file_deserializes() {
+        // JSON from a twapp version predating role/provenance fields.
+        let legacy = r#"{
+            "session_id": "old-abc",
+            "name": "legacy",
+            "color": "",
+            "ticket_key": null,
+            "claude_cwd": "/tmp/legacy",
+            "created": "2025-12-01T00:00:00Z",
+            "last_resumed": null
+        }"#;
+        let data: SessionData = serde_json::from_str(legacy).unwrap();
+        assert_eq!(data.name, "legacy");
+        assert!(data.role.is_none());
+        assert!(data.provenance.is_none());
+    }
+
     #[test]
     fn display_session_id_prefers_requested_provider() {
         let data = SessionData {
@@ -433,6 +536,8 @@ mod tests {
             imported_from: None,
             use_chrome: None,
             override_terminal_theme: None,
+            role: None,
+            provenance: None,
         };
 
         assert_eq!(
@@ -463,6 +568,8 @@ mod tests {
             imported_from: None,
             use_chrome: None,
             override_terminal_theme: None,
+            role: None,
+            provenance: None,
         };
 
         assert!(data.needs_migration(AgentProvider::Codex));

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -9,6 +9,16 @@ use crate::cli::session::{
     shell_escape_single, AgentProvider, SessionData,
 };
 
+/// Read `(role, provenance)` from the parent session file so a GUI fork can
+/// inherit them. Returns `(None, None)` if the file is missing or unreadable —
+/// a fork off an unknown session is treated as a plain session.
+pub fn read_fork_inherited_metadata(parent_cwd: &str) -> (Option<String>, Option<String>) {
+    crate::cli::session::read_session(std::path::Path::new(parent_cwd))
+        .ok()
+        .map(|s| (s.role, s.provenance))
+        .unwrap_or((None, None))
+}
+
 pub fn sanitize_instance_name(name: &str) -> String {
     let safe: String = name
         .chars()
@@ -1384,6 +1394,10 @@ pub async fn fork_session(
     let provider = config.provider;
     let original_cwd = config.cwd.clone().unwrap_or_else(|| ".".to_string());
     let mut work_dir = original_cwd.clone();
+    // Fork inherits role + provenance from the parent session so CLI `twapp resume --fork`
+    // and the GUI fork button agree. A fork is a derivative of the parent's context, not
+    // a fresh launch — resetting these would drop the agent tag on every fork.
+    let (parent_role, parent_provenance) = read_fork_inherited_metadata(&original_cwd);
     let mut window_name = std::path::Path::new(&work_dir)
         .file_name()
         .and_then(|n| n.to_str())
@@ -1492,8 +1506,8 @@ pub async fn fork_session(
                 imported_from: None,
                 use_chrome: None,
                 override_terminal_theme: None,
-                role: None,
-                provenance: None,
+                role: parent_role.clone(),
+                provenance: parent_provenance.clone(),
             },
         )
     } else {
@@ -1536,8 +1550,8 @@ pub async fn fork_session(
                 imported_from: None,
                 use_chrome: None,
                 override_terminal_theme: None,
-                role: None,
-                provenance: None,
+                role: parent_role,
+                provenance: parent_provenance,
             },
         )
     };
@@ -1579,4 +1593,72 @@ pub async fn fork_session(
     crate::cli::app_bundle::launch_gui(&instance_app, &app_args)?;
 
     Ok(window_name)
+}
+
+#[cfg(test)]
+mod fork_inheritance_tests {
+    use super::read_fork_inherited_metadata;
+    use std::fs;
+
+    #[test]
+    fn inherits_role_and_provenance_from_parent_session_file() {
+        let dir = std::env::temp_dir().join(format!("twapp-fork-inherit-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(".twapp-session.json"),
+            serde_json::json!({
+                "session_id": "abc",
+                "name": "parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": dir.to_string_lossy(),
+                "created": "2026-01-01T00:00:00Z",
+                "last_resumed": null,
+                "role": "implementer",
+                "provenance": "spawned",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        assert_eq!(role.as_deref(), Some("implementer"));
+        assert_eq!(prov.as_deref(), Some("spawned"));
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_parent_returns_none_pair() {
+        let dir = std::env::temp_dir().join(format!("twapp-fork-missing-{}", uuid::Uuid::new_v4()));
+        // Intentionally do not create the directory; fork against a path with no session file.
+        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        assert_eq!(role, None);
+        assert_eq!(prov, None);
+    }
+
+    #[test]
+    fn legacy_parent_without_fields_returns_none_pair() {
+        let dir = std::env::temp_dir().join(format!("twapp-fork-legacy-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(".twapp-session.json"),
+            r#"{
+                "session_id": "old",
+                "name": "legacy-parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": "/tmp/legacy",
+                "created": "2025-12-01T00:00:00Z",
+                "last_resumed": null
+            }"#,
+        )
+        .unwrap();
+
+        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        assert_eq!(role, None);
+        assert_eq!(prov, None);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
 }

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -585,7 +585,9 @@ pub async fn create_and_launch_session(
     github: bool,
     chrome: bool,
 ) -> Result<(), String> {
-    let result = crate::cli::create_session_core(ticket, name, None, github, None, None, chrome)?;
+    let result = crate::cli::create_session_core(
+        ticket, name, None, github, None, None, chrome, None, Some("user".to_string()),
+    )?;
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&result.name, &result.color)?;
     crate::cli::app_bundle::launch_gui(&instance_app, &result.app_args)?;
@@ -1355,6 +1357,8 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
             imported_from: Some(original_cwd),
             use_chrome: None,
             override_terminal_theme: None,
+            role: None,
+            provenance: None,
         };
         crate::cli::session::write_session(&session_dir, &session_data)?;
 
@@ -1488,6 +1492,8 @@ pub async fn fork_session(
                 imported_from: None,
                 use_chrome: None,
                 override_terminal_theme: None,
+                role: None,
+                provenance: None,
             },
         )
     } else {
@@ -1530,6 +1536,8 @@ pub async fn fork_session(
                 imported_from: None,
                 use_chrome: None,
                 override_terminal_theme: None,
+                role: None,
+                provenance: None,
             },
         )
     };


### PR DESCRIPTION
## Summary
- Adds `role` and `provenance` fields to `.twapp-session.json` (both `Option<String>`, serde-default, skip-serializing-if-none, so legacy files load unchanged).
- `twapp work` gains `--role <ROLE>`, `--spawned`, and `--provenance <VAL>`. Empty `--role` / `--provenance` error out. Precedence: `--provenance` > `--spawned` > `--from-file` implies spawned > default `"user"`.
- `twapp sessions` output now includes a Role column: `[impl] spawned` format (4-char role tag, `spawned` shown only for spawned-provenance). `-` when neither set.
- GUI `create_and_launch_session` stamps `provenance="user"` on GUI-initiated sessions; the fork path inherits role/provenance from the parent.

## Design notes
- Metadata plumbing only — no React/Tauri UI changes (that's `twapp-ui-role-badge`, a later PR).
- `role` is free-form string at this layer; the UI will validate against the archetype list.
- `--from-file` auto-implies `provenance="spawned"` so agent-launch scripts don't need to pass `--spawned` on every invocation. `--provenance user` overrides for the edge case.

## Test plan
- [x] `cargo test --lib` — all 60 unit tests pass, including 17 new ones.
- [x] `cargo check` clean.
- [x] `twapp work --help` shows the new flags with human-readable descriptions.
- [ ] Reviewer: verify legacy `.twapp-session.json` (without role/provenance) still loads and round-trips without spontaneously gaining fields.
- [ ] Reviewer: verify sessions list layout still readable on narrow terminals (added ~16 chars).

## Coordination
- Coordinates with `twapp-coordinator-launch-cli` (parallel): that PR consumes this `--role` flag. If they land first, they'll add a follow-up; if this lands first, they adopt directly.

Refs briefing: `twapp-session-role-metadata`.