### PR TITLE
docs: unify multi-agent sections under "co-lab" umbrella

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,42 +349,197 @@ The forked session gets a new twapp-managed session and carries Claude context f
 
 > Current limitation: unmanaged external import is Claude-only. Codex support currently targets twapp-managed sessions and provider switching inside twapp.
 
-## Messaging between sessions
+## co-lab: multi-agent coordination on twapp
+
+If you only ever run one terminal at a time, `twapp work` is all you need
+— the rest of this section is optional. Once you start spawning a second
+Claude (or Codex) instance to help the first — implementer + reviewer,
+coordinator + workers, audit + research — twapp grows a small set of
+conventions that keep the pieces straight. Collectively, those
+conventions are **co-lab**.
+
+co-lab is not a separate product and it is not a new CLI namespace. There
+is no `twapp colab <verb>`. It's the same `twapp work`, `twapp stop`, and
+`twapp msg` verbs used with a handful of shared patterns: a filesystem
+mailbox for messaging, briefings for prepared worker prompts, role tags
+on sessions, and a coordinator session that supervises the fleet.
+
+If you're reading top-to-bottom for the first time and single-session use
+is all you need, skip ahead to the [CLI Reference](#cli-reference) and
+come back if you ever want to coordinate multiple agents. Otherwise, the
+subsections below walk through each piece.
+
+### How co-lab works
+
+A typical co-lab flow:
+
+1. A **coordinator** session writes a briefing file for each worker — a
+   markdown file that spells out the goal, the protocol, and the
+   out-of-scope carve-outs.
+2. The coordinator spawns each worker with `twapp work --from-file
+   <briefing>`. Every worker runs in its own twapp session (own window,
+   own working directory or git worktree).
+3. Workers and the coordinator talk through a shared **mailbox** — a
+   plain directory on disk that every participant can `ls`, `grep`, and
+   `mv`. `twapp msg send`, `twapp msg broadcast`, and `twapp msg fetch`
+   are the CLI entry points.
+4. Each session carries a **role tag** (`coordinator`, `implementer`,
+   `reviewer`, etc.) so `twapp sessions` and the launcher can tell a
+   worker from a supervisor at a glance.
+5. When a worker finishes, it posts an offboard message and the
+   coordinator cleans up the twapp host and worktree.
+
+```
+┌──────────────┐        mailbox/inbox/          ┌────────────┐
+│ coordinator  │── briefings/worker-a.md ────▶│  worker-a  │
+│              │◀── 20260420T1501Z-hello ─────│            │
+│              │── 20260420T1530Z-rebase ────▶│            │
+│              │                                 └────────────┘
+│              │── briefings/worker-b.md ────▶┌────────────┐
+│              │                                 │  worker-b  │
+└──────────────┘                                 └────────────┘
+```
+
+The rest of this section covers each piece of that flow.
+
+### Spawning a worker agent
+
+twapp works well as a terminal wrapper for *interactive* sessions, but
+it's also handy for spawning long-running agent or worker instances —
+kicking off a Claude instance that reads a briefing file and runs to
+completion on its own.
+
+```bash
+# 1. Spawn a worker that reads a briefing file and executes it.
+twapp work --name "worker-a" \
+  --from-file /path/to/briefings/worker-a.md
+
+# 2. Later, gracefully shut it down when the work is done.
+twapp stop --name "worker-a"
+
+# 3. If the graceful shutdown doesn't land, escalate to SIGKILL.
+twapp stop --name "worker-a" --force
+```
+
+See the [`spawn-agent`](skills/spawn-agent/SKILL.md) skill for the full
+playbook — briefing shape, worktree permission seeding,
+hello-within-2-min verification, and shutdown.
+
+#### `--from-file` vs `--run`
+
+`--run` works for short, simple commands, but shell quoting becomes
+fragile when the embedded prompt is long or contains
+Unicode/backticks/quotes. Prefer `--from-file` whenever the prompt is
+longer than ~100 characters or contains special characters: twapp
+resolves the path to an absolute path, verifies it exists *before*
+spawning the terminal, and wraps the prompt as
+`claude --dangerously-skip-permissions 'Read <abs-path> and execute.'`.
+
+This keeps the caller side simple — just write the prompt into a
+markdown file and point twapp at it. Nothing to escape.
+
+#### Pre-approving bypass permissions
+
+Agents spawned via `--from-file` typically want to run without permission
+prompts. Seed a per-worktree
+[`.claude/settings.local.json`](https://docs.anthropic.com/en/docs/claude-cli/settings)
+in the directory your worker will run in:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "allow": ["Bash(*)", "Write(**)", "Edit(**)", "Read(**)"]
+  }
+}
+```
+
+Adjust the allow list to fit your threat model. twapp itself doesn't
+touch this file — it's read by Claude on startup.
+
+#### Pre-flight checks
+
+`twapp work` fails fast (before spawning the terminal) when:
+
+- `--from-file <path>` points at a file that doesn't exist (exit **2**).
+- `--claude-cwd <dir>` points at a directory that doesn't exist (exit **3**).
+- `--run` starts with `cd <dir> && ...` and `<dir>` doesn't exist (exit **3**).
+
+Without these checks, the spawned terminal would appear to launch fine
+and then silently fail inside the new window — a painful debug loop when
+automating spawns.
+
+### Bootstrapping a coordinator
+
+> **Coming in [#44](https://github.com/piekstra/twapp/pull/44).** That
+> PR adds `twapp coordinator launch` and `twapp coordinator claim`,
+> which wrap the moves below into a one-liner and ship a bundled
+> bootstrap briefing pointing new coordinators at
+> [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md).
+
+A coordinator today is just a regular `twapp work` session opened in
+whatever directory holds your mailbox, with the
+[`agent-coordinator`](skills/agent-coordinator/SKILL.md) skill in scope.
+
+```bash
+# Start a coordinator session (pre-#44).
+export TWAPP_MAILBOX_DIR=$HOME/collab/mailbox
+mkdir -p "$TWAPP_MAILBOX_DIR/inbox" "$TWAPP_MAILBOX_DIR/archive"
+twapp work --name coordinator --cwd "$HOME/collab"
+```
+
+Once #44 lands:
+
+```bash
+twapp coordinator launch                       # uses a bundled bootstrap briefing
+twapp coordinator launch --briefing /path/to/bootstrap.md
+twapp coordinator launch --shared-dir ~/collab/mailbox
+twapp coordinator claim                        # flip an existing session's role in place
+```
+
+The bundled bootstrap briefing points the new coordinator at the
+`agent-coordinator` skill, the messaging design doc, and the mailbox
+protocol, so you don't have to hand-roll a prompt when you stand up a
+fleet. Override it with `--briefing <path>` when you want a
+project-specific bootstrap.
+
+### Messaging between sessions
 
 When you have more than one agent session working together — a spawned
-worker and its coordinator, a pair of implementers sharing a review queue,
-or a human driver coordinating several workers — a shared filesystem
-mailbox is a simple way to let them leave each other messages without
-leaving twapp.
+worker and its coordinator, a pair of implementers sharing a review
+queue, or a human driver coordinating several workers — a shared
+filesystem mailbox is a simple way to let them leave each other messages
+without leaving twapp.
 
 `twapp msg` is a thin wrapper over that convention: it drops
 fenced-frontmatter markdown files into a shared `inbox/` directory and
-reads them back. See [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md)
-for the full model. This release covers **PR-1** of that design — the
-CLI scaffolding for `send`, `broadcast`, and `fetch` against the current
-flat `inbox/` layout. Threading, directory split, cursors, priority
-lanes, presence, channels, and archive rotation all land in later PRs.
+reads them back. See
+[`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) for
+the full model. Today's CLI covers **PR-1** of that design — `send`,
+`broadcast`, and `fetch` against the current flat `inbox/` layout.
+Threading, directory split, cursors, priority lanes, presence, channels,
+and archive rotation all land in later PRs.
 
-### Configure the mailbox
+#### Configure the mailbox
 
 Set one of these (the first wins):
 
 ```bash
 # Preferred: point directly at the mailbox root.
-export TWAPP_MAILBOX_DIR="$HOME/my-team-mailbox"
+export TWAPP_MAILBOX_DIR="$HOME/collab/mailbox"
 
 # Alternative: point at a shared dir; the mailbox is <shared>/mailbox/.
-export TWAPP_SHARED_DIR="$HOME/my-team-shared"
+export TWAPP_SHARED_DIR="$HOME/collab"
 ```
 
 Messages land in `<mailbox>/inbox/<YYYYMMDDTHHMMSSZ>-<id6>.md`.
 
-### Send, broadcast, fetch
+#### Send, broadcast, fetch
 
 ```bash
 # Direct message — `<to>` is required and can be comma-separated.
 twapp msg send reviewer "PR-1 is up, ready to review"
-twapp msg send a,b --priority urgent --subject "build broke" "see CI 1234"
+twapp msg send worker-a,worker-b --priority urgent --subject "build broke" "see CI 1234"
 twapp msg send reviewer --cc coordinator,qa "heads up on scope change"
 
 # Replies inherit the parent's thread id and set in_reply_to.
@@ -408,7 +563,7 @@ If `--from` is not passed, the sender handle is taken from the current
 directory's `.twapp-session.json` `name`. Bodies may be passed as a
 positional argument or piped in on stdin.
 
-### Reading legacy (bare) files
+#### Reading legacy (bare) files
 
 `fetch` accepts both the new fenced-frontmatter shape and the older bare
 `from:` / `to:` / `re:` layout so inboxes don't need to be migrated
@@ -453,67 +608,71 @@ records `reclaimed_from: <previous>` for the audit trail. See
 for the full design (atomic-mkdir rationale, stale semantics, and
 what's out of scope).
 
-## Spawning agent instances
+### Roles and provenance
 
-twapp works well as a terminal wrapper for *interactive* sessions, but it's
-also handy for spawning long-running agent or worker instances — for example,
-kicking off a Claude instance that reads a briefing file and runs to
-completion on its own.
+> **Coming in [#43](https://github.com/piekstra/twapp/pull/43).** That PR
+> adds `role` and `provenance` fields to `.twapp-session.json`, plus
+> `--role <ROLE>`, `--spawned`, and `--provenance <VAL>` flags on
+> `twapp work`.
+
+Once #43 merges, every session carries two extra pieces of metadata:
+
+- **`role`** — a free-form string tag. Conventionally one of the
+  archetypes from
+  [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md):
+  `coordinator`, `implementer`, `reviewer`, `auditor`, `log-watcher`,
+  `architect`, `qa`, `area-owner`, `designer`.
+- **`provenance`** — where the session came from: `user` (you launched
+  it), `spawned` (another agent launched it), or a free-form override
+  for edge cases. `--from-file` implies `provenance=spawned` unless you
+  pass `--provenance user`.
 
 ```bash
-# 1. Spawn a worker that reads a briefing file and executes it.
-twapp work --name "my-worker" \
-  --from-file /path/to/my-briefing.md
+twapp work --name worker-a --role implementer \
+  --from-file /path/to/briefings/worker-a.md
+# --from-file implies provenance=spawned.
 
-# 2. Later, gracefully shut it down when the work is done.
-twapp stop --name "my-worker"
-
-# 3. If the graceful shutdown doesn't land, escalate to SIGKILL.
-twapp stop --name "my-worker" --force
+twapp work --name reviewer-standby --role reviewer --spawned
 ```
 
-### `--from-file` vs `--run`
+`twapp sessions` output gains a Role column (`[impl] spawned`) so
+workers and supervisors are visually distinct. Legacy
+`.twapp-session.json` files without these fields continue to load
+unchanged.
 
-`--run` works for short, simple commands, but shell quoting becomes fragile
-when the embedded prompt is long or contains Unicode/backticks/quotes. Prefer
-`--from-file` whenever the prompt is longer than ~100 characters or contains
-special characters: twapp resolves the path to an absolute path, verifies
-it exists *before* spawning the terminal, and wraps the prompt as
-`claude --dangerously-skip-permissions 'Read <abs-path> and execute.'`.
+### Model selection per agent
 
-This keeps the caller side simple — just write the prompt into a markdown
-file and point twapp at it. Nothing to escape.
+> **Planned.** A forthcoming PR (tracked as `twapp-model-selection` in
+> the coordination notes) will let you pick which Claude model backs a
+> spawned session — e.g. a coordinator on a stronger model, worker
+> implementers on a cheaper or faster one — without hand-editing the
+> spawned `claude` invocation.
 
-### Pre-approving bypass permissions
+Until that lands, per-agent model choice is governed by whatever default
+your Claude CLI is configured with; spawning a cheaper worker means
+adjusting the Claude config that the worker's cwd resolves to.
 
-Agents spawned via `--from-file` typically want to run without
-permission prompts. Seed a per-worktree
-[`.claude/settings.local.json`](https://docs.anthropic.com/en/docs/claude-cli/settings)
-in the directory your worker will run in:
+### Related skills
 
-```json
-{
-  "permissions": {
-    "defaultMode": "bypassPermissions",
-    "allow": ["Bash(*)", "Write(**)", "Edit(**)", "Read(**)"]
-  }
-}
-```
+- [`skills/spawn-agent/SKILL.md`](skills/spawn-agent/SKILL.md) — how a
+  Claude instance spawns another (file-reference prompt pattern,
+  worktree permission seeding, hello-within-2-min verification,
+  shutdown).
+- [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md)
+  — how to act as a coordinator across many workers (briefing shape,
+  mailbox protocol, self-merge gating, offboard cleanup, role
+  archetypes, question routing).
 
-Adjust the allow list to fit your threat model. twapp itself doesn't touch
-this file — it's read by Claude on startup.
+### Design docs
 
-### Pre-flight checks
-
-`twapp work` fails fast (before spawning the terminal) when:
-
-- `--from-file <path>` points at a file that doesn't exist (exit **2**).
-- `--claude-cwd <dir>` points at a directory that doesn't exist (exit **3**).
-- `--run` starts with `cd <dir> && ...` and `<dir>` doesn't exist (exit **3**).
-
-Without these checks, the spawned terminal would appear to launch fine and
-then silently fail inside the new window — a painful debug loop when
-automating spawns.
+- [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) —
+  the mailbox shape and addressing model behind `twapp msg`, plus the
+  migration path from the current flat `inbox/` layout to threads,
+  cursors, priority lanes, presence, and channels.
+- [`docs/designs/agent-aware-ui.md`](docs/designs/agent-aware-ui.md) —
+  proposed UI / dashboard surface once the messaging substrate is
+  load-bearing, with the constraint that single-session users see no
+  change.
 
 ## Model selection
 

--- a/README.md
+++ b/README.md
@@ -392,13 +392,15 @@ A typical co-lab flow:
 ```
 ┌──────────────┐        mailbox/inbox/          ┌────────────┐
 │ coordinator  │── briefings/worker-a.md ────▶│  worker-a  │
-│              │◀── 20260420T1501Z-hello ─────│            │
-│              │── 20260420T1530Z-rebase ────▶│            │
+│              │◀── <ts>-<id>-hello.md ───────│            │
+│              │── <ts>-<id>-rebase.md ──────▶│            │
 │              │                                 └────────────┘
 │              │── briefings/worker-b.md ────▶┌────────────┐
 │              │                                 │  worker-b  │
 └──────────────┘                                 └────────────┘
 ```
+
+> The `<ts>-<id>` placeholders stand in for the real `YYYYMMDDTHHMMSSZ-<id6>` filename shape described in the [Configure the mailbox](#configure-the-mailbox) subsection — the diagram elides timestamps to keep the boxes aligned.
 
 The rest of this section covers each piece of that flow.
 
@@ -619,9 +621,10 @@ Once #43 merges, every session carries two extra pieces of metadata:
 
 - **`role`** — a free-form string tag. Conventionally one of the
   archetypes from
-  [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md):
-  `coordinator`, `implementer`, `reviewer`, `auditor`, `log-watcher`,
-  `architect`, `qa`, `area-owner`, `designer`.
+  [`skills/agent-coordinator/SKILL.md` §13](skills/agent-coordinator/SKILL.md#13-role-archetypes)
+  (that file is the canonical list; the names here are a snapshot for
+  convenience): `coordinator`, `implementer`, `reviewer`, `auditor`,
+  `log-watcher`, `architect`, `qa`, `area-owner`, `designer`.
 - **`provenance`** — where the session came from: `user` (you launched
   it), `spawned` (another agent launched it), or a free-form override
   for edge cases. `--from-file` implies `provenance=spawned` unless you

--- a/README.md
+++ b/README.md
@@ -612,12 +612,9 @@ what's out of scope).
 
 ### Roles and provenance
 
-> **Coming in [#43](https://github.com/piekstra/twapp/pull/43).** That PR
-> adds `role` and `provenance` fields to `.twapp-session.json`, plus
-> `--role <ROLE>`, `--spawned`, and `--provenance <VAL>` flags on
-> `twapp work`.
-
-Once #43 merges, every session carries two extra pieces of metadata:
+Every session carries two extra pieces of metadata on
+`.twapp-session.json`, both optional and both backwards-compatible with
+pre-role session files:
 
 - **`role`** — a free-form string tag. Conventionally one of the
   archetypes from
@@ -645,44 +642,12 @@ unchanged.
 
 ### Model selection per agent
 
-> **Planned.** A forthcoming PR (tracked as `twapp-model-selection` in
-> the coordination notes) will let you pick which Claude model backs a
-> spawned session — e.g. a coordinator on a stronger model, worker
-> implementers on a cheaper or faster one — without hand-editing the
-> spawned `claude` invocation.
-
-Until that lands, per-agent model choice is governed by whatever default
-your Claude CLI is configured with; spawning a cheaper worker means
-adjusting the Claude config that the worker's cwd resolves to.
-
-### Related skills
-
-- [`skills/spawn-agent/SKILL.md`](skills/spawn-agent/SKILL.md) — how a
-  Claude instance spawns another (file-reference prompt pattern,
-  worktree permission seeding, hello-within-2-min verification,
-  shutdown).
-- [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md)
-  — how to act as a coordinator across many workers (briefing shape,
-  mailbox protocol, self-merge gating, offboard cleanup, role
-  archetypes, question routing).
-
-### Design docs
-
-- [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) —
-  the mailbox shape and addressing model behind `twapp msg`, plus the
-  migration path from the current flat `inbox/` layout to threads,
-  cursors, priority lanes, presence, and channels.
-- [`docs/designs/agent-aware-ui.md`](docs/designs/agent-aware-ui.md) —
-  proposed UI / dashboard surface once the messaging substrate is
-  load-bearing, with the constraint that single-session users see no
-  change.
-
-## Model selection
-
 `twapp work --model <name>` pass-through sets the model on the spawned
 provider CLI. When unset, twapp does **not** pass `--model` and the
 provider's own default applies (e.g. the Claude CLI's global
-`ANTHROPIC_MODEL` or user config).
+`ANTHROPIC_MODEL` or user config). This lets a coordinator put its
+workers on a cheaper or faster model than itself without hand-editing
+the spawned `claude` invocation.
 
 ```bash
 # Pin a spawned worker to a specific Claude model.
@@ -701,7 +666,7 @@ is forwarded as `--model <name>`; for codex, as `-c model='<name>'`
 not accept `--model` — a resumed session keeps whatever model the
 original spawn picked.
 
-### Discovering available models
+#### Discovering available models
 
 ```bash
 # Three-column table: NAME / TIER / DESCRIPTION.
@@ -733,7 +698,7 @@ bundled default list shipped with the binary.
 hand; a refresh verb will land when the upstream CLI exposes a listing
 endpoint.
 
-### Picking a tier when spawning workers
+#### Picking a tier when spawning workers
 
 - **haiku** — plumbing, doc edits, simple refactors, CLI scaffolding.
 - **sonnet** — default for most implementation work; good balance of
@@ -744,6 +709,28 @@ endpoint.
 Match the model to the scope cost. Sending a one-line dependency bump
 to opus burns budget; sending a complex architecture audit to haiku
 burns iteration.
+
+### Related skills
+
+- [`skills/spawn-agent/SKILL.md`](skills/spawn-agent/SKILL.md) — how a
+  Claude instance spawns another (file-reference prompt pattern,
+  worktree permission seeding, hello-within-2-min verification,
+  shutdown).
+- [`skills/agent-coordinator/SKILL.md`](skills/agent-coordinator/SKILL.md)
+  — how to act as a coordinator across many workers (briefing shape,
+  mailbox protocol, self-merge gating, offboard cleanup, role
+  archetypes, question routing).
+
+### Design docs
+
+- [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) —
+  the mailbox shape and addressing model behind `twapp msg`, plus the
+  migration path from the current flat `inbox/` layout to threads,
+  cursors, priority lanes, presence, and channels.
+- [`docs/designs/agent-aware-ui.md`](docs/designs/agent-aware-ui.md) —
+  proposed UI / dashboard surface once the messaging substrate is
+  load-bearing, with the constraint that single-session users see no
+  change.
 
 ## CLI Reference
 

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -10,6 +10,8 @@ The long-running orchestration loop that wraps around many agent launches.
 
 This skill teaches a Claude instance how to act as a **coordinator** — managing the lifecycle of two or more twapp-hosted worker agents, reviewing their work, merging their PRs, and keeping a shared mailbox tidy.
 
+> This is the orchestration half of the twapp README's [co-lab overview](../../README.md#co-lab-multi-agent-coordination-on-twapp); pair it with [`spawn-agent`](../spawn-agent/SKILL.md) for the individual-worker primitive.
+
 For launching a single agent, use the [`spawn-agent`](../spawn-agent/SKILL.md) skill. This skill assumes you already know how to spawn one agent; it covers what to do when you have many.
 
 ## 1. When to use

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -8,6 +8,8 @@ allowed-tools: Bash(twapp *), Bash(mkdir *), Bash(cat *), Bash(git worktree *), 
 
 Spawn a background / long-running Claude agent as a twapp-hosted session, give it a briefing it can actually read, and confirm it came up.
 
+> This is one of the **co-lab** patterns the twapp README describes — see the [co-lab overview](../../README.md#co-lab-multi-agent-coordination-on-twapp) for how spawning fits alongside messaging, roles, and the coordinator. Use [`agent-coordinator`](../agent-coordinator/SKILL.md) for the supervision loop that wraps many spawns.
+
 ## When to use
 
 Use this skill when you want to launch a **worker** — a Claude instance that executes a prepared briefing in its own terminal window until the job is done — not when you want to open an interactive shell for yourself.


### PR DESCRIPTION
## Summary
- Introduces a single top-level **"co-lab: multi-agent coordination on twapp"** section that reframes the cluster of recent multi-agent features (spawn ergonomics, `twapp msg`, coordinator bootstrap, role/provenance metadata, per-agent model selection) as one coherent story instead of several bolted-on sections.
- Preserves the technical content of the existing "Spawning agent instances" and "Messaging between sessions" sections (now `### Spawning a worker agent` and `### Messaging between sessions` subsections) — nothing is cut, just reorganized with connective intro, an ASCII flow diagram, and cross-links.
- Adds placeholder subsections for in-flight work:
  - `### Bootstrapping a coordinator` references [#44](https://github.com/piekstra/twapp/pull/44) (`twapp coordinator launch|claim`) with a pre-#44 fallback.
  - `### Roles and provenance` references [#43](https://github.com/piekstra/twapp/pull/43) (`role` / `provenance` fields + `--role` / `--spawned` / `--provenance` flags).
  - `### Model selection per agent` notes the planned per-agent model selection work (no PR yet).
- Keeps the single-session story intact at the top of the README — co-lab material sits after Quick Start / Importing Existing Claude Sessions and before the CLI Reference, and is explicitly flagged as optional for users who only run one terminal.
- Adds one-line cross-links from `skills/spawn-agent/SKILL.md` and `skills/agent-coordinator/SKILL.md` back to the README co-lab overview so readers arriving at either skill see how it fits.

## Not in this PR
- No CLI changes. No new verbs, no `--flags`, no `twapp colab` namespace (co-lab is a docs-only branding choice per Option C).
- No edits under `src/`, `src-tauri/`, or `docs/designs/`.
- No rewrites of skill content beyond the single cross-link line.

## Coordination
- If [#43](https://github.com/piekstra/twapp/pull/43) or [#44](https://github.com/piekstra/twapp/pull/44) merge before this, their README additions will collide with the new co-lab subsections — the fix is a rebase that folds the landed copy into the matching co-lab subsection (`### Roles and provenance` or `### Bootstrapping a coordinator`) instead of re-introducing a top-level header.
- If this merges first, in-flight PRs can append their content under the matching co-lab subsection rather than adding a new top-level section.

## Test plan
- [x] `grep -n '^##\|^###' README.md` — section structure is linear, no duplicates, co-lab sits between "Importing Existing Claude Sessions" and "CLI Reference".
- [ ] Reviewer: render the README on GitHub and confirm anchor links to `#co-lab-multi-agent-coordination-on-twapp` from the skill files resolve.
- [ ] Reviewer: confirm the single-session path (Quick Start → Importing → CLI Reference) still reads cleanly for someone who never wants multi-agent.