### PR TITLE
feat: lane-claim coordination primitive (twapp msg claim/release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,42 @@ get synthetic defaults (routine priority, no thread, id derived from the
 filename). This keeps day-one upgrades unbreaking; directory split and
 layout migration live in later PRs.
 
+### Lane claims — coordinating N workers on a shared queue
+
+When two or more sessions pull from the same list — reviewers against a
+PR queue, auditors against a backlog, implementers pulling from a
+prioritized task file — `twapp msg claim` / `release` adds an atomic
+"I got this" step before the work, so simultaneous workers don't
+double-up on the same item. The primitive is a POSIX-atomic `mkdir`
+into `<mailbox>/claims/<lane-id>/`, an `owner.json` written
+(tmp+rename) inside, and a `to: [all]` broadcast into the inbox so the
+event shows up in the normal message flow.
+
+```bash
+# Before each item: atomic claim. Exit 0 → proceed; exit 1 → skip.
+if twapp msg claim PR-91 --note "reviewing"; then
+  gh pr view 91
+  # ...post review...
+  twapp msg release PR-91 --note "review posted"
+fi
+
+# Who's working on what?
+twapp msg claim --list
+twapp msg claim --list --lane-prefix PR- --format json | jq
+
+# Stale-reclaim threshold (default 10 min). Match to your poll interval
+# so a busy peer isn't reclaimed mid-task.
+twapp msg claim audit-fees --stale-seconds 300
+```
+
+Only the current owner may release a lane. A claim whose `owner.json`
+is older than `--stale-seconds` and has no `released.json` is
+considered stale — any worker may force a re-claim, and the new owner
+records `reclaimed_from: <previous>` for the audit trail. See
+[`docs/designs/worker-coordination.md`](docs/designs/worker-coordination.md)
+for the full design (atomic-mkdir rationale, stale semantics, and
+what's out of scope).
+
 ## Spawning agent instances
 
 twapp works well as a terminal wrapper for *interactive* sessions, but it's
@@ -577,6 +613,9 @@ burns iteration.
 | `twapp msg send <to> [body]` | Send a message (writes to the shared mailbox inbox) |
 | `twapp msg broadcast [body]` | Broadcast to every handle (`to: [all]`) |
 | `twapp msg fetch [--for <h>] [--since <ts>]` | List inbox messages, filtered |
+| `twapp msg claim <lane-id> [--note <s>]` | Atomically claim a shared lane (PR, audit, backlog item); exit 1 if already claimed |
+| `twapp msg release <lane-id> [--note <s>]` | Release a lane you own; writes `released.json` and broadcasts the release |
+| `twapp msg claim --list [--lane-prefix <p>]` | List all active (unreleased, unstale) claims; `--format json` for machine-readable |
 | `twapp install-gui <binary>` | Install or update the app bundle |
 | `twapp setup-cert` | Create code signing certificate |
 | `twapp dev-reload --pid <pid>` | Rebuild and relaunch (dev workflow) |

--- a/docs/designs/worker-coordination.md
+++ b/docs/designs/worker-coordination.md
@@ -1,0 +1,212 @@
+# Design: Lane-claim coordination for N workers on a shared queue
+
+Status: **shipped** (initial primitive — `twapp msg claim / release`)
+Sibling doc: [`agent-messaging.md`](agent-messaging.md) — the broader
+filesystem-mailbox model this primitive plugs into.
+
+---
+
+## 0. Problem
+
+Two workers polling the same task queue will, given enough traffic, grab
+the same item at the same moment. Observed instance: two reviewer agents
+running simultaneously against the same PR list, both picking PR #91,
+both posting reviews, one's review arriving seconds after the other and
+fighting for the last-word.
+
+The pattern generalizes. Any N-worker-on-shared-queue scenario —
+reviewers on PRs, auditors on a backlog, implementers pulling from a
+prioritized list — needs a *claim* step before the *work* step, and a
+*release* step after the work is done, that is:
+
+- Atomic — simultaneous attempts resolve to exactly one winner.
+- Auditable — humans and other agents can see who claimed what and when.
+- Recoverable — a crashed claimant does not wedge the lane forever.
+- Lightweight — no new daemons, no new dependencies; plays with the
+  existing filesystem-mailbox convention.
+
+## 1. Design
+
+**Hybrid: filesystem-atomic race-resolver + message-log audit shadow.**
+
+### 1.1 Claim
+
+```
+<mailbox>/claims/<lane-id>/owner.json
+```
+
+`<lane-id>` is a caller-chosen string like `PR-91`, `audit-fees`, or
+`backlog-item-7`. A worker claims by:
+
+1. `std::fs::create_dir("<claims>/<lane-id>")`. POSIX `mkdir(2)` is
+   atomic — it succeeds exactly once across concurrent callers. The
+   winner is whichever process's syscall returned success.
+2. The winner atomically writes `owner.json` (tmp-file + rename) into
+   the newly created dir:
+   ```json
+   {
+     "owner": "twapp-reviewer",
+     "claimed_at": "2026-04-20T23:02:00Z",
+     "note": "starting review of PR #91"
+   }
+   ```
+3. Emit a `to: [all]` broadcast into `<mailbox>/inbox/` describing the
+   claim (see §1.4).
+
+Losing callers see `ErrorKind::AlreadyExists` and proceed to §1.3.
+
+### 1.2 Release
+
+Release writes a sibling file:
+
+```
+<mailbox>/claims/<lane-id>/released.json
+```
+
+```json
+{
+  "released_by": "twapp-reviewer",
+  "released_at": "2026-04-20T23:42:00Z",
+  "note": "review posted on PR #91"
+}
+```
+
+The directory is left in place as an audit trail. Only the current
+owner may release a lane.
+
+### 1.3 Contest & reclaim
+
+When `create_dir` fails with `AlreadyExists`, the losing caller reads
+the current `owner.json` (with a brief spin to wait out a concurrent
+writer's tmp-rename window) and branches:
+
+| State of `claims/<lane-id>/` | Action |
+|---|---|
+| `owner.json` present, no `released.json`, age ≤ `stale_seconds` | **Contest fails.** Print the current owner + age, exit 1. |
+| `owner.json` present, no `released.json`, age > `stale_seconds` | **Stale reclaim.** Overwrite `owner.json` with the new owner + `reclaimed_from: <previous-owner>` and `reclaimed_from_claimed_at: <previous-ts>`. Emit a reclaim broadcast. Exit 0. |
+| `released.json` present | **Re-claim after release.** Atomically rename the directory to `<lane-id>.released-<previous-claimed-at>/` (preserving the audit trail under a unique name), then retry the `create_dir` — this attempt succeeds. |
+
+Stale reclaim is the only write that is not mkdir-atomic. Two workers
+racing to reclaim the same stale lane can both win the `owner.json`
+write. The shadow broadcast (§1.4) makes the race observable, and the
+design is explicit that stale reclaims are coarse-grained coordination
+events — in practice stale reclaim happens when a worker has crashed or
+been force-killed, which is already rare.
+
+### 1.4 Message-log shadow
+
+Every claim / reclaim / release emits a `to: [all]` broadcast into the
+mailbox inbox using the standard `twapp msg` frontmatter shape:
+
+```
+---
+id: <ulid>
+from: twapp-reviewer
+to: [all]
+priority: routine
+subject: "claim lane PR-91"
+ts: 20260420T230200Z
+---
+
+claiming PR-91; will release when done. note: starting review of PR #91
+```
+
+This gives the "I got this, do you ack?" feel — other workers see the
+claim as a broadcast and can respond if they have a reason to contest,
+otherwise silent ack. The shadow is best-effort: a failed broadcast
+write is logged and does not fail the underlying claim (the claim is
+already recorded in `owner.json`).
+
+### 1.5 Stale threshold
+
+Default: **600 seconds (10 minutes).** Override via `--stale-seconds
+<N>`. This matches the rough timescale of "a worker crashed or wedged"
+while being short enough that humans don't wait hours to recover. When
+in doubt, pick a threshold slightly longer than the worker's own idle
+poll interval — otherwise a busy worker can be reclaimed mid-task by a
+peer who thinks it's dormant.
+
+## 2. CLI surface
+
+```
+twapp msg claim <lane-id> [--note <s>] [--stale-seconds <N>] [--from <h>]
+  → mkdir attempts. On success: writes owner.json, emits claim broadcast.
+    Prints "claimed: <lane-id> by <handle>". Exit 0.
+  → On stale: writes new owner.json with reclaimed_from, emits reclaim
+    broadcast. Prints "reclaimed: ...". Exit 0.
+  → On fresh contest: prints "already claimed: ...". Exit 1.
+
+twapp msg release <lane-id> [--note <s>] [--from <h>]
+  → Writes released.json, emits release broadcast. Exit 0.
+
+twapp msg claim --list [--lane-prefix <p>] [--format json|pretty]
+  → Prints all active (unreleased, unstale) claims.
+```
+
+`--from` defaults to the current session's `.twapp-session.json`
+`name` field, falling through to an explicit handle if required. Same
+resolution rule as `twapp msg send` / `broadcast`.
+
+### Recommended pattern (reviewer example)
+
+```bash
+# Before reviewing PR #N:
+if twapp msg claim PR-$N --note "reviewing"; then
+  gh pr view $N
+  # ...post review...
+  twapp msg release PR-$N --note "review posted"
+else
+  # exit 1 — another reviewer has it. Move on.
+  continue
+fi
+```
+
+Same shape for any N-worker queue: claim, work, release. Losing the
+claim race is a normal outcome, not an error — skip and poll the next
+item.
+
+## 3. What is NOT in scope
+
+- **Distributed locking across hosts.** `mkdir` is atomic per
+  filesystem; two machines with different mailbox volumes are two
+  independent coordination domains. A network filesystem with well-
+  behaved `O_CREAT | O_EXCL` semantics is the minimum cross-host story
+  and is not guaranteed by this design.
+- **Cryptographic ownership proof.** Anyone with filesystem access can
+  write any `owner.json`. This matches the existing mailbox's "filesystem
+  ACLs are the trust boundary" model.
+- **Priority / preemption of claims.** Claims are first-come-first-
+  served. A higher-priority worker cannot preempt a lower-priority one;
+  the stale-reclaim path is the only recovery primitive.
+- **Byzantine workers.** A malicious worker can claim lanes it has no
+  intention of working, release lanes it doesn't own via manual file
+  edits, etc. The shadow broadcasts make such behavior observable but
+  do not prevent it.
+- **Integration with GitHub review-assignment.** Using `gh api
+  /repos/.../pulls/N/requested_reviewers` to claim a PR is an orthogonal
+  path that happens *inside* GitHub's authorization model. This design
+  lives outside it and is therefore cheaper to deploy but less
+  authoritative.
+- **Archive rotation for released lanes.** The next claim attempt
+  renames `<lane-id>/` to `<lane-id>.released-<ts>/`. A periodic sweep
+  of `*.released-*/` older than some retention window is the obvious
+  maintenance task and is left to the coordinator's existing mailbox
+  janitor (see `agent-messaging.md`).
+
+## 4. Rationale — why not other shapes?
+
+- **Single `claim.json` with `rename` lock?** Requires an initial state
+  file that both cooperating and adversarial writers agree on, and the
+  POSIX rename semantics get subtle (e.g. `renameat2` with
+  `RENAME_NOREPLACE` is Linux-only). `mkdir` is universally atomic and
+  needs no seed state.
+- **Advisory lock via `flock`?** Dies with the process — no audit
+  trail, no post-mortem ownership record. The point of this design is
+  the audit trail as much as the atomicity.
+- **Database / Redis / queue service?** The goal is to keep the whole
+  multi-agent stack inspectable with `ls` and `cat`. A daemon is a
+  different project.
+- **Just use GitHub review-assignment?** Requires every worker to have
+  write access to the PR's repo and doesn't generalize to non-GitHub
+  queues (audit backlogs, implementation lists, etc.). This primitive
+  is complementary, not a replacement.

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -278,6 +278,79 @@ A PR with an explicit "Ship it" review that has not merged after ~20 minutes is 
 
 Always diagnose before spawning a replacement — duplicate work across two agents on the same branch is worse than a brief delay.
 
+## 8.5. N-worker coordination via lane claims
+
+When 2+ workers pull from the same shared queue — reviewers on a PR
+list, auditors on a backlog, implementers on a prioritized task list —
+nothing in the mailbox alone stops two of them from picking the same
+item. `twapp msg claim` / `release` adds that coordination primitive.
+
+### Mechanics
+
+- `twapp msg claim <lane-id> --note "<what I'm doing>"` — atomic-mkdir
+  race resolver. Exits 0 on a fresh claim or a stale-reclaim; exits 1
+  if the lane is already claimed by a live worker.
+- `twapp msg release <lane-id> --note "<done>"` — writes
+  `released.json` into the claim directory. The directory stays in
+  place as an audit trail; the next claim re-archives it.
+- `twapp msg claim --list [--lane-prefix PR-] [--format json]` — print
+  all active (unreleased, unstale) claims.
+
+Every claim / reclaim / release emits a `to: [all]` broadcast into the
+mailbox inbox so the event shows up in the normal message flow — the
+"I got this, do you ack?" handshake is visible to humans and other
+agents at the same time as the on-disk lock.
+
+### Reviewer-race example
+
+Before reviewing PR #N:
+
+```bash
+# Before starting work on PR #N
+if twapp msg claim PR-$N --note "reviewing"; then
+  # Exit 0 → we got the lane. Proceed with review.
+  gh pr view $N
+  # ...post review comments...
+  twapp msg release PR-$N --note "review posted"
+else
+  # Exit 1 → another reviewer has it. Skip and poll the next PR.
+  continue
+fi
+```
+
+Same shape for any N-worker queue: *claim, work, release.* Losing the
+claim race is a normal outcome — not an error; skip and move on.
+
+### Stale-claim recovery
+
+If `owner.json` is older than `--stale-seconds` (default 600) and no
+`released.json` has appeared, the claim is considered stale — the owner
+likely crashed, was force-killed, or wedged. Any worker may force a
+re-claim; the new `owner.json` records `reclaimed_from: <previous-
+owner>` and a reclaim broadcast posts to the mailbox so the
+coordinator and humans see it happened.
+
+Set `--stale-seconds` a bit larger than the worker's own idle poll
+interval (90-120s per this skill's mailbox protocol) — otherwise a busy
+worker can be reclaimed mid-task by a peer who thinks it's dormant.
+
+### Briefing instructions for consumers
+
+When briefing a worker whose job is to pull from a shared queue, add a
+concrete claim/release loop under `## Protocol`:
+
+```
+- Before each item, run `twapp msg claim <lane-id> --note "<short>"`.
+  On exit 0 proceed; on exit 1 skip the item and poll the next.
+- After posting results, run `twapp msg release <lane-id> --note "<short>"`.
+- If your /loop polls infrequently, pass `--stale-seconds <N>` where N
+  is ≥ your poll interval so peers don't reclaim mid-task.
+```
+
+See [`docs/designs/worker-coordination.md`](../../docs/designs/worker-coordination.md)
+for the full design (atomic mkdir rationale, stale-reclaim semantics,
+audit-trail layout, out-of-scope list).
+
 ## 9. Merge order and cross-worker coordination
 
 When two PRs touch overlapping files:

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -177,6 +177,32 @@ sleep 3 && kill -KILL $(pgrep -f 'twapp --name my-agent') 2>/dev/null
 
 Have the agent post an "offboard" message to the mailbox right before it exits, so callers can confirm the shutdown was clean and not a crash.
 
+## Coordinating N workers on a shared queue
+
+When you spawn two or more workers that pull from the same list —
+reviewers against a PR queue, auditors against a backlog, implementers
+against a prioritized task file — use `twapp msg claim` / `release`
+before each item so simultaneous workers don't grab the same one. The
+primitive is atomic (POSIX `mkdir`), emits a `to: [all]` broadcast for
+auditability, and recovers stale claims automatically.
+
+```bash
+# In each worker's briefing, before picking up an item:
+if twapp msg claim <lane-id> --note "starting"; then
+  # Exit 0 → proceed. Do the work.
+  twapp msg release <lane-id> --note "done"
+else
+  # Exit 1 → another worker has this lane. Skip and poll the next.
+  continue
+fi
+```
+
+Full pattern — reviewer-race example, stale-reclaim semantics, `--list`
+output, and briefing-template language — lives in the
+[`agent-coordinator`](../agent-coordinator/SKILL.md#85-n-worker-coordination-via-lane-claims)
+skill. See also [`docs/designs/worker-coordination.md`](../../docs/designs/worker-coordination.md)
+for the full design.
+
 ## Common pitfalls
 
 - **Missing `--cwd` when `--run` assumes a different directory.** Either pass `--cwd` to twapp or prefix `--run` with `cd /path && ...`. Don't assume the caller's shell cwd.

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod models;
 pub mod monitor;
 pub mod msg;
+pub mod msg_claim;
 pub mod notes;
 pub mod permissions;
 pub mod prompts;
@@ -446,6 +447,22 @@ pub fn run(cmd: Commands) -> i32 {
             } => msg::cmd_fetch(
                 for_handle, since, priority, thread, channel, mark_read, limit, format, all,
             ),
+            MsgCommands::Claim {
+                lane_id,
+                from,
+                note,
+                stale_seconds,
+                list,
+                lane_prefix,
+                format,
+            } => msg_claim::cmd_claim(
+                lane_id, from, note, stale_seconds, list, lane_prefix, format,
+            ),
+            MsgCommands::Release {
+                lane_id,
+                from,
+                note,
+            } => msg_claim::cmd_release(lane_id, from, note),
         },
         Commands::Models { command } => match command {
             ModelsCommands::List { provider, format } => models::cmd_list(provider, format),

--- a/src-tauri/src/cli/msg.rs
+++ b/src-tauri/src/cli/msg.rs
@@ -126,6 +126,52 @@ pub enum MsgCommands {
         /// Message body. Read from stdin if omitted.
         body: Option<String>,
     },
+    /// Claim a shared lane (PR, audit, backlog item) — atomic mkdir race resolver.
+    ///
+    /// Exits 0 on a fresh claim or a stale-reclaim. Exits 1 if the lane is
+    /// already claimed by a live worker. Emits a `to: [all]` broadcast into
+    /// the mailbox inbox so the event shows up in the normal message flow.
+    ///
+    /// See `docs/designs/worker-coordination.md` for the full design.
+    #[command(after_help = "Examples:\n  twapp msg claim PR-91 --note \"starting review\"\n  twapp msg claim audit-fees --stale-seconds 300\n  twapp msg claim --list\n  twapp msg claim --list --lane-prefix PR- --format json")]
+    Claim {
+        /// Lane id (e.g. PR-91, audit-fees, backlog-item-7). Required unless --list.
+        lane_id: Option<String>,
+        /// Sender handle. Defaults to the current .twapp-session.json name.
+        #[arg(long)]
+        from: Option<String>,
+        /// Note stored on the claim (and echoed in the broadcast).
+        #[arg(long)]
+        note: Option<String>,
+        /// Seconds before an unreleased claim is considered stale (default 600).
+        #[arg(long = "stale-seconds")]
+        stale_seconds: Option<u64>,
+        /// Print all active (unreleased, unstale) claims instead of claiming.
+        #[arg(long)]
+        list: bool,
+        /// When listing, restrict to lanes starting with this prefix.
+        #[arg(long = "lane-prefix")]
+        lane_prefix: Option<String>,
+        /// Output format for --list.
+        #[arg(long, value_enum, default_value_t = FetchFormat::Pretty)]
+        format: FetchFormat,
+    },
+    /// Release a previously-claimed lane.
+    ///
+    /// Writes `released.json` into the claim directory and broadcasts the
+    /// release. The directory is left in place as an audit trail; the next
+    /// claim attempt archives it under `<lane-id>.released-<ts>/`.
+    #[command(after_help = "Examples:\n  twapp msg release PR-91 --note \"review posted\"\n  twapp msg release audit-fees")]
+    Release {
+        /// Lane id to release (must match a live claim owned by --from).
+        lane_id: String,
+        /// Sender handle. Defaults to the current .twapp-session.json name.
+        #[arg(long)]
+        from: Option<String>,
+        /// Note stored on the release (and echoed in the broadcast).
+        #[arg(long)]
+        note: Option<String>,
+    },
     /// List messages from the mailbox inbox
     #[command(after_help = "Examples:\n  twapp msg fetch --for reviewer\n  twapp msg fetch --priority urgent\n  twapp msg fetch --since 20260420T180000Z --limit 10\n  twapp msg fetch --for reviewer --format json")]
     Fetch {

--- a/src-tauri/src/cli/msg_claim.rs
+++ b/src-tauri/src/cli/msg_claim.rs
@@ -1,0 +1,1169 @@
+//! `twapp msg claim` / `twapp msg release` — lane-claim coordination primitive.
+//!
+//! Purpose: when N workers share a task queue (reviewers on a PR queue,
+//! auditors working through a backlog, implementers pulling from a list),
+//! something has to stop two of them from grabbing the same item. This
+//! module is that "something".
+//!
+//! Design (see `docs/designs/worker-coordination.md`):
+//!
+//! - **Race resolver** — `std::fs::create_dir(<mailbox>/claims/<lane-id>)`.
+//!   POSIX mkdir is atomic, so it succeeds exactly once across concurrent
+//!   attempts. The worker that wins writes `owner.json` into the new dir.
+//! - **Release** — writes `released.json` into the same dir and leaves it
+//!   in place as an audit trail.
+//! - **Re-claim after release** — the next claim attempt atomically
+//!   renames the released dir to `<lane-id>.released-<claimed_at>` and
+//!   then creates the fresh dir, preserving history and the atomic mkdir
+//!   guarantee.
+//! - **Stale reclaim** — if `owner.json` is older than `stale_seconds` and
+//!   there is no `released.json`, any worker may force a re-claim by
+//!   overwriting `owner.json` with `reclaimed_from: <previous-owner>`.
+//! - **Message-log shadow** — every claim / reclaim / release emits a
+//!   `to: [all]` broadcast into the mailbox inbox so the event shows up
+//!   in the normal message flow.
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use super::msg::{
+    resolve_from, resolve_mailbox_dir, write_message, FetchFormat, MsgPriority, SendArgs,
+};
+
+// --- On-disk shapes --------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaimOwner {
+    pub owner: String,
+    /// RFC3339 UTC timestamp (e.g. `2026-04-20T23:02:00Z`).
+    pub claimed_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reclaimed_from: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reclaimed_from_claimed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ClaimRelease {
+    pub released_by: String,
+    pub released_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+/// Convenience view of a claim directory — what `--list` emits.
+#[derive(Debug, Clone, Serialize)]
+pub struct ClaimView {
+    pub lane_id: String,
+    pub owner: String,
+    pub claimed_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reclaimed_from: Option<String>,
+    pub age_seconds: i64,
+    pub stale: bool,
+}
+
+// --- Paths -----------------------------------------------------------------
+
+pub const DEFAULT_STALE_SECONDS: u64 = 600;
+
+pub fn claims_dir() -> Result<PathBuf, String> {
+    Ok(resolve_mailbox_dir()?.join("claims"))
+}
+
+fn owner_path(claims: &Path, lane_id: &str) -> PathBuf {
+    claims.join(lane_id).join("owner.json")
+}
+
+fn released_path(claims: &Path, lane_id: &str) -> PathBuf {
+    claims.join(lane_id).join("released.json")
+}
+
+// --- Lane id validation ----------------------------------------------------
+
+/// Characters permitted in a lane id: letters, digits, and `- _ . : # @`.
+/// Explicit allow-list keeps path separators, wildcards, null bytes, and
+/// shell metacharacters out of the mailbox tree.
+fn validate_lane_id(lane_id: &str) -> Result<(), String> {
+    if lane_id.is_empty() {
+        return Err("lane id is empty".to_string());
+    }
+    if lane_id == "." || lane_id == ".." {
+        return Err("lane id '.' and '..' are reserved".to_string());
+    }
+    if lane_id.len() > 128 {
+        return Err(format!(
+            "lane id '{}' is too long ({} > 128 chars)",
+            lane_id,
+            lane_id.len()
+        ));
+    }
+    let ok = lane_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | ':' | '#' | '@'));
+    if !ok {
+        return Err(format!(
+            "lane id '{}' contains disallowed characters (allowed: alnum, - _ . : # @)",
+            lane_id
+        ));
+    }
+    Ok(())
+}
+
+// --- Timestamps ------------------------------------------------------------
+
+/// RFC3339 UTC seconds precision (e.g. `2026-04-20T23:02:00Z`). Stable and
+/// cheap to parse back into a DateTime<Utc> for age math.
+pub fn current_rfc3339() -> String {
+    chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+fn age_seconds(claimed_at: &str) -> i64 {
+    match chrono::DateTime::parse_from_rfc3339(claimed_at) {
+        Ok(t) => (chrono::Utc::now() - t.with_timezone(&chrono::Utc)).num_seconds(),
+        Err(_) => 0,
+    }
+}
+
+// --- File IO helpers -------------------------------------------------------
+
+fn read_owner(claims: &Path, lane_id: &str) -> Option<ClaimOwner> {
+    let s = std::fs::read_to_string(owner_path(claims, lane_id)).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+fn read_release(claims: &Path, lane_id: &str) -> Option<ClaimRelease> {
+    let s = std::fs::read_to_string(released_path(claims, lane_id)).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+/// Atomic owner.json write: tmp-file + rename. Keeps a concurrent reader
+/// from ever observing a half-written file. Paired with `read_owner`'s
+/// brief poll on the "dir exists, owner.json not yet" race.
+fn write_owner(claims: &Path, lane_id: &str, owner: &ClaimOwner) -> Result<(), String> {
+    let lane_dir = claims.join(lane_id);
+    let final_path = lane_dir.join("owner.json");
+    let suffix: u64 = rand::random();
+    let tmp = lane_dir.join(format!("owner.json.tmp.{:016x}", suffix));
+    let json = serde_json::to_string_pretty(owner)
+        .map_err(|e| format!("serialize owner.json: {}", e))?;
+    std::fs::write(&tmp, json).map_err(|e| format!("write {}: {}", tmp.display(), e))?;
+    std::fs::rename(&tmp, &final_path).map_err(|e| {
+        let _ = std::fs::remove_file(&tmp);
+        format!("rename {} -> {}: {}", tmp.display(), final_path.display(), e)
+    })
+}
+
+/// Read `owner.json` with a short spin while a concurrent writer may
+/// still be finishing the tmp+rename. Returns None only if the file is
+/// still absent (or malformed) after the spin — genuine orphan state.
+fn read_owner_with_wait(claims: &Path, lane_id: &str) -> Option<ClaimOwner> {
+    // ~200ms total. The race window in practice is single-digit ms;
+    // anything longer means the writer crashed after create_dir.
+    for attempt in 0..20 {
+        if let Some(o) = read_owner(claims, lane_id) {
+            return Some(o);
+        }
+        if attempt < 19 {
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+    None
+}
+
+fn write_release(claims: &Path, lane_id: &str, rel: &ClaimRelease) -> Result<(), String> {
+    let path = released_path(claims, lane_id);
+    let json = serde_json::to_string_pretty(rel)
+        .map_err(|e| format!("serialize released.json: {}", e))?;
+    std::fs::write(&path, json).map_err(|e| format!("write {}: {}", path.display(), e))
+}
+
+/// Archive a released lane so a fresh `create_dir` can take the slot.
+/// The archive name preserves the previous owner's `claimed_at` so the
+/// directory listing reads chronologically. Falls back to random suffix
+/// on a name collision.
+fn archive_released_dir(claims: &Path, lane_id: &str, prev_claimed_at: &str) -> Result<(), String> {
+    let src = claims.join(lane_id);
+    let claimed_slug = prev_claimed_at.replace([':', '-'], "");
+    let base = claims.join(format!("{}.released-{}", lane_id, claimed_slug));
+    let dst = if base.exists() {
+        let suffix: u32 = rand::random();
+        claims.join(format!("{}.released-{}-{:08x}", lane_id, claimed_slug, suffix))
+    } else {
+        base
+    };
+    match std::fs::rename(&src, &dst) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            // Another worker already archived — treat as success and let
+            // the caller retry the mkdir.
+            Ok(())
+        }
+        Err(e) => Err(format!(
+            "archive released lane {} -> {}: {}",
+            src.display(),
+            dst.display(),
+            e
+        )),
+    }
+}
+
+// --- Outcome model ---------------------------------------------------------
+
+#[derive(Clone, PartialEq, Eq)]
+pub enum ClaimOutcome {
+    Claimed {
+        lane_id: String,
+        owner: ClaimOwner,
+    },
+    Reclaimed {
+        lane_id: String,
+        owner: ClaimOwner,
+        previous_owner: String,
+    },
+    AlreadyClaimed {
+        lane_id: String,
+        existing: ClaimOwner,
+        age_seconds: i64,
+    },
+}
+
+// --- Core claim logic ------------------------------------------------------
+
+pub struct ClaimRequest<'a> {
+    pub lane_id: &'a str,
+    pub from: &'a str,
+    pub note: Option<&'a str>,
+    pub stale_seconds: u64,
+}
+
+/// Attempt to claim `lane_id`. This is the filesystem-atomic core used by
+/// both `cmd_claim` and by tests. Does not emit broadcasts — callers are
+/// responsible for the mailbox shadow.
+pub fn try_claim(claims: &Path, req: &ClaimRequest) -> Result<ClaimOutcome, String> {
+    validate_lane_id(req.lane_id)?;
+    std::fs::create_dir_all(claims)
+        .map_err(|e| format!("create {}: {}", claims.display(), e))?;
+
+    // One retry is enough for the release→archive→claim path: the retry
+    // loop exists only so a concurrent archive doesn't wedge us.
+    for attempt in 0..3 {
+        let lane_dir = claims.join(req.lane_id);
+        match std::fs::create_dir(&lane_dir) {
+            Ok(()) => {
+                let owner = ClaimOwner {
+                    owner: req.from.to_string(),
+                    claimed_at: current_rfc3339(),
+                    note: req.note.map(|s| s.to_string()),
+                    reclaimed_from: None,
+                    reclaimed_from_claimed_at: None,
+                };
+                write_owner(claims, req.lane_id, &owner)?;
+                return Ok(ClaimOutcome::Claimed {
+                    lane_id: req.lane_id.to_string(),
+                    owner,
+                });
+            }
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                // Winner may still be in the tmp->rename window; spin briefly.
+                let existing = read_owner_with_wait(claims, req.lane_id).ok_or_else(|| {
+                    format!(
+                        "lane {} exists but owner.json is missing or malformed",
+                        req.lane_id
+                    )
+                })?;
+
+                if read_release(claims, req.lane_id).is_some() {
+                    // Released — archive and retry the mkdir.
+                    archive_released_dir(claims, req.lane_id, &existing.claimed_at)?;
+                    let _ = attempt; // next loop iteration re-attempts create_dir
+                    continue;
+                }
+
+                let age = age_seconds(&existing.claimed_at);
+                // age can be negative if the writer's clock was ahead of
+                // ours; treat that as "fresh, can't reclaim".
+                let is_stale = age > 0 && (age as u64) > req.stale_seconds;
+                if is_stale {
+                    // Stale: reclaim in place. This is not mkdir-atomic,
+                    // but stale reclaims are coarse-grained coordination
+                    // events that always emit a broadcast, so the audit
+                    // trail catches any lost-race duplication.
+                    let prev_owner = existing.owner.clone();
+                    let owner = ClaimOwner {
+                        owner: req.from.to_string(),
+                        claimed_at: current_rfc3339(),
+                        note: req.note.map(|s| s.to_string()),
+                        reclaimed_from: Some(prev_owner.clone()),
+                        reclaimed_from_claimed_at: Some(existing.claimed_at.clone()),
+                    };
+                    write_owner(claims, req.lane_id, &owner)?;
+                    return Ok(ClaimOutcome::Reclaimed {
+                        lane_id: req.lane_id.to_string(),
+                        owner,
+                        previous_owner: prev_owner,
+                    });
+                }
+
+                return Ok(ClaimOutcome::AlreadyClaimed {
+                    lane_id: req.lane_id.to_string(),
+                    existing,
+                    age_seconds: age,
+                });
+            }
+            Err(e) => {
+                return Err(format!("create {}: {}", lane_dir.display(), e));
+            }
+        }
+    }
+    Err(format!(
+        "lane {}: archive-and-retry loop did not converge",
+        req.lane_id
+    ))
+}
+
+/// Release a claim: writes `released.json` and leaves the directory in
+/// place. Returns an error if the lane is not currently claimed or the
+/// caller does not own it. Does not emit broadcasts.
+pub fn try_release(
+    claims: &Path,
+    lane_id: &str,
+    from: &str,
+    note: Option<&str>,
+) -> Result<ClaimRelease, String> {
+    validate_lane_id(lane_id)?;
+    let owner = read_owner(claims, lane_id)
+        .ok_or_else(|| format!("lane {} is not claimed", lane_id))?;
+    if read_release(claims, lane_id).is_some() {
+        return Err(format!("lane {} is already released", lane_id));
+    }
+    if owner.owner != from {
+        return Err(format!(
+            "lane {} is owned by {}, not {}",
+            lane_id, owner.owner, from
+        ));
+    }
+    let rel = ClaimRelease {
+        released_by: from.to_string(),
+        released_at: current_rfc3339(),
+        note: note.map(|s| s.to_string()),
+    };
+    write_release(claims, lane_id, &rel)?;
+    Ok(rel)
+}
+
+/// List active (unreleased, unstale) claims. The `stale_seconds` bound
+/// matches the one used by `try_claim` for reclaim decisions.
+pub fn list_active_claims(
+    claims: &Path,
+    lane_prefix: Option<&str>,
+    stale_seconds: u64,
+) -> Vec<ClaimView> {
+    let mut out: Vec<ClaimView> = Vec::new();
+    let Ok(entries) = std::fs::read_dir(claims) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        // Archived released dirs use `.released-` — filter out.
+        if name.contains(".released-") {
+            continue;
+        }
+        if let Some(prefix) = lane_prefix {
+            if !name.starts_with(prefix) {
+                continue;
+            }
+        }
+        let Some(owner) = read_owner(claims, name) else {
+            continue;
+        };
+        if read_release(claims, name).is_some() {
+            continue;
+        }
+        let age = age_seconds(&owner.claimed_at);
+        let is_stale = age > 0 && (age as u64) > stale_seconds;
+        if is_stale {
+            continue;
+        }
+        out.push(ClaimView {
+            lane_id: name.to_string(),
+            owner: owner.owner,
+            claimed_at: owner.claimed_at,
+            note: owner.note,
+            reclaimed_from: owner.reclaimed_from,
+            age_seconds: age,
+            stale: false,
+        });
+    }
+    out.sort_by(|a, b| a.claimed_at.cmp(&b.claimed_at).then_with(|| a.lane_id.cmp(&b.lane_id)));
+    out
+}
+
+// --- Broadcast shadow ------------------------------------------------------
+
+/// Write a `to: [all]` message into the mailbox inbox so human + agent
+/// observers see the claim event in the normal message flow. Failures
+/// are logged but never fail the underlying claim.
+fn broadcast_event(
+    mailbox: &Path,
+    from: &str,
+    subject: &str,
+    body: &str,
+) {
+    let inbox = mailbox.join("inbox");
+    let args = SendArgs {
+        to: vec!["all".to_string()],
+        from: from.to_string(),
+        priority: MsgPriority::Routine,
+        subject: Some(subject.to_string()),
+        thread: None,
+        in_reply_to: None,
+        cc: Vec::new(),
+        body: body.to_string(),
+    };
+    if let Err(e) = write_message(&inbox, args) {
+        eprintln!("warn: shadow broadcast failed: {}", e);
+    }
+}
+
+// --- CLI entry points ------------------------------------------------------
+
+pub fn cmd_claim(
+    lane_id: Option<String>,
+    from: Option<String>,
+    note: Option<String>,
+    stale_seconds: Option<u64>,
+    list: bool,
+    lane_prefix: Option<String>,
+    format: FetchFormat,
+) -> i32 {
+    let mailbox = match resolve_mailbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let claims = mailbox.join("claims");
+    let stale = stale_seconds.unwrap_or(DEFAULT_STALE_SECONDS);
+
+    if list {
+        let views = list_active_claims(&claims, lane_prefix.as_deref(), stale);
+        return match format {
+            FetchFormat::Json => match serde_json::to_string_pretty(&views) {
+                Ok(s) => {
+                    println!("{}", s);
+                    0
+                }
+                Err(e) => {
+                    eprintln!("Error serializing: {}", e);
+                    1
+                }
+            },
+            FetchFormat::Pretty => {
+                if views.is_empty() {
+                    println!("(no active claims)");
+                    return 0;
+                }
+                for v in &views {
+                    let reclaim_tag = v
+                        .reclaimed_from
+                        .as_deref()
+                        .map(|p| format!(" (reclaimed from {})", p))
+                        .unwrap_or_default();
+                    let note_tag = v
+                        .note
+                        .as_deref()
+                        .filter(|s| !s.is_empty())
+                        .map(|n| format!(" — {}", n))
+                        .unwrap_or_default();
+                    println!(
+                        "{}\t{}\tclaimed {} ({}s ago){}{}",
+                        v.lane_id, v.owner, v.claimed_at, v.age_seconds, reclaim_tag, note_tag
+                    );
+                }
+                0
+            }
+        };
+    }
+
+    let lane_id = match lane_id {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => {
+            eprintln!("Error: <lane-id> is required (or pass --list).");
+            return 1;
+        }
+    };
+    let from_handle = match resolve_from(from.as_deref()) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let req = ClaimRequest {
+        lane_id: lane_id.as_str(),
+        from: from_handle.as_str(),
+        note: note.as_deref(),
+        stale_seconds: stale,
+    };
+    match try_claim(&claims, &req) {
+        Ok(ClaimOutcome::Claimed { lane_id, owner }) => {
+            println!("claimed: {} by {}", lane_id, owner.owner);
+            let body = format!(
+                "claiming {}; will release when done.{}",
+                lane_id,
+                owner
+                    .note
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .map(|n| format!(" note: {}", n))
+                    .unwrap_or_default()
+            );
+            broadcast_event(
+                &mailbox,
+                &owner.owner,
+                &format!("claim lane {}", lane_id),
+                &body,
+            );
+            0
+        }
+        Ok(ClaimOutcome::Reclaimed {
+            lane_id,
+            owner,
+            previous_owner,
+        }) => {
+            println!(
+                "reclaimed: {} by {} (from stale owner {})",
+                lane_id, owner.owner, previous_owner
+            );
+            let body = format!(
+                "reclaimed {} from stale owner {}; will release when done.{}",
+                lane_id,
+                previous_owner,
+                owner
+                    .note
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .map(|n| format!(" note: {}", n))
+                    .unwrap_or_default()
+            );
+            broadcast_event(
+                &mailbox,
+                &owner.owner,
+                &format!("reclaim lane {}", lane_id),
+                &body,
+            );
+            0
+        }
+        Ok(ClaimOutcome::AlreadyClaimed {
+            lane_id,
+            existing,
+            age_seconds,
+        }) => {
+            eprintln!(
+                "already claimed: {} by {} ({}s ago)",
+                lane_id, existing.owner, age_seconds
+            );
+            1
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            1
+        }
+    }
+}
+
+pub fn cmd_release(lane_id: String, from: Option<String>, note: Option<String>) -> i32 {
+    let mailbox = match resolve_mailbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let claims = mailbox.join("claims");
+    let from_handle = match resolve_from(from.as_deref()) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    match try_release(&claims, &lane_id, &from_handle, note.as_deref()) {
+        Ok(rel) => {
+            println!("released: {} by {}", lane_id, rel.released_by);
+            let body = format!(
+                "released {}.{}",
+                lane_id,
+                rel.note
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .map(|n| format!(" note: {}", n))
+                    .unwrap_or_default()
+            );
+            broadcast_event(
+                &mailbox,
+                &rel.released_by,
+                &format!("release lane {}", lane_id),
+                &body,
+            );
+            0
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            1
+        }
+    }
+}
+
+// --- Claim-list format selector (clap bridge) ------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum ClaimListFormat {
+    Pretty,
+    Json,
+}
+
+impl From<ClaimListFormat> for FetchFormat {
+    fn from(f: ClaimListFormat) -> Self {
+        match f {
+            ClaimListFormat::Pretty => FetchFormat::Pretty,
+            ClaimListFormat::Json => FetchFormat::Json,
+        }
+    }
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::msg::parse_message_file;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    struct MailboxGuard {
+        root: PathBuf,
+        prev_mailbox: Option<String>,
+        prev_shared: Option<String>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl MailboxGuard {
+        fn new() -> Self {
+            let _guard = env_lock();
+            let root = std::env::temp_dir()
+                .join(format!("twapp-claim-test-{}", uuid::Uuid::new_v4()));
+            std::fs::create_dir_all(root.join("inbox")).unwrap();
+            std::fs::create_dir_all(root.join("claims")).unwrap();
+            let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
+            let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
+            std::env::set_var("TWAPP_MAILBOX_DIR", &root);
+            std::env::remove_var("TWAPP_SHARED_DIR");
+            MailboxGuard {
+                root,
+                prev_mailbox,
+                prev_shared,
+                _guard,
+            }
+        }
+
+        fn claims(&self) -> PathBuf {
+            self.root.join("claims")
+        }
+
+        fn inbox(&self) -> PathBuf {
+            self.root.join("inbox")
+        }
+    }
+
+    impl Drop for MailboxGuard {
+        fn drop(&mut self) {
+            match &self.prev_mailbox {
+                Some(v) => std::env::set_var("TWAPP_MAILBOX_DIR", v),
+                None => std::env::remove_var("TWAPP_MAILBOX_DIR"),
+            }
+            match &self.prev_shared {
+                Some(v) => std::env::set_var("TWAPP_SHARED_DIR", v),
+                None => std::env::remove_var("TWAPP_SHARED_DIR"),
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn req<'a>(lane_id: &'a str, from: &'a str) -> ClaimRequest<'a> {
+        ClaimRequest {
+            lane_id,
+            from,
+            note: None,
+            stale_seconds: DEFAULT_STALE_SECONDS,
+        }
+    }
+
+    // ---- Validation ------------------------------------------------------
+
+    #[test]
+    fn lane_id_rejects_path_separators_and_empty() {
+        assert!(validate_lane_id("").is_err());
+        assert!(validate_lane_id(".").is_err());
+        assert!(validate_lane_id("..").is_err());
+        assert!(validate_lane_id("a/b").is_err());
+        assert!(validate_lane_id("a\\b").is_err());
+        assert!(validate_lane_id("a b").is_err());
+        assert!(validate_lane_id("../escape").is_err());
+        assert!(validate_lane_id("PR-91").is_ok());
+        assert!(validate_lane_id("audit-fees").is_ok());
+        assert!(validate_lane_id("scope:sub.3").is_ok());
+        assert!(validate_lane_id("owner/repo#123").is_err());
+        assert!(validate_lane_id("owner_repo-123@ci").is_ok());
+    }
+
+    // ---- Fresh / existing-fresh -----------------------------------------
+
+    #[test]
+    fn claim_succeeds_on_fresh_lane() {
+        let g = MailboxGuard::new();
+        let r = req("PR-91", "reviewer-a");
+        let outcome = try_claim(&g.claims(), &r).unwrap();
+        match outcome {
+            ClaimOutcome::Claimed { lane_id, owner } => {
+                assert_eq!(lane_id, "PR-91");
+                assert_eq!(owner.owner, "reviewer-a");
+                assert!(owner.reclaimed_from.is_none());
+            }
+            other => panic!("expected Claimed, got {:?}", other),
+        }
+        let owner = read_owner(&g.claims(), "PR-91").unwrap();
+        assert_eq!(owner.owner, "reviewer-a");
+    }
+
+    #[test]
+    fn claim_fails_on_existing_fresh_claim() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "reviewer-a")).unwrap();
+        let outcome = try_claim(&g.claims(), &req("PR-91", "reviewer-b")).unwrap();
+        match outcome {
+            ClaimOutcome::AlreadyClaimed { lane_id, existing, .. } => {
+                assert_eq!(lane_id, "PR-91");
+                assert_eq!(existing.owner, "reviewer-a");
+            }
+            other => panic!("expected AlreadyClaimed, got {:?}", other),
+        }
+        // reviewer-a still owns it.
+        assert_eq!(read_owner(&g.claims(), "PR-91").unwrap().owner, "reviewer-a");
+    }
+
+    // ---- Concurrent claims resolve atomically ---------------------------
+
+    #[test]
+    fn concurrent_claims_produce_exactly_one_winner() {
+        let g = MailboxGuard::new();
+        let claims = g.claims();
+        let lane = "concurrent-lane";
+
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+        let handles: Vec<_> = (0..8)
+            .map(|i| {
+                let claims = claims.clone();
+                let barrier = std::sync::Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    let from = format!("worker-{}", i);
+                    try_claim(
+                        &claims,
+                        &ClaimRequest {
+                            lane_id: lane,
+                            from: &from,
+                            note: None,
+                            stale_seconds: DEFAULT_STALE_SECONDS,
+                        },
+                    )
+                    .unwrap()
+                })
+            })
+            .collect();
+        let outcomes: Vec<ClaimOutcome> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        let winners: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, ClaimOutcome::Claimed { .. }))
+            .collect();
+        let losers: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, ClaimOutcome::AlreadyClaimed { .. }))
+            .collect();
+        assert_eq!(winners.len(), 1, "outcomes: {:?}", outcomes);
+        assert_eq!(losers.len(), 7, "outcomes: {:?}", outcomes);
+    }
+
+    // ---- Stale reclaim ---------------------------------------------------
+
+    #[test]
+    fn claim_reclaims_stale_lane() {
+        let g = MailboxGuard::new();
+        // Seed a stale owner.json directly (claimed_at 1h ago, no release).
+        let claims = g.claims();
+        std::fs::create_dir_all(claims.join("audit-fees")).unwrap();
+        let stale = ClaimOwner {
+            owner: "original-owner".to_string(),
+            claimed_at: (chrono::Utc::now() - chrono::Duration::hours(1))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string(),
+            note: Some("original note".to_string()),
+            reclaimed_from: None,
+            reclaimed_from_claimed_at: None,
+        };
+        write_owner(&claims, "audit-fees", &stale).unwrap();
+
+        // Default stale threshold is 600s; 1h claim is stale.
+        let outcome = try_claim(&claims, &req("audit-fees", "new-owner")).unwrap();
+        match outcome {
+            ClaimOutcome::Reclaimed { owner, previous_owner, .. } => {
+                assert_eq!(owner.owner, "new-owner");
+                assert_eq!(owner.reclaimed_from.as_deref(), Some("original-owner"));
+                assert_eq!(previous_owner, "original-owner");
+            }
+            other => panic!("expected Reclaimed, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn stale_reclaim_respects_custom_threshold() {
+        let g = MailboxGuard::new();
+        let claims = g.claims();
+
+        // Seed a lane with a claimed_at 5s in the past — no sleep required.
+        std::fs::create_dir_all(claims.join("lane-x")).unwrap();
+        let seeded = ClaimOwner {
+            owner: "original".to_string(),
+            claimed_at: (chrono::Utc::now() - chrono::Duration::seconds(5))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string(),
+            note: None,
+            reclaimed_from: None,
+            reclaimed_from_claimed_at: None,
+        };
+        write_owner(&claims, "lane-x", &seeded).unwrap();
+
+        // Default 600s threshold treats a 5s claim as fresh.
+        let outcome = try_claim(&claims, &req("lane-x", "contender")).unwrap();
+        assert!(
+            matches!(outcome, ClaimOutcome::AlreadyClaimed { .. }),
+            "outcome: {:?}",
+            outcome
+        );
+
+        // A 3s threshold treats the same 5s claim as stale.
+        let outcome = try_claim(
+            &claims,
+            &ClaimRequest {
+                lane_id: "lane-x",
+                from: "contender-2",
+                note: None,
+                stale_seconds: 3,
+            },
+        )
+        .unwrap();
+        assert!(
+            matches!(outcome, ClaimOutcome::Reclaimed { .. }),
+            "outcome: {:?}",
+            outcome
+        );
+    }
+
+    // ---- Release / re-claim ---------------------------------------------
+
+    #[test]
+    fn release_marks_lane_available() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "reviewer-a")).unwrap();
+        let rel = try_release(&g.claims(), "PR-91", "reviewer-a", Some("done")).unwrap();
+        assert_eq!(rel.released_by, "reviewer-a");
+        assert_eq!(rel.note.as_deref(), Some("done"));
+        let read_back = read_release(&g.claims(), "PR-91").unwrap();
+        assert_eq!(read_back.released_by, "reviewer-a");
+    }
+
+    #[test]
+    fn release_refuses_non_owner() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "reviewer-a")).unwrap();
+        let err = try_release(&g.claims(), "PR-91", "reviewer-b", None).err().unwrap();
+        assert!(err.contains("owned by reviewer-a"), "err: {}", err);
+    }
+
+    #[test]
+    fn release_refuses_unclaimed_lane() {
+        let g = MailboxGuard::new();
+        let err = try_release(&g.claims(), "never-claimed", "anyone", None)
+            .err()
+            .unwrap();
+        assert!(err.contains("not claimed"), "err: {}", err);
+    }
+
+    #[test]
+    fn claim_after_release_succeeds() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "reviewer-a")).unwrap();
+        try_release(&g.claims(), "PR-91", "reviewer-a", None).unwrap();
+
+        let outcome = try_claim(&g.claims(), &req("PR-91", "reviewer-b")).unwrap();
+        match outcome {
+            ClaimOutcome::Claimed { owner, .. } => {
+                assert_eq!(owner.owner, "reviewer-b");
+                assert!(owner.reclaimed_from.is_none());
+            }
+            other => panic!("expected Claimed, got {:?}", other),
+        }
+        // The previous release is preserved under an archive name.
+        let archived: Vec<_> = std::fs::read_dir(g.claims())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().into_string().ok())
+            .filter(|n| n.starts_with("PR-91.released-"))
+            .collect();
+        assert_eq!(archived.len(), 1, "archived: {:?}", archived);
+    }
+
+    // ---- List active claims ----------------------------------------------
+
+    #[test]
+    fn claim_list_includes_active_excludes_released_and_stale() {
+        let g = MailboxGuard::new();
+        let claims = g.claims();
+
+        // Active.
+        try_claim(&claims, &req("PR-91", "reviewer-a")).unwrap();
+        try_claim(&claims, &req("PR-92", "reviewer-b")).unwrap();
+        // Released.
+        try_claim(&claims, &req("PR-93", "reviewer-c")).unwrap();
+        try_release(&claims, "PR-93", "reviewer-c", None).unwrap();
+        // Stale — seed directly with 1h-old claimed_at.
+        std::fs::create_dir_all(claims.join("audit-stale")).unwrap();
+        let stale = ClaimOwner {
+            owner: "ghost".to_string(),
+            claimed_at: (chrono::Utc::now() - chrono::Duration::hours(1))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string(),
+            note: None,
+            reclaimed_from: None,
+            reclaimed_from_claimed_at: None,
+        };
+        write_owner(&claims, "audit-stale", &stale).unwrap();
+
+        let views = list_active_claims(&claims, None, DEFAULT_STALE_SECONDS);
+        let names: Vec<_> = views.iter().map(|v| v.lane_id.as_str()).collect();
+        assert!(names.contains(&"PR-91"), "names: {:?}", names);
+        assert!(names.contains(&"PR-92"), "names: {:?}", names);
+        assert!(!names.contains(&"PR-93"), "names: {:?}", names);
+        assert!(!names.contains(&"audit-stale"), "names: {:?}", names);
+        assert_eq!(views.len(), 2);
+    }
+
+    #[test]
+    fn claim_list_filters_by_lane_prefix() {
+        let g = MailboxGuard::new();
+        let claims = g.claims();
+        try_claim(&claims, &req("PR-91", "a")).unwrap();
+        try_claim(&claims, &req("PR-92", "b")).unwrap();
+        try_claim(&claims, &req("audit-fees", "c")).unwrap();
+
+        let pr_only = list_active_claims(&claims, Some("PR-"), DEFAULT_STALE_SECONDS);
+        let names: Vec<_> = pr_only.iter().map(|v| v.lane_id.as_str()).collect();
+        assert_eq!(names, vec!["PR-91", "PR-92"]);
+    }
+
+    // ---- Broadcast shadow -----------------------------------------------
+
+    #[test]
+    fn claim_emits_broadcast_into_inbox() {
+        let g = MailboxGuard::new();
+        let exit = cmd_claim(
+            Some("PR-91".to_string()),
+            Some("reviewer-a".to_string()),
+            Some("reviewing".to_string()),
+            None,
+            false,
+            None,
+            FetchFormat::Pretty,
+        );
+        assert_eq!(exit, 0);
+
+        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1, "expected 1 broadcast");
+        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        assert_eq!(parsed.fm.from, "reviewer-a");
+        assert_eq!(parsed.fm.to, vec!["all"]);
+        assert_eq!(
+            parsed.fm.subject.as_deref(),
+            Some("claim lane PR-91"),
+            "fm: {:?}",
+            parsed.fm
+        );
+        assert!(parsed.body.contains("claiming PR-91"));
+    }
+
+    #[test]
+    fn release_emits_broadcast_into_inbox() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "reviewer-a")).unwrap();
+        let exit = cmd_release(
+            "PR-91".to_string(),
+            Some("reviewer-a".to_string()),
+            Some("shipped".to_string()),
+        );
+        assert_eq!(exit, 0);
+        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
+        // The cmd_release path emits exactly one broadcast; claims done
+        // via try_claim skip the broadcast.
+        assert_eq!(entries.len(), 1, "expected 1 broadcast");
+        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        assert_eq!(parsed.fm.subject.as_deref(), Some("release lane PR-91"));
+        assert!(parsed.body.contains("released PR-91"));
+    }
+
+    #[test]
+    fn reclaim_emits_reclaim_broadcast() {
+        let g = MailboxGuard::new();
+        let claims = g.claims();
+        // Seed a stale claim.
+        std::fs::create_dir_all(claims.join("lane-z")).unwrap();
+        let stale = ClaimOwner {
+            owner: "ghost".to_string(),
+            claimed_at: (chrono::Utc::now() - chrono::Duration::hours(1))
+                .format("%Y-%m-%dT%H:%M:%SZ")
+                .to_string(),
+            note: None,
+            reclaimed_from: None,
+            reclaimed_from_claimed_at: None,
+        };
+        write_owner(&claims, "lane-z", &stale).unwrap();
+
+        let exit = cmd_claim(
+            Some("lane-z".to_string()),
+            Some("new".to_string()),
+            None,
+            None,
+            false,
+            None,
+            FetchFormat::Pretty,
+        );
+        assert_eq!(exit, 0);
+        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
+        assert_eq!(entries.len(), 1);
+        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        assert_eq!(parsed.fm.subject.as_deref(), Some("reclaim lane lane-z"));
+        assert!(parsed.body.contains("reclaimed lane-z from stale owner ghost"));
+    }
+
+    // ---- cmd_claim exit codes -------------------------------------------
+
+    #[test]
+    fn cmd_claim_exits_1_on_existing_fresh_claim() {
+        let g = MailboxGuard::new();
+        let _ = g;
+        cmd_claim(
+            Some("PR-91".to_string()),
+            Some("a".to_string()),
+            None,
+            None,
+            false,
+            None,
+            FetchFormat::Pretty,
+        );
+        let exit = cmd_claim(
+            Some("PR-91".to_string()),
+            Some("b".to_string()),
+            None,
+            None,
+            false,
+            None,
+            FetchFormat::Pretty,
+        );
+        assert_eq!(exit, 1);
+    }
+
+    #[test]
+    fn cmd_claim_list_without_lane_id_succeeds() {
+        let g = MailboxGuard::new();
+        try_claim(&g.claims(), &req("PR-91", "a")).unwrap();
+        let exit = cmd_claim(
+            None,
+            Some("observer".to_string()),
+            None,
+            None,
+            true,
+            None,
+            FetchFormat::Json,
+        );
+        assert_eq!(exit, 0);
+    }
+
+    #[test]
+    fn cmd_claim_missing_lane_id_without_list_errors() {
+        let _g = MailboxGuard::new();
+        let exit = cmd_claim(
+            None,
+            Some("observer".to_string()),
+            None,
+            None,
+            false,
+            None,
+            FetchFormat::Pretty,
+        );
+        assert_eq!(exit, 1);
+    }
+}
+
+// Allow `Debug` on ClaimOutcome for panic messages in tests.
+impl std::fmt::Debug for ClaimOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ClaimOutcome::Claimed { lane_id, owner } => f
+                .debug_struct("Claimed")
+                .field("lane_id", lane_id)
+                .field("owner", &owner.owner)
+                .finish(),
+            ClaimOutcome::Reclaimed {
+                lane_id,
+                owner,
+                previous_owner,
+            } => f
+                .debug_struct("Reclaimed")
+                .field("lane_id", lane_id)
+                .field("owner", &owner.owner)
+                .field("previous_owner", previous_owner)
+                .finish(),
+            ClaimOutcome::AlreadyClaimed {
+                lane_id,
+                existing,
+                age_seconds,
+            } => f
+                .debug_struct("AlreadyClaimed")
+                .field("lane_id", lane_id)
+                .field("owner", &existing.owner)
+                .field("age_seconds", age_seconds)
+                .finish(),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `twapp msg claim <lane-id>` / `release <lane-id>` / `claim --list` — a filesystem-atomic lane-claim primitive for N workers pulling from a shared queue (reviewers on PRs, auditors on backlogs, implementers on task lists).
- Atomic resolver is POSIX `mkdir` of `<mailbox>/claims/<lane-id>/`; `owner.json` is written tmp+rename inside. Release writes a sibling `released.json`, leaves the dir in place as audit trail; next claim archives it to `<lane-id>.released-<ts>/`.
- Every claim / reclaim / release emits a `to: [all]` shadow broadcast into the mailbox inbox so the event is visible in the normal message flow — the "I got this, do you ack?" handshake is visible to humans + other agents at the same time as the on-disk lock.
- Stale reclaim (`--stale-seconds`, default 600) overwrites `owner.json` with `reclaimed_from: <previous-owner>` and emits a reclaim broadcast; this is the only non-mkdir-atomic path and is coarse-grained by design.
- Skills + docs: `agent-coordinator` gets §8.5 "N-worker coordination via lane claims" with a reviewer-race example; `spawn-agent` cross-refs it; new `docs/designs/worker-coordination.md` covers atomic-mkdir rationale, stale semantics, and out-of-scope list.

## Test plan

- [x] `cargo test --lib` — 68 passed (18 new in `cli::msg_claim::tests`).
- [x] Concurrent claim: 8-thread race with `std::sync::Barrier`; exactly one `Claimed` outcome, 7 `AlreadyClaimed`.
- [x] Release refuses non-owner + unclaimed lane.
- [x] Re-claim after release: previous dir is archived under `<lane>.released-<prev-claimed-at>`.
- [x] Stale-reclaim by seeded past `claimed_at` (no sleep — deterministic).
- [x] List excludes released + stale + non-matching prefix; emits valid JSON.
- [x] End-to-end CLI smoke: fresh claim → contest → list → release → re-claim → list --format json → 3 broadcasts in inbox + archive dir on disk.

## What's NOT in scope

Explicit in `docs/designs/worker-coordination.md` §3: distributed locking across hosts, cryptographic ownership proof, priority/preemption of claims, byzantine workers, GitHub review-assignment integration, periodic archive rotation (relies on the existing mailbox janitor).