### PR TITLE
feat: model selection (--model) + models list/refresh subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,12 +479,83 @@ Without these checks, the spawned terminal would appear to launch fine and
 then silently fail inside the new window — a painful debug loop when
 automating spawns.
 
+## Model selection
+
+`twapp work --model <name>` pass-through sets the model on the spawned
+provider CLI. When unset, twapp does **not** pass `--model` and the
+provider's own default applies (e.g. the Claude CLI's global
+`ANTHROPIC_MODEL` or user config).
+
+```bash
+# Pin a spawned worker to a specific Claude model.
+twapp work --name plumbing-worker \
+  --from-file /path/to/briefing.md \
+  --model claude-haiku-4-5-20251001
+
+# Use the tier alias for the latest model of that tier.
+twapp work --name design-worker --from-file /path/to/briefing.md --model opus
+```
+
+twapp does **not** validate the model name — pass-through means the
+provider CLI rejects unknown names at spawn time. For claude, the value
+is forwarded as `--model <name>`; for codex, as `-c model='<name>'`
+(a TOML config override). The `twapp resume` command intentionally does
+not accept `--model` — a resumed session keeps whatever model the
+original spawn picked.
+
+### Discovering available models
+
+```bash
+# Three-column table: NAME / TIER / DESCRIPTION.
+twapp models list
+
+# Different provider (defaults to claude).
+twapp models list --provider claude
+
+# Machine-readable output for scripts.
+twapp models list --format json
+
+# Refresh the cache from the provider's models endpoint.
+# For claude, requires ANTHROPIC_API_KEY in the environment.
+ANTHROPIC_API_KEY=sk-ant-... twapp models refresh
+```
+
+`twapp models list` reads a cache at
+`~/.config/twapp/models.<provider>.json` if present, or falls back to a
+bundled default list shipped with the binary.
+
+> **Caveat:** the bundled default is a snapshot of the Claude model
+> family at build time. `twapp models refresh` is the authoritative
+> source — run it whenever you want a current view of available models.
+> The cache always takes precedence over the bundled default.
+
+`twapp models refresh` currently supports `--provider claude` (calls
+`https://api.anthropic.com/v1/models` with `x-api-key` and
+`anthropic-version: 2023-06-01`). For codex, edit the cache file by
+hand; a refresh verb will land when the upstream CLI exposes a listing
+endpoint.
+
+### Picking a tier when spawning workers
+
+- **haiku** — plumbing, doc edits, simple refactors, CLI scaffolding.
+- **sonnet** — default for most implementation work; good balance of
+  capability and cost.
+- **opus** — design audits, cross-cutting synthesis, high-stakes
+  correctness work where the model's reasoning is load-bearing.
+
+Match the model to the scope cost. Sending a one-line dependency bump
+to opus burns budget; sending a complex architecture audit to haiku
+burns iteration.
+
 ## CLI Reference
 
 | Command | Description |
 |---------|-------------|
 | `twapp work <ticket\|--name>` | Start a new work session using the configured provider |
 | `twapp work --from-file <path>` | Spawn a session whose prompt is `Read <path> and execute.` (safer than `--run` for long prompts) |
+| `twapp work --model <name>` | Pass-through model selection; forwarded to the provider CLI (claude: `--model`, codex: `-c model='…'`) |
+| `twapp models list [--provider <p>] [--format json]` | Show known models for the provider (cache if present, else bundled default) |
+| `twapp models refresh [--provider <p>]` | Re-populate the provider cache from the models endpoint (claude: `ANTHROPIC_API_KEY` required) |
 | `twapp stop --name <name> [--force]` | Gracefully stop a running session (SIGTERM, optional SIGKILL escalation) |
 | `twapp resume [--fork]` | Resume or fork the current session using the configured provider |
 | `twapp sessions` | List all sessions with activity timestamps |

--- a/data/models.claude.default.json
+++ b/data/models.claude.default.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "claude-opus-4-7",
+    "tier": "opus",
+    "description": "Most capable Claude model; use for design audits and complex synthesis."
+  },
+  {
+    "name": "claude-sonnet-4-6",
+    "tier": "sonnet",
+    "description": "Strong general-purpose Claude model; default for most implementation work."
+  },
+  {
+    "name": "claude-haiku-4-5-20251001",
+    "tier": "haiku",
+    "description": "Fast and inexpensive Claude model; use for plumbing and simple edits."
+  },
+  {
+    "name": "opus",
+    "tier": "opus",
+    "description": "Alias: latest opus-tier Claude model."
+  },
+  {
+    "name": "sonnet",
+    "tier": "sonnet",
+    "description": "Alias: latest sonnet-tier Claude model."
+  },
+  {
+    "name": "haiku",
+    "tier": "haiku",
+    "description": "Alias: latest haiku-tier Claude model."
+  }
+]

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -73,6 +73,18 @@ Why each section earns its place:
 - **Worktree** — copy-paste beats improvisation; workers that improvise their worktree path get lost.
 - **Domain facts** — how you avoid the class of bug where an agent silently misinterprets units, multipliers, field semantics, or ownership boundaries.
 
+### Model selection when spawning workers
+
+Every briefing implicitly picks a model — either explicitly, via `twapp work --model <name>` on the spawn command, or implicitly, by falling through to the provider's default. Coordinators should match the model tier to the scope cost:
+
+- **haiku** for plumbing, docs, small mechanical PRs.
+- **sonnet** (default) for most implementation work.
+- **opus** for design audits, cross-cutting synthesis, and high-stakes correctness work.
+
+Pass `--model` at spawn time; the flag is pass-through to the provider CLI and twapp does not validate the name. See the [`spawn-agent`](../spawn-agent/SKILL.md#model-selection) skill's "Model selection" subsection for per-tier guidance, the `twapp models list` output shape, and how to refresh the known-models cache. Don't duplicate that content here — if the guidance drifts, update it in spawn-agent and link.
+
+Budget note: un-pinned spawns inherit the user's global default. For a batch of workers of mixed scope, pin each one explicitly so a default swap (e.g. user switching to opus while debugging) doesn't silently re-cost the whole batch.
+
 ## 3. Mailbox protocol
 
 A plain-directory mailbox is the coordination bus. No database, no service — just files you can `ls`, `grep`, and `mv`.

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -45,6 +45,49 @@ Notes:
 - The `Read <path> and execute.` wrapper is deliberately short — every character is literal text the shell must carry intact to Claude. Keep what's in the markdown file.
 - Treat the briefing file as the contract. Put acceptance criteria, protocol, and a handle name in it. Don't try to squeeze those into `--run`.
 
+## Model selection
+
+Pair `--from-file` with `--model <name>` to pin the spawned agent to a specific model. Match the tier to the scope cost so cheap plumbing PRs don't burn opus-level inference and complex design audits don't hit capability ceilings on haiku.
+
+```bash
+twapp work --name plumbing-worker --from-file /abs/path/brief.md --model claude-haiku-4-5-20251001
+twapp work --name impl-worker     --from-file /abs/path/brief.md --model claude-sonnet-4-6
+twapp work --name design-worker   --from-file /abs/path/brief.md --model opus
+```
+
+twapp does not validate the model name — the provider CLI rejects unknown names at spawn time. When `--model` is omitted, the provider's own default wins (e.g. the Claude CLI's `ANTHROPIC_MODEL` env var or user config).
+
+### When to pick which tier
+
+- **haiku** — plumbing, doc touch-ups, one-line dependency bumps, CLI scaffolding, mechanical refactors with tests already in place. Anything where correctness is obvious on inspection.
+- **sonnet** — default for implementation work. Non-trivial feature code, most bug fixes, test writing, reviewer roles. Good capability/cost balance.
+- **opus** — design audits, cross-cutting synthesis, high-stakes correctness work (money, safety, concurrency), architect and innovator roles producing RFCs. Reserve for scope that actually benefits from the extra reasoning.
+
+### Discovering available models
+
+Before pinning a specific name, run:
+
+```bash
+twapp models list
+```
+
+Sample output (bundled default on a fresh install):
+
+```
+NAME                       TIER    DESCRIPTION
+claude-opus-4-7            opus    Most capable Claude model; use for design audits and complex synthesis.
+claude-sonnet-4-6          sonnet  Strong general-purpose Claude model; default for most implementation work.
+claude-haiku-4-5-20251001  haiku   Fast and inexpensive Claude model; use for plumbing and simple edits.
+opus                       opus    Alias: latest opus-tier Claude model.
+sonnet                     sonnet  Alias: latest sonnet-tier Claude model.
+haiku                      haiku   Alias: latest haiku-tier Claude model.
+(source: bundled)
+```
+
+The `opus`/`sonnet`/`haiku` aliases resolve to the latest model in that tier — handy for briefings that shouldn't pin to a specific snapshot. Use explicit dated names (e.g. `claude-haiku-4-5-20251001`) when you need reproducibility.
+
+The bundled list is a snapshot — run `ANTHROPIC_API_KEY=… twapp models refresh` to pull the current list into `~/.config/twapp/models.claude.json`. The cache takes precedence over the bundled default.
+
 ## Worktree permission pre-approval
 
 A freshly spawned Claude instance reads `.claude/settings.local.json` from its working directory at startup. If that file isn't there, the first tool call blocks on an interactive permission prompt — which is a disaster for a background worker because nobody is there to answer.

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod app_bundle;
 pub mod config;
+pub mod models;
 pub mod monitor;
 pub mod msg;
 pub mod notes;
@@ -12,12 +13,12 @@ pub mod ticket;
 
 use clap::Subcommand;
 use msg::MsgCommands;
-use session::{AgentProvider, shell_escape_single};
+use session::{AgentProvider, build_claude_run_command, build_codex_run_command, shell_escape_single};
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
     /// Start a new work session
-    #[command(after_help = "Examples:\n  twapp work MON-1234                                    Start fresh session\n  twapp work --name \"research\"                           Start session without a ticket\n  twapp work --name worker --from-file /path/brief.md    Spawn agent to read a briefing file\n  twapp work MON-5678 -s abc123 --claude-cwd /old/dir    Fork existing session to new ticket\n\nShutdown: use `twapp stop --name <name>` to gracefully shut down a spawned instance.")]
+    #[command(after_help = "Examples:\n  twapp work MON-1234                                    Start fresh session\n  twapp work --name \"research\"                           Start session without a ticket\n  twapp work --name worker --from-file /path/brief.md    Spawn agent to read a briefing file\n  twapp work --name worker --model sonnet                Pin the spawned agent to a specific model\n  twapp work MON-5678 -s abc123 --claude-cwd /old/dir    Fork existing session to new ticket\n\nShutdown: use `twapp stop --name <name>` to gracefully shut down a spawned instance.")]
     Work {
         /// Ticket ID (e.g. MON-1234, 1234, owner/repo#123)
         ticket: Option<String>,
@@ -31,6 +32,11 @@ pub enum Commands {
         /// long prompts with special characters. Path must exist at spawn time.
         #[arg(long)]
         from_file: Option<String>,
+        /// Model name passed through to the provider CLI (claude: `--model`,
+        /// codex: `-c model='<name>'`). twapp does not validate the name —
+        /// the provider CLI rejects unknown models. See `twapp models list`.
+        #[arg(long)]
+        model: Option<String>,
         /// Force GitHub issue lookup
         #[arg(long, short = 'g')]
         github: bool,
@@ -145,6 +151,18 @@ pub enum Commands {
     Msg {
         #[command(subcommand)]
         command: MsgCommands,
+    },
+    /// Inspect or refresh the provider model cache used by --model.
+    ///
+    /// `twapp models list` reads a cached list of known models for the
+    /// provider (falls back to a bundled default on fresh installs).
+    /// `twapp models refresh` re-populates the cache from the provider's
+    /// models endpoint. twapp does not maintain an authoritative list —
+    /// refresh is the source of truth.
+    #[command(after_help = "Examples:\n  twapp models list                         Show known claude models (cache or bundled fallback)\n  twapp models list --provider codex        Show the codex list (empty until you seed the cache)\n  twapp models list --format json           Machine-readable output\n  twapp models refresh                      Pull current list from the Anthropic models endpoint")]
+    Models {
+        #[command(subcommand)]
+        command: ModelsCommands,
     },
     /// Generate shell completions
     #[command(name = "completions")]
@@ -269,6 +287,25 @@ pub enum PromptCommands {
 }
 
 #[derive(Subcommand, Debug)]
+pub enum ModelsCommands {
+    /// List known models for the provider (cache if present, else bundled default).
+    List {
+        /// Provider to inspect (default: claude)
+        #[arg(long, default_value = "claude")]
+        provider: String,
+        /// Output format: defaults to a three-column table; `json` prints the raw cache shape.
+        #[arg(long)]
+        format: Option<String>,
+    },
+    /// Re-populate the provider model cache from the provider's models endpoint.
+    Refresh {
+        /// Provider to refresh (default: claude). Requires ANTHROPIC_API_KEY for claude.
+        #[arg(long, default_value = "claude")]
+        provider: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 pub enum PermissionCommands {
     /// Show default permissions
     List,
@@ -297,11 +334,12 @@ pub fn run(cmd: Commands) -> i32 {
             name,
             run,
             from_file,
+            model,
             github,
             session_id: fork_session_id,
             claude_cwd,
             chrome,
-        } => cmd_work(ticket, name, run, from_file, github, fork_session_id, claude_cwd, chrome),
+        } => cmd_work(ticket, name, run, from_file, model, github, fork_session_id, claude_cwd, chrome),
         Commands::Stop { name, force } => stop::cmd_stop(&name, force),
         Commands::Resume { fork } => cmd_resume(fork),
         Commands::Sessions { path } => cmd_sessions(path),
@@ -409,6 +447,10 @@ pub fn run(cmd: Commands) -> i32 {
                 for_handle, since, priority, thread, channel, mark_read, limit, format, all,
             ),
         },
+        Commands::Models { command } => match command {
+            ModelsCommands::List { provider, format } => models::cmd_list(provider, format),
+            ModelsCommands::Refresh { provider } => models::cmd_refresh(provider),
+        },
         Commands::Completions { shell } => {
             clap_complete::generate(
                 shell,
@@ -457,11 +499,16 @@ pub fn format_session_name(key: &str, title: &str) -> String {
     result
 }
 
-/// Core session creation logic shared between CLI (cmd_work) and GUI (create_and_launch_session)
+/// Core session creation logic shared between CLI (cmd_work) and GUI (create_and_launch_session).
+///
+/// `model`, when set, is pass-through inserted into the spawned provider
+/// invocation (claude: `--model <name>`, codex: `-c model='<name>'`).
+/// twapp does not validate the name.
 pub fn create_session_core(
     ticket_id: Option<String>,
     session_name: Option<String>,
     run_command: Option<String>,
+    model: Option<String>,
     github: bool,
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
@@ -584,35 +631,30 @@ pub fn create_session_core(
     };
     session::write_session(&work_dir, &session_data)?;
 
-    let chrome_flag = if chrome { " --chrome" } else { "" };
     let command = if let Some(ref custom) = run_command {
         custom.clone()
     } else if provider == AgentProvider::Codex {
-        format!(
-            "codex -C '{}'{}",
-            shell_escape_single(&work_dir.to_string_lossy()),
-            if let Some(ref ti) = ticket_info {
-                if dir_already_existed {
-                    format!(" '{}'", shell_escape_single(&format!("I'm working on {}: {}.", ti.key, ti.title)))
-                } else {
-                    String::new()
-                }
+        let initial_prompt = ticket_info.as_ref().and_then(|ti| {
+            if dir_already_existed {
+                Some(format!("I'm working on {}: {}.", ti.key, ti.title))
             } else {
-                String::new()
+                None
             }
-        )
-    } else if let Some(ref old_id) = fork_session_id {
-        let cd_prefix = if claude_cwd != work_dir.to_string_lossy() {
-            format!("cd '{}' && ", claude_cwd.replace('\'', "'\\''"))
-        } else {
-            String::new()
-        };
-        format!(
-            "{}claude --resume {} --fork-session --session-id {}{}",
-            cd_prefix, old_id, session_id, chrome_flag
+        });
+        build_codex_run_command(
+            &work_dir.to_string_lossy(),
+            model.as_deref(),
+            initial_prompt.as_deref(),
         )
     } else {
-        format!("claude --session-id {}{}", session_id, chrome_flag)
+        build_claude_run_command(
+            &session_id,
+            fork_session_id.as_deref(),
+            model.as_deref(),
+            &claude_cwd,
+            &work_dir.to_string_lossy(),
+            chrome,
+        )
     };
 
     let prefill = if let Some(ref ti) = ticket_info {
@@ -669,6 +711,7 @@ fn cmd_work(
     session_name: Option<String>,
     run_command: Option<String>,
     from_file: Option<String>,
+    model: Option<String>,
     github: bool,
     fork_session_id: Option<String>,
     claude_cwd_arg: Option<String>,
@@ -727,7 +770,7 @@ fn cmd_work(
         return 1;
     }
 
-    let result = match create_session_core(ticket_id, session_name, effective_run, github, fork_session_id, claude_cwd_arg, chrome) {
+    let result = match create_session_core(ticket_id, session_name, effective_run, model, github, fork_session_id, claude_cwd_arg, chrome) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/src-tauri/src/cli/models.rs
+++ b/src-tauri/src/cli/models.rs
@@ -1,0 +1,332 @@
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelEntry {
+    pub name: String,
+    pub tier: String,
+    pub description: String,
+}
+
+const BUNDLED_CLAUDE_DEFAULT: &str =
+    include_str!("../../../data/models.claude.default.json");
+
+pub fn cache_path(provider: &str) -> PathBuf {
+    let base = dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".config")
+        .join("twapp");
+    base.join(format!("models.{}.json", provider))
+}
+
+pub fn bundled_default(provider: &str) -> Result<Vec<ModelEntry>, String> {
+    match provider {
+        "claude" => serde_json::from_str(BUNDLED_CLAUDE_DEFAULT)
+            .map_err(|e| format!("parse bundled claude default: {}", e)),
+        "codex" => Ok(Vec::new()),
+        other => Err(format!("unknown provider: {}", other)),
+    }
+}
+
+pub fn load_models_from(cache: &Path, provider: &str) -> Result<(Vec<ModelEntry>, &'static str), String> {
+    if cache.exists() {
+        let s = std::fs::read_to_string(cache)
+            .map_err(|e| format!("read cache {}: {}", cache.display(), e))?;
+        let entries: Vec<ModelEntry> = serde_json::from_str(&s)
+            .map_err(|e| format!("parse cache {}: {}", cache.display(), e))?;
+        Ok((entries, "cache"))
+    } else {
+        bundled_default(provider).map(|e| (e, "bundled"))
+    }
+}
+
+pub fn parse_anthropic_response(body: &str) -> Result<Vec<ModelEntry>, String> {
+    #[derive(Deserialize)]
+    struct Resp {
+        data: Vec<AModel>,
+    }
+    #[derive(Deserialize)]
+    struct AModel {
+        id: String,
+        #[serde(default)]
+        display_name: String,
+    }
+    let resp: Resp =
+        serde_json::from_str(body).map_err(|e| format!("parse anthropic response: {}", e))?;
+    Ok(resp
+        .data
+        .into_iter()
+        .map(|m| {
+            let tier = tier_for_name(&m.id).to_string();
+            let description = if m.display_name.is_empty() {
+                format!("{}-tier Claude model.", tier)
+            } else {
+                m.display_name
+            };
+            ModelEntry {
+                name: m.id,
+                tier,
+                description,
+            }
+        })
+        .collect())
+}
+
+pub fn tier_for_name(name: &str) -> &'static str {
+    let n = name.to_lowercase();
+    if n.contains("opus") {
+        "opus"
+    } else if n.contains("sonnet") {
+        "sonnet"
+    } else if n.contains("haiku") {
+        "haiku"
+    } else {
+        "other"
+    }
+}
+
+pub fn write_cache_atomic(path: &Path, entries: &[ModelEntry]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let s = serde_json::to_string_pretty(entries).map_err(|e| format!("serialize: {}", e))?;
+    std::fs::write(&tmp, s).map_err(|e| format!("write temp {}: {}", tmp.display(), e))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| format!("rename to {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+pub fn cmd_list(provider: String, format: Option<String>) -> i32 {
+    let cache = cache_path(&provider);
+    let (entries, source) = match load_models_from(&cache, &provider) {
+        Ok(x) => x,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    match format.as_deref() {
+        Some("json") => match serde_json::to_string_pretty(&entries) {
+            Ok(s) => {
+                println!("{}", s);
+                0
+            }
+            Err(e) => {
+                eprintln!("Error: {}", e);
+                1
+            }
+        },
+        Some(other) => {
+            eprintln!("Error: unknown --format {} (want: json)", other);
+            2
+        }
+        None => {
+            if entries.is_empty() {
+                println!("no models cached for {} (source: {})", provider, source);
+                return 0;
+            }
+            let name_w = entries
+                .iter()
+                .map(|e| e.name.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            let tier_w = entries
+                .iter()
+                .map(|e| e.tier.len())
+                .max()
+                .unwrap_or(4)
+                .max(4);
+            println!(
+                "{:<nw$}  {:<tw$}  DESCRIPTION",
+                "NAME",
+                "TIER",
+                nw = name_w,
+                tw = tier_w
+            );
+            for e in &entries {
+                println!(
+                    "{:<nw$}  {:<tw$}  {}",
+                    e.name,
+                    e.tier,
+                    e.description,
+                    nw = name_w,
+                    tw = tier_w
+                );
+            }
+            eprintln!("(source: {source})");
+            0
+        }
+    }
+}
+
+pub fn cmd_refresh(provider: String) -> i32 {
+    match provider.as_str() {
+        "claude" => refresh_claude(),
+        "codex" => {
+            let path = cache_path("codex");
+            eprintln!(
+                "Error: refresh not supported for codex yet; edit the cache by hand at {}",
+                path.display()
+            );
+            1
+        }
+        other => {
+            eprintln!("Error: unknown provider: {}", other);
+            1
+        }
+    }
+}
+
+fn refresh_claude() -> i32 {
+    let api_key = match std::env::var("ANTHROPIC_API_KEY") {
+        Ok(v) if !v.is_empty() => v,
+        _ => {
+            eprintln!(
+                "Error: ANTHROPIC_API_KEY is not set. Export ANTHROPIC_API_KEY and retry."
+            );
+            return 1;
+        }
+    };
+
+    let output = match std::process::Command::new("curl")
+        .arg("-sS")
+        .arg("-f")
+        .arg("-H")
+        .arg(format!("x-api-key: {}", api_key))
+        .arg("-H")
+        .arg("anthropic-version: 2023-06-01")
+        .arg("https://api.anthropic.com/v1/models")
+        .output()
+    {
+        Ok(o) => o,
+        Err(e) => {
+            eprintln!("Error: failed to invoke curl: {}", e);
+            return 1;
+        }
+    };
+
+    if !output.status.success() {
+        eprintln!(
+            "Error: curl exited with status {}: {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return 1;
+    }
+
+    let body = String::from_utf8_lossy(&output.stdout).into_owned();
+    let entries = match parse_anthropic_response(&body) {
+        Ok(e) => e,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let path = cache_path("claude");
+    if let Err(e) = write_cache_atomic(&path, &entries) {
+        eprintln!("Error: {}", e);
+        return 1;
+    }
+
+    println!(
+        "refreshed claude models: {} entries cached at {}",
+        entries.len(),
+        path.display()
+    );
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_default_parses() {
+        let entries = bundled_default("claude").expect("bundled default parses");
+        assert!(!entries.is_empty(), "bundled default must not be empty");
+        for e in &entries {
+            assert!(!e.name.is_empty());
+            assert!(matches!(e.tier.as_str(), "opus" | "sonnet" | "haiku" | "other"));
+            assert!(!e.description.is_empty());
+        }
+    }
+
+    #[test]
+    fn models_list_loads_bundled_default_when_cache_missing() {
+        let tmp = tempdir();
+        let cache = tmp.join("models.claude.json");
+        assert!(!cache.exists());
+        let (entries, source) =
+            load_models_from(&cache, "claude").expect("load falls back to bundled");
+        assert_eq!(source, "bundled");
+        assert!(!entries.is_empty());
+    }
+
+    #[test]
+    fn models_list_prefers_cache_over_bundled_when_both_exist() {
+        let tmp = tempdir();
+        let cache = tmp.join("models.claude.json");
+        let canned = vec![ModelEntry {
+            name: "cache-only-model".to_string(),
+            tier: "haiku".to_string(),
+            description: "from the cache".to_string(),
+        }];
+        write_cache_atomic(&cache, &canned).expect("write cache");
+        let (entries, source) =
+            load_models_from(&cache, "claude").expect("load from cache");
+        assert_eq!(source, "cache");
+        assert_eq!(entries, canned);
+    }
+
+    #[test]
+    fn models_refresh_parses_anthropic_response() {
+        let body = r#"{
+          "data": [
+            {"id": "claude-opus-4-7", "display_name": "Claude Opus 4.7"},
+            {"id": "claude-sonnet-4-6", "display_name": "Claude Sonnet 4.6"},
+            {"id": "claude-haiku-4-5-20251001", "display_name": "Claude Haiku 4.5"}
+          ],
+          "has_more": false
+        }"#;
+        let entries = parse_anthropic_response(body).expect("parse");
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].name, "claude-opus-4-7");
+        assert_eq!(entries[0].tier, "opus");
+        assert_eq!(entries[0].description, "Claude Opus 4.7");
+        assert_eq!(entries[1].tier, "sonnet");
+        assert_eq!(entries[2].tier, "haiku");
+    }
+
+    #[test]
+    fn models_refresh_errors_without_api_key() {
+        let prior = std::env::var("ANTHROPIC_API_KEY").ok();
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        let code = refresh_claude();
+        if let Some(v) = prior {
+            std::env::set_var("ANTHROPIC_API_KEY", v);
+        }
+        assert_eq!(code, 1);
+    }
+
+    #[test]
+    fn tier_for_name_matches_family() {
+        assert_eq!(tier_for_name("claude-opus-4-7"), "opus");
+        assert_eq!(tier_for_name("claude-sonnet-4-6"), "sonnet");
+        assert_eq!(tier_for_name("claude-haiku-4-5"), "haiku");
+        assert_eq!(tier_for_name("something-else"), "other");
+    }
+
+    fn tempdir() -> PathBuf {
+        let base = std::env::temp_dir().join(format!(
+            "twapp-models-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&base).expect("create tempdir");
+        base
+    }
+}

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -139,6 +139,138 @@ pub fn shell_escape_single(text: &str) -> String {
     text.replace('\'', "'\\''")
 }
 
+/// Build the shell command that `twapp work` will execute to launch a claude
+/// session. `model`, when set, is pass-through inserted as `--model <name>`.
+/// `fork_session_id` indicates a resume-with-fork spawn; when set and
+/// `claude_cwd != work_dir_str`, the command is prefixed with `cd '<dir>' && `.
+pub fn build_claude_run_command(
+    session_id: &str,
+    fork_session_id: Option<&str>,
+    model: Option<&str>,
+    claude_cwd: &str,
+    work_dir_str: &str,
+    chrome: bool,
+) -> String {
+    let chrome_flag = if chrome { " --chrome" } else { "" };
+    let model_flag = match model {
+        Some(m) if !m.is_empty() => format!(" --model '{}'", shell_escape_single(m)),
+        _ => String::new(),
+    };
+
+    match fork_session_id {
+        Some(old_id) => {
+            let cd_prefix = if claude_cwd != work_dir_str {
+                format!("cd '{}' && ", shell_escape_single(claude_cwd))
+            } else {
+                String::new()
+            };
+            format!(
+                "{}claude{} --resume {} --fork-session --session-id {}{}",
+                cd_prefix, model_flag, old_id, session_id, chrome_flag
+            )
+        }
+        None => format!(
+            "claude{} --session-id {}{}",
+            model_flag, session_id, chrome_flag
+        ),
+    }
+}
+
+/// Build the shell command that `twapp work` will execute to launch a codex
+/// session. Codex takes a model via `-c model='<name>'` config override.
+pub fn build_codex_run_command(
+    work_dir_str: &str,
+    model: Option<&str>,
+    initial_prompt: Option<&str>,
+) -> String {
+    let model_flag = match model {
+        Some(m) if !m.is_empty() => format!(" -c model='{}'", shell_escape_single(m)),
+        _ => String::new(),
+    };
+    let prompt_arg = match initial_prompt {
+        Some(p) if !p.is_empty() => format!(" '{}'", shell_escape_single(p)),
+        _ => String::new(),
+    };
+    format!(
+        "codex{} -C '{}'{}",
+        model_flag,
+        shell_escape_single(work_dir_str),
+        prompt_arg
+    )
+}
+
+#[cfg(test)]
+mod command_build_tests {
+    use super::*;
+
+    #[test]
+    fn model_flag_threads_through_to_claude_invocation() {
+        let cmd = build_claude_run_command(
+            "abc-123",
+            None,
+            Some("claude-sonnet-4-6"),
+            "/tmp/wd",
+            "/tmp/wd",
+            false,
+        );
+        assert!(
+            cmd.contains("--model 'claude-sonnet-4-6'"),
+            "claude invocation should contain --model flag, got: {}",
+            cmd
+        );
+        assert!(cmd.contains("--session-id abc-123"));
+    }
+
+    #[test]
+    fn claude_invocation_omits_model_when_unset() {
+        let cmd = build_claude_run_command(
+            "abc-123",
+            None,
+            None,
+            "/tmp/wd",
+            "/tmp/wd",
+            false,
+        );
+        assert!(
+            !cmd.contains("--model"),
+            "unset model should leave --model out, got: {}",
+            cmd
+        );
+    }
+
+    #[test]
+    fn model_flag_threads_through_fork_resume() {
+        let cmd = build_claude_run_command(
+            "new-id",
+            Some("old-id"),
+            Some("opus"),
+            "/tmp/other",
+            "/tmp/wd",
+            true,
+        );
+        assert!(cmd.contains("cd '/tmp/other' &&"));
+        assert!(cmd.contains("claude --model 'opus' --resume old-id --fork-session --session-id new-id --chrome"),
+            "unexpected fork-resume shape: {}", cmd);
+    }
+
+    #[test]
+    fn model_flag_threads_through_to_codex_invocation() {
+        let cmd = build_codex_run_command("/tmp/wd", Some("o3"), None);
+        assert!(
+            cmd.contains("-c model='o3'"),
+            "codex invocation should contain -c model='...', got: {}",
+            cmd
+        );
+        assert!(cmd.contains("-C '/tmp/wd'"));
+    }
+
+    #[test]
+    fn codex_invocation_omits_model_when_unset() {
+        let cmd = build_codex_run_command("/tmp/wd", None, None);
+        assert!(!cmd.contains("-c model="));
+    }
+}
+
 pub fn count_codex_conversation_messages(session_id: &str) -> Option<u32> {
     let history_path = dirs::home_dir()?.join(".codex/history.jsonl");
     if !history_path.exists() {

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -585,7 +585,7 @@ pub async fn create_and_launch_session(
     github: bool,
     chrome: bool,
 ) -> Result<(), String> {
-    let result = crate::cli::create_session_core(ticket, name, None, github, None, None, chrome)?;
+    let result = crate::cli::create_session_core(ticket, name, None, None, github, None, None, chrome)?;
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&result.name, &result.color)?;
     crate::cli::app_bundle::launch_gui(&instance_app, &result.app_args)?;


### PR DESCRIPTION
## Summary

- `twapp work --model <name>` pass-through to the spawned provider CLI. Claude gets `--model <name>`; codex gets `-c model='<name>'`. When unset, twapp does not pass `--model` and the provider's own default wins. No validation — the provider CLI rejects unknown names.
- `twapp models list [--provider <p>] [--format json]` prints a three-column `NAME / TIER / DESCRIPTION` table (or JSON). Reads from `~/.config/twapp/models.<provider>.json` if cached, otherwise falls back to a bundled default committed at `data/models.claude.default.json` so the command works on a fresh install with no network call.
- `twapp models refresh [--provider <p>]` (claude only for now) hits `https://api.anthropic.com/v1/models` with `x-api-key` + `anthropic-version: 2023-06-01`, parses `data[]`, and writes the cache atomically (temp + rename). Requires `ANTHROPIC_API_KEY`; errors cleanly if unset. Codex refresh errors with a pointer to the cache path for manual editing until the upstream CLI exposes a listing endpoint.
- Skill docs (`skills/spawn-agent/SKILL.md`, `skills/agent-coordinator/SKILL.md`) and README updated alongside the feature per coordinator request — future agents can discover the verb without a lag.

## Design notes

- Model list is loaded from JSON (both bundled default and cache), not hardcoded in Rust, so editors don't need to rebuild to change the list.
- Command-building extracted into `build_claude_run_command` / `build_codex_run_command` helpers in `cli/session.rs` so the pass-through can be unit-tested directly without mocking the spawn side.
- Explicitly out of scope: `--model` on `twapp resume` (resume keeps whatever model the original spawn picked) and on `twapp coordinator launch` (subcommand not yet landed in main — will fold in via the `twapp-coordinator-launch-cli` lane's PR or a follow-up).

## Test plan

- [x] `cargo test --lib` — 50 passing, incl. 6 new `cli::models::tests::*` and 5 new `cli::session::command_build_tests::*`
  - `model_flag_threads_through_to_claude_invocation` — asserts `--model 'claude-sonnet-4-6'` appears in the generated claude command
  - `claude_invocation_omits_model_when_unset` — asserts no `--model` when flag is absent
  - `model_flag_threads_through_fork_resume` — asserts `--model` is positioned correctly on fork-resume
  - `model_flag_threads_through_to_codex_invocation` — asserts `-c model='o3'` appears in the generated codex command
  - `codex_invocation_omits_model_when_unset`
  - `bundled_default_parses` — sanity check on the shipped JSON
  - `models_list_loads_bundled_default_when_cache_missing`
  - `models_list_prefers_cache_over_bundled_when_both_exist`
  - `models_refresh_parses_anthropic_response` — parses a canned fixture, asserts tier mapping
  - `models_refresh_errors_without_api_key`
  - `tier_for_name_matches_family`
- [x] `cargo clippy --lib` — no new warnings in touched files
- [x] Smoke: `twapp models list`, `twapp models list --format json`, `twapp models refresh` (errors without key), `twapp models refresh --provider codex` (errors with manual-edit pointer), `twapp work --help` (shows `--model`)