### PR TITLE
docs(skills): mandate headless operation via /loop

### DIFF
--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -46,8 +46,11 @@ and a link to any relevant upstream data, audit, or prior PR.>
 
 ## Protocol
 <Handle, smoke-test command, branch name, base branch,
-hello-within-2-min requirement, self-merge criteria,
+hello-within-2-min requirement, /loop mandate (see "Headless
+operation — worker contract" below), self-merge criteria,
 offboard shape, hard rules.>
+
+- Invoke `/loop` after hello; poll every 90-120s. Never finish a turn asking the user a question — mailbox the coordinator if stuck.
 
 ## Coordinate with
 <Names of other in-flight workers whose work overlaps —
@@ -72,6 +75,20 @@ Why each section earns its place:
 - **Coordinate with** — prevents collisions on shared files. Cheap to write, expensive to omit.
 - **Worktree** — copy-paste beats improvisation; workers that improvise their worktree path get lost.
 - **Domain facts** — how you avoid the class of bug where an agent silently misinterprets units, multipliers, field semantics, or ownership boundaries.
+
+### Headless operation — worker contract
+
+**Headless operation.** Every worker invokes `/loop` after its hello and operates autonomously. Never end a turn waiting for user input. If stuck, mailbox the coordinator. The coordinator decides when to escalate to the user.
+
+Coordinators MUST include this mandate in every worker briefing's `## Protocol` block. The canonical one-liner is already inlined in the template above:
+
+```
+- Invoke `/loop` after hello; poll every 90-120s. Never finish a turn asking the user a question — mailbox the coordinator if stuck.
+```
+
+Workers may occasionally address the user directly when the coordinator explicitly routes a question there, but the default interaction channel is async mailbox with the coordinator — **not** a trailing "do you want me to ...?" question that freezes the turn and blocks silently until someone happens to look.
+
+A worker that completes a turn with an open question to the user is a coordination failure, not a worker failure: the briefing was missing or too weak. Correct in two places — send a directed mailbox message unsticking the worker now, and tighten the briefing template (or this subsection) so future spawns inherit the rule automatically. See [`spawn-agent`'s "Headless operation" section](../spawn-agent/SKILL.md#headless-operation) for the per-state defaults (waiting-for-review, concern-not-Ship-it, CLI-rejected, work-complete).
 
 ### Model selection when spawning workers
 

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -133,6 +133,7 @@ Include this in every briefing:
   `/tmp/agent-mailbox/inbox/<ISO-timestamp>-my-agent-hello.md`
   describing what you picked up and your planned first step.
 - Poll the inbox every 90s for follow-up messages addressed to your handle.
+- Invoke `/loop` after hello; poll every 90-120s. Never finish a turn asking the user a question — mailbox the coordinator if stuck.
 ```
 
 Caller-side poll after spawn:
@@ -157,6 +158,19 @@ ps -eo pid,command | grep "twapp --name my-agent"       # the host process shoul
 ```
 
 If both look healthy but no hello lands within 2 min, assume the agent is blocked on a permission prompt or failed to cd. Stop it and re-spawn with corrected paths / settings.
+
+## Headless operation
+
+**Headless operation.** Every worker invokes `/loop` after its hello and operates autonomously. Never end a turn waiting for user input. If stuck, mailbox the coordinator. The coordinator decides when to escalate to the user.
+
+The failure mode this rule prevents: a worker finishes a turn with a trailing "do you want me to ...?" question and blocks silently until a human happens to look. The coordinator cannot supervise questions nobody sees. Post the question to the mailbox instead and let the next `/loop` tick wake the worker to handle the reply.
+
+Defaults for common wait states:
+
+- **Waiting for a review** → `/loop` every 90-120s until the review arrives or the user says stop.
+- **Reviewer posts a concern** rather than "Ship it" → address the concern or mailbox the coordinator; do not freeze the turn waiting for the user.
+- **CLI / `gh` / `git push` rejects the operation** → diagnose once; on the second failure, mailbox the coordinator. Do not retry indefinitely and do not prompt the user.
+- **Work complete** → post an offboard message and stop `/loop`. A quiet next poll is the signal the run ended cleanly.
 
 ## Shutdown
 


### PR DESCRIPTION
## Summary

- Add a **Headless operation** section to `skills/spawn-agent/SKILL.md` with the shared contract phrasing and per-state defaults (waiting-for-review, concern-not-Ship-it, CLI-rejected, work-complete). Thread the `/loop` mandate into the briefing-template Protocol block so every spawn-agent-produced briefing inherits it.
- Add a matching **Headless operation — worker contract** subsection under §2 *Briefing structure* in `skills/agent-coordinator/SKILL.md`, frame a worker-asks-the-user-a-question turn as a coordination failure (not a worker failure), and insert the same one-liner into the canonical briefing template's Protocol block so coordinator-written briefings inherit the rule.
- Both skills now carry the same canonical sentence in matching phrasing, so readers of either file see the same contract.

### Why

Earlier today an implementer finished a turn and asked the user "Do you want me to poll?" — blocking for ~9 minutes. The coordinator broadcast a runtime correction to running agents, but the merged skills themselves still lacked the rule, so a newly-spawned agent would repeat the mistake. This closes that gap at the source.

### Out of scope

- No `src/` or `src-tauri/` touches; docs-only.
- No rewrites of other skill sections.
- No changes to `docs/designs/`.

## Test plan

- [x] `skills/spawn-agent/SKILL.md` has a **Headless operation** top-level section.
- [x] `skills/agent-coordinator/SKILL.md` §2 has **Headless operation — worker contract** subsection.
- [x] Briefing-template Protocol blocks in both skills include the `/loop` one-liner.
- [x] Canonical sentence is identical across both skills ("Every worker invokes `/loop` after its hello and operates autonomously…").
- [x] No private-project references (grep clean).
- [ ] Reviewer confirms markdown renders cleanly in the GitHub preview.

## Coordinate with

- #44 (`twapp-coordinator-launch-cli`) — also touches skills. If #44 lands first I will rebase on updated skills and refine; if this lands first, #44 rebases.
- #45 (`twapp-readme-colab`) — README only; no conflict expected.