### PR TITLE
feat(ui): message composer modal (send/broadcast)

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,12 @@ twapp msg fetch --since 20260420T120000Z --limit 20
 twapp msg fetch --for reviewer --format json | jq
 ```
 
+Inside a twapp session window, the same `send` / `broadcast` actions are
+reachable from the UI: **Actions ▸ Send Message…** or the keyboard
+shortcut **⌘⇧M** (Ctrl+Shift+M on non-Mac) opens a composer modal that
+shells out to `twapp msg` under the hood. `To: all` routes through
+`broadcast`; any other value goes through `send`.
+
 If `--from` is not passed, the sender handle is taken from the current
 directory's `.twapp-session.json` `name`. Bodies may be passed as a
 positional argument or piped in on stdin.

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod files;
 pub mod monitor;
+pub mod msg;
 pub mod notes;
 pub mod prompts;
 pub mod pty;
@@ -111,6 +112,7 @@ pub fn run(args: GuiArgs) {
             config::set_monitor_float,
             monitor::list_monitor_logs,
             files::reveal_in_finder,
+            msg::send_message,
         ])
         .setup(move |app| {
             // Set window title — this controls the Mission Control fullscreen space label

--- a/src-tauri/src/gui/msg.rs
+++ b/src-tauri/src/gui/msg.rs
@@ -79,6 +79,10 @@ fn validate(args: &SendArgs) -> Result<(), String> {
 }
 
 fn twapp_binary() -> std::path::PathBuf {
+    // Contract: the Tauri GUI binary dispatches the CLI via subcommand (see
+    // `src-tauri/src/lib.rs`), so `current_exe()` is the same `twapp` binary
+    // that exposes `msg send` / `msg broadcast`. If the GUI is ever split out
+    // into its own binary, point this at a resolved `twapp` in PATH instead.
     std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("twapp"))
 }
 
@@ -278,10 +282,21 @@ mod tests {
         path
     }
 
+    fn unique_tmp(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!("twapp-send-{}-{}-{}", tag, std::process::id(), nanos));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+        tmp
+    }
+
     #[test]
     fn fake_cli_success_returns_id() {
-        let tmp = std::env::temp_dir().join(format!("twapp-send-ok-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("ok");
         let bin = write_fake_bin(
             &tmp,
             "fake-twapp-ok",
@@ -290,12 +305,12 @@ mod tests {
         let argv = build_argv(&base());
         let id = run_with_fake_bin(&bin, argv, "hello").expect("should succeed");
         assert_eq!(id, "FAKEID42");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
     fn fake_cli_error_surfaces_stderr() {
-        let tmp = std::env::temp_dir().join(format!("twapp-send-err-{}", std::process::id()));
-        std::fs::create_dir_all(&tmp).unwrap();
+        let tmp = unique_tmp("err");
         let bin = write_fake_bin(
             &tmp,
             "fake-twapp-err",
@@ -304,5 +319,6 @@ mod tests {
         let argv = build_argv(&base());
         let err = run_with_fake_bin(&bin, argv, "hello").expect_err("should fail");
         assert!(err.contains("mailbox not found"), "expected stderr in error, got: {}", err);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src-tauri/src/gui/msg.rs
+++ b/src-tauri/src/gui/msg.rs
@@ -1,0 +1,308 @@
+//! Tauri command that shells out to `twapp msg send` / `twapp msg broadcast`.
+//!
+//! Invoked by the message composer modal (`src/components/MessageComposer.tsx`).
+//! Writes the message body through stdin so no shell-escaping is needed and
+//! large bodies do not hit argv length limits.
+
+use super::types::*;
+use serde::Deserialize;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendArgs {
+    /// Comma-separated recipient handles, or the literal string "all" for broadcast.
+    pub to: String,
+    /// "routine" | "urgent" | "blocker".
+    pub priority: String,
+    pub subject: Option<String>,
+    /// Stubbed in this PR — always None from the UI today. Wired for a later Reply-to flow.
+    pub thread: Option<String>,
+    pub cc: Option<String>,
+    pub body: String,
+}
+
+/// Build the argv handed to the child `twapp` process (without the body,
+/// which we pipe through stdin). Pure function so we can unit-test it.
+pub fn build_argv(args: &SendArgs) -> Vec<String> {
+    let mut argv = vec!["msg".to_string()];
+    let to_trimmed = args.to.trim();
+    let is_broadcast = to_trimmed.eq_ignore_ascii_case("all");
+    if is_broadcast {
+        argv.push("broadcast".to_string());
+    } else {
+        argv.push("send".to_string());
+        argv.push(to_trimmed.to_string());
+    }
+    argv.push("--priority".to_string());
+    argv.push(args.priority.to_lowercase());
+    if let Some(s) = args.subject.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        argv.push("--subject".to_string());
+        argv.push(s.to_string());
+    }
+    if !is_broadcast {
+        if let Some(t) = args.thread.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+            argv.push("--thread".to_string());
+            argv.push(t.to_string());
+        }
+        if let Some(c) = args.cc.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+            argv.push("--cc".to_string());
+            argv.push(c.to_string());
+        }
+    }
+    argv
+}
+
+/// Extract the message id from `twapp msg send` stdout: `Sent <path> (<id>)`.
+pub fn parse_sent_id(stdout: &str) -> Option<String> {
+    let line = stdout.lines().find(|l| l.starts_with("Sent "))?;
+    let open = line.rfind('(')?;
+    let close = line.rfind(')')?;
+    if close <= open + 1 {
+        return None;
+    }
+    Some(line[open + 1..close].to_string())
+}
+
+fn validate(args: &SendArgs) -> Result<(), String> {
+    if args.to.trim().is_empty() {
+        return Err("Recipient is required (handle or \"all\")".into());
+    }
+    if args.body.trim().is_empty() {
+        return Err("Message body cannot be empty".into());
+    }
+    match args.priority.to_lowercase().as_str() {
+        "routine" | "urgent" | "blocker" => Ok(()),
+        other => Err(format!("Unknown priority: {}", other)),
+    }
+}
+
+fn twapp_binary() -> std::path::PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("twapp"))
+}
+
+/// Run the `twapp msg` subprocess and return the id on success.
+fn run(argv: Vec<String>, body: &str, cwd: Option<&str>) -> Result<String, String> {
+    let bin = twapp_binary();
+    let mut cmd = Command::new(&bin);
+    cmd.args(&argv).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if let Some(d) = cwd {
+        cmd.current_dir(d);
+    }
+    let mut child = cmd.spawn().map_err(|e| format!("Failed to launch {}: {}", bin.display(), e))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(body.as_bytes()).map_err(|e| format!("Failed to pipe body: {}", e))?;
+    }
+    let out = child.wait_with_output().map_err(|e| format!("Failed waiting for twapp: {}", e))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("twapp msg exited with {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    parse_sent_id(&stdout).ok_or_else(|| format!("Could not parse message id from output: {}", stdout.trim()))
+}
+
+#[tauri::command]
+pub fn send_message(
+    args: SendArgs,
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<String, String> {
+    validate(&args)?;
+    let argv = build_argv(&args);
+    run(argv, &args.body, config.cwd.as_deref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn base() -> SendArgs {
+        SendArgs {
+            to: "reviewer".into(),
+            priority: "routine".into(),
+            subject: None,
+            thread: None,
+            cc: None,
+            body: "hello".into(),
+        }
+    }
+
+    #[test]
+    fn argv_direct_minimal() {
+        let a = base();
+        assert_eq!(build_argv(&a), vec!["msg", "send", "reviewer", "--priority", "routine"]);
+    }
+
+    #[test]
+    fn argv_broadcast_when_to_is_all() {
+        let a = SendArgs { to: "all".into(), ..base() };
+        let argv = build_argv(&a);
+        assert_eq!(argv[0], "msg");
+        assert_eq!(argv[1], "broadcast");
+        assert!(!argv.iter().any(|s| s == "send"));
+        assert!(argv.iter().any(|s| s == "--priority"));
+    }
+
+    #[test]
+    fn argv_broadcast_is_case_insensitive() {
+        let a = SendArgs { to: "ALL".into(), ..base() };
+        assert_eq!(build_argv(&a)[1], "broadcast");
+    }
+
+    #[test]
+    fn argv_broadcast_drops_thread_and_cc() {
+        let a = SendArgs {
+            to: "all".into(),
+            thread: Some("01JS".into()),
+            cc: Some("x,y".into()),
+            ..base()
+        };
+        let argv = build_argv(&a);
+        assert!(!argv.iter().any(|s| s == "--thread"));
+        assert!(!argv.iter().any(|s| s == "--cc"));
+    }
+
+    #[test]
+    fn argv_includes_subject_thread_cc_on_send() {
+        let a = SendArgs {
+            subject: Some("build broke".into()),
+            thread: Some("01JS4M7Q8W".into()),
+            cc: Some("qa,arch".into()),
+            ..base()
+        };
+        let argv = build_argv(&a);
+        assert!(argv.windows(2).any(|w| w[0] == "--subject" && w[1] == "build broke"));
+        assert!(argv.windows(2).any(|w| w[0] == "--thread" && w[1] == "01JS4M7Q8W"));
+        assert!(argv.windows(2).any(|w| w[0] == "--cc" && w[1] == "qa,arch"));
+    }
+
+    #[test]
+    fn argv_skips_empty_optional_fields() {
+        let a = SendArgs {
+            subject: Some("   ".into()),
+            thread: Some("".into()),
+            cc: Some("  ".into()),
+            ..base()
+        };
+        let argv = build_argv(&a);
+        assert!(!argv.iter().any(|s| s == "--subject"));
+        assert!(!argv.iter().any(|s| s == "--thread"));
+        assert!(!argv.iter().any(|s| s == "--cc"));
+    }
+
+    #[test]
+    fn argv_priority_normalized_to_lowercase() {
+        let a = SendArgs { priority: "URGENT".into(), ..base() };
+        let argv = build_argv(&a);
+        let i = argv.iter().position(|s| s == "--priority").unwrap();
+        assert_eq!(argv[i + 1], "urgent");
+    }
+
+    #[test]
+    fn parse_id_success() {
+        let out = "Sent /tmp/mailbox/inbox/20260421T080000Z-ABCDEF.md (ABCDEFGHJKMNPQRSTVWX)\n";
+        assert_eq!(parse_sent_id(out).as_deref(), Some("ABCDEFGHJKMNPQRSTVWX"));
+    }
+
+    #[test]
+    fn parse_id_ignores_leading_noise() {
+        let out = "warning: PATH is weird\nSent /m/inbox/x.md (XYZ123)\n";
+        assert_eq!(parse_sent_id(out).as_deref(), Some("XYZ123"));
+    }
+
+    #[test]
+    fn parse_id_missing_returns_none() {
+        assert_eq!(parse_sent_id("no match here\n"), None);
+        assert_eq!(parse_sent_id("Sent /x/y.md\n"), None);
+        assert_eq!(parse_sent_id(""), None);
+    }
+
+    #[test]
+    fn validate_requires_recipient() {
+        let a = SendArgs { to: "   ".into(), ..base() };
+        assert!(validate(&a).is_err());
+    }
+
+    #[test]
+    fn validate_requires_body() {
+        let a = SendArgs { body: "\n\n  ".into(), ..base() };
+        assert!(validate(&a).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_priority() {
+        let a = SendArgs { priority: "maybe".into(), ..base() };
+        assert!(validate(&a).is_err());
+    }
+
+    #[test]
+    fn validate_accepts_priority_mixed_case() {
+        for p in ["Routine", "URGENT", "blocker"] {
+            let a = SendArgs { priority: p.into(), ..base() };
+            assert!(validate(&a).is_ok(), "expected {} to validate", p);
+        }
+    }
+
+    // Integration: mock the CLI by pointing at a shell script that mimics
+    // twapp's "Sent <path> (<id>)" stdout or emits stderr on --fail.
+    fn run_with_fake_bin(bin: &std::path::Path, argv: Vec<String>, body: &str) -> Result<String, String> {
+        let mut cmd = Command::new(bin);
+        cmd.args(&argv).stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::piped());
+        let mut child = cmd.spawn().map_err(|e| e.to_string())?;
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(body.as_bytes()).map_err(|e| e.to_string())?;
+        }
+        let out = child.wait_with_output().map_err(|e| e.to_string())?;
+        if !out.status.success() {
+            return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+        }
+        let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+        parse_sent_id(&stdout).ok_or_else(|| format!("no id in: {}", stdout.trim()))
+    }
+
+    fn write_fake_bin(tmp: &std::path::Path, name: &str, script: &str) -> std::path::PathBuf {
+        let path = tmp.join(name);
+        std::fs::write(&path, script).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn fake_cli_success_returns_id() {
+        let tmp = std::env::temp_dir().join(format!("twapp-send-ok-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin = write_fake_bin(
+            &tmp,
+            "fake-twapp-ok",
+            "#!/bin/sh\necho 'Sent /tmp/mailbox/inbox/X.md (FAKEID42)'\nexit 0\n",
+        );
+        let argv = build_argv(&base());
+        let id = run_with_fake_bin(&bin, argv, "hello").expect("should succeed");
+        assert_eq!(id, "FAKEID42");
+    }
+
+    #[test]
+    fn fake_cli_error_surfaces_stderr() {
+        let tmp = std::env::temp_dir().join(format!("twapp-send-err-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let bin = write_fake_bin(
+            &tmp,
+            "fake-twapp-err",
+            "#!/bin/sh\necho 'Error: mailbox not found' 1>&2\nexit 1\n",
+        );
+        let argv = build_argv(&base());
+        let err = run_with_fake_bin(&bin, argv, "hello").expect_err("should fail");
+        assert!(err.contains("mailbox not found"), "expected stderr in error, got: {}", err);
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -4331,6 +4331,14 @@ a.file-link {
   cursor: not-allowed;
 }
 
+.actions-menu-shortcut {
+  float: right;
+  color: var(--text-muted);
+  font-size: 11px;
+  margin-left: 12px;
+  letter-spacing: 0.02em;
+}
+
 .composer-toast {
   position: fixed;
   bottom: 24px;

--- a/src/App.css
+++ b/src/App.css
@@ -4163,3 +4163,186 @@ a.file-link {
   color: var(--text-secondary);
   line-height: 1.4;
 }
+
+/* Message Composer Modal */
+.composer-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.composer-panel {
+  width: 520px;
+  max-width: 92vw;
+  max-height: 90vh;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.composer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border-color);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 14px;
+}
+
+.composer-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  line-height: 1;
+  border-radius: 4px;
+  font-size: 14px;
+}
+
+.composer-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.composer-body {
+  padding: 14px 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+
+.composer-label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.composer-input {
+  padding: 7px 9px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.composer-input:focus {
+  outline: none;
+  border-color: var(--accent-color, var(--text-primary));
+}
+
+.composer-input-disabled,
+.composer-input:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.composer-input::placeholder {
+  color: var(--text-muted);
+}
+
+.composer-textarea {
+  padding: 9px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: none;
+  letter-spacing: normal;
+  resize: vertical;
+  min-height: 160px;
+}
+
+.composer-textarea:focus {
+  outline: none;
+  border-color: var(--accent-color, var(--text-primary));
+}
+
+.composer-error {
+  padding: 8px 10px;
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.35);
+  color: #dc2626;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.composer-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.composer-cancel,
+.composer-submit {
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.composer-cancel:hover:not(:disabled) {
+  background: var(--bg-tertiary, var(--bg-primary));
+}
+
+.composer-submit {
+  background: var(--accent-color, #2563eb);
+  border-color: var(--accent-color, #2563eb);
+  color: #fff;
+  font-weight: 600;
+}
+
+.composer-submit:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+.composer-submit:disabled,
+.composer-cancel:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.composer-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.22);
+  z-index: 310;
+  cursor: pointer;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { renderJsonNode, renderYamlNode } from "./components/FilePreview/rendere
 import PromptSections from "./components/PromptSections";
 import type { EditingPromptState } from "./components/PromptSections";
 import SessionLauncher from "./components/SessionLauncher";
+import MessageComposer from "./components/MessageComposer";
 
 
 const SESSION_COLORS = [
@@ -126,6 +127,10 @@ function App() {
 
   // Actions dropdown
   const [actionsOpen, setActionsOpen] = useState(false);
+
+  // Message composer modal
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerToast, setComposerToast] = useState<string | null>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
 
   // Session settings popover
@@ -939,6 +944,11 @@ function App() {
       if (e.key === "N" || (e.shiftKey && e.key === "n")) {
         e.preventDefault();
         invoke("fork_session", { ticketKey: null }).catch(console.error);
+      }
+      // Cmd+Shift+M — open message composer
+      if (e.key === "M" || (e.shiftKey && e.key === "m")) {
+        e.preventDefault();
+        setComposerOpen(true);
       }
       // Cmd+Shift+] — next tab
       if (e.key === "}" || (e.shiftKey && e.key === "]")) {
@@ -2245,6 +2255,9 @@ function App() {
                     <button className="actions-menu-item" onClick={() => { setActionsOpen(false); setShowForkDialog(true); }}>
                       Fork Session...
                     </button>
+                    <button className="actions-menu-item" onClick={() => { setActionsOpen(false); setComposerOpen(true); }}>
+                      Send Message...
+                    </button>
                     <div className="actions-menu-separator" />
                     <button
                       className="actions-menu-item"
@@ -2930,6 +2943,21 @@ function App() {
               )}
             </div>
           </div>
+        </div>
+      )}
+
+      <MessageComposer
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+        onSent={(id) => {
+          setComposerToast(id);
+          window.setTimeout(() => setComposerToast(null), 4000);
+        }}
+      />
+
+      {composerToast && (
+        <div className="composer-toast" onClick={() => setComposerToast(null)}>
+          Message sent (id: {composerToast.slice(0, 6)})
         </div>
       )}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,7 @@ function App() {
   // Message composer modal
   const [composerOpen, setComposerOpen] = useState(false);
   const [composerToast, setComposerToast] = useState<string | null>(null);
+  const composerToastTimer = useRef<number | null>(null);
   const actionsRef = useRef<HTMLDivElement>(null);
 
   // Session settings popover
@@ -2256,7 +2257,7 @@ function App() {
                       Fork Session...
                     </button>
                     <button className="actions-menu-item" onClick={() => { setActionsOpen(false); setComposerOpen(true); }}>
-                      Send Message...
+                      Send Message... <span className="actions-menu-shortcut">⌘⇧M</span>
                     </button>
                     <div className="actions-menu-separator" />
                     <button
@@ -2950,8 +2951,14 @@ function App() {
         open={composerOpen}
         onClose={() => setComposerOpen(false)}
         onSent={(id) => {
+          if (composerToastTimer.current !== null) {
+            window.clearTimeout(composerToastTimer.current);
+          }
           setComposerToast(id);
-          window.setTimeout(() => setComposerToast(null), 4000);
+          composerToastTimer.current = window.setTimeout(() => {
+            setComposerToast(null);
+            composerToastTimer.current = null;
+          }, 4000);
         }}
       />
 

--- a/src/components/MessageComposer.test.ts
+++ b/src/components/MessageComposer.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { validateArgs, type SendArgs } from "./MessageComposer";
+
+const base: SendArgs = {
+  to: "reviewer",
+  priority: "routine",
+  body: "hello",
+};
+
+describe("validateArgs", () => {
+  it("accepts minimal valid args", () => {
+    expect(validateArgs(base)).toBeNull();
+  });
+
+  it("accepts broadcast (to: all)", () => {
+    expect(validateArgs({ ...base, to: "all" })).toBeNull();
+  });
+
+  it("rejects empty recipient", () => {
+    expect(validateArgs({ ...base, to: "" })).toMatch(/Recipient/i);
+    expect(validateArgs({ ...base, to: "   " })).toMatch(/Recipient/i);
+  });
+
+  it("rejects empty body", () => {
+    expect(validateArgs({ ...base, body: "" })).toMatch(/body/i);
+    expect(validateArgs({ ...base, body: "\n  \n" })).toMatch(/body/i);
+  });
+
+  it("ignores optional fields when blank", () => {
+    expect(
+      validateArgs({ ...base, subject: "", thread: "", cc: "" }),
+    ).toBeNull();
+  });
+});

--- a/src/components/MessageComposer.tsx
+++ b/src/components/MessageComposer.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export type MessagePriority = "routine" | "urgent" | "blocker";
+
+export type SendArgs = {
+  to: string;
+  priority: MessagePriority;
+  subject?: string;
+  thread?: string;
+  cc?: string;
+  body: string;
+};
+
+type MessageComposerProps = {
+  open: boolean;
+  onClose: () => void;
+  onSent?: (id: string) => void;
+  initialTo?: string;
+  initialThread?: string;
+  initialReplyToSubject?: string;
+};
+
+export function validateArgs(args: SendArgs): string | null {
+  if (!args.to.trim()) return "Recipient is required (handle or \"all\")";
+  if (!args.body.trim()) return "Message body cannot be empty";
+  return null;
+}
+
+export default function MessageComposer({
+  open,
+  onClose,
+  onSent,
+  initialTo = "",
+  initialThread = "",
+  initialReplyToSubject = "",
+}: MessageComposerProps) {
+  const [to, setTo] = useState(initialTo);
+  const [priority, setPriority] = useState<MessagePriority>("routine");
+  const [subject, setSubject] = useState(initialReplyToSubject);
+  const [thread, setThread] = useState(initialThread);
+  const [cc, setCc] = useState("");
+  const [body, setBody] = useState("");
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setTo(initialTo);
+    setSubject(initialReplyToSubject);
+    setThread(initialThread);
+    setPriority("routine");
+    setCc("");
+    setBody("");
+    setError(null);
+    setSending(false);
+    setTimeout(() => toRef.current?.focus(), 0);
+  }, [open, initialTo, initialReplyToSubject, initialThread]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const submit = async () => {
+    const args: SendArgs = {
+      to: to.trim(),
+      priority,
+      subject: subject.trim() || undefined,
+      thread: thread.trim() || undefined,
+      cc: cc.trim() || undefined,
+      body,
+    };
+    const validationError = validateArgs(args);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setSending(true);
+    setError(null);
+    try {
+      const id = await invoke<string>("send_message", { args });
+      onSent?.(id);
+      onClose();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const onBodyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      if (!sending) submit();
+    }
+  };
+
+  return (
+    <div className="composer-overlay" onClick={onClose}>
+      <div className="composer-panel" onClick={(e) => e.stopPropagation()}>
+        <div className="composer-header">
+          <span>Send Message</span>
+          <button className="composer-close" onClick={onClose} aria-label="Close">
+            x
+          </button>
+        </div>
+        <div className="composer-body">
+          <label className="composer-label">
+            To
+            <input
+              ref={toRef}
+              type="text"
+              className="composer-input"
+              placeholder='handle, or "all" for broadcast'
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+            />
+          </label>
+          <label className="composer-label">
+            Priority
+            <select
+              className="composer-input"
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as MessagePriority)}
+            >
+              <option value="routine">routine</option>
+              <option value="urgent">urgent</option>
+              <option value="blocker">blocker</option>
+            </select>
+          </label>
+          <label className="composer-label">
+            Subject
+            <input
+              type="text"
+              className="composer-input"
+              placeholder="optional — one line"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+            />
+          </label>
+          <label className="composer-label">
+            Thread
+            <input
+              type="text"
+              className="composer-input composer-input-disabled"
+              placeholder="prefilled when replying to an inbox message"
+              value={thread}
+              onChange={(e) => setThread(e.target.value)}
+              disabled
+              title="Reply-to threading lands in a follow-up PR"
+            />
+          </label>
+          <label className="composer-label">
+            cc
+            <input
+              type="text"
+              className="composer-input"
+              placeholder="comma-separated handles — optional"
+              value={cc}
+              onChange={(e) => setCc(e.target.value)}
+            />
+          </label>
+          <label className="composer-label">
+            Body
+            <textarea
+              className="composer-textarea"
+              placeholder="Markdown body. Cmd/Ctrl+Enter to send."
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              onKeyDown={onBodyKeyDown}
+              rows={10}
+            />
+          </label>
+          {error && <div className="composer-error">{error}</div>}
+          <div className="composer-actions">
+            <button className="composer-cancel" onClick={onClose} disabled={sending}>
+              Cancel
+            </button>
+            <button className="composer-submit" onClick={submit} disabled={sending}>
+              {sending ? "Sending..." : "Send"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a modal in the session window (Actions ▸ **Send Message…** / **⌘⇧M**) that wraps `twapp msg send` / `twapp msg broadcast`. When `To` is `all` the body routes through `broadcast`; anything else goes through `send`.
- New Tauri command `send_message` shells out to the running `twapp` binary (via `std::env::current_exe()`), pipes the body through stdin (no argv length / shell-escape issues), parses the `Sent <path> (<id>)` stdout, and returns the 20-char id to the UI. Stderr is surfaced verbatim on CLI failure.
- Part of `docs/designs/agent-aware-ui.md` §5 — narrowed to the composer pane only per briefing. Inbox / broadcast / urgent / thread viewers and rich-text remain out of scope and land in wave-2 PRs.

## UX

- **Fields:** `To` (handle or `all`), `Priority` (routine/urgent/blocker, default routine), `Subject` (optional), `Thread` (disabled — reserved for a later Reply-to entry point per the briefing), `cc` (comma-separated), `Body` (plain markdown-ready textarea).
- **Validation:** recipient required, body required, priority must be routine/urgent/blocker. Errors render inline in the modal.
- **Keyboard:** `⌘⇧M` opens the modal, `Esc` closes, `⌘/Ctrl + Enter` submits from the body.
- **Discovery:** new **Send Message…** entry in the Actions dropdown next to Fork Session.
- **Feedback:** on success, a transient bottom-of-window toast `Message sent (id: <short>)` that auto-dismisses after 4s (or on click). On failure, inline modal error with the CLI's stderr.

## Test plan

- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib` — **127 passed**, includes 16 new in `gui::msg::tests`:
  - argv build: direct vs broadcast (incl. case-insensitive `all`), thread/cc dropped on broadcast, optional trimming, priority lowercased.
  - `parse_sent_id` — happy path, leading noise, missing-id returns None.
  - Validation — empty recipient / empty body / unknown priority / mixed-case priorities accepted.
  - Integration via a tempdir `fake-twapp` shell script: success path returns parsed id; failure path surfaces stderr contents.
- [x] `npm test` (vitest) — **85 passed**, includes 5 new for `validateArgs` (minimal valid, `all` accepted, empty recipient, empty body, optional blanks ignored).
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run dev` + `curl` smoke — Vite serves the component without a transform error.
- [ ] Manual GUI walkthrough (reviewer): `npm run tauri build && twapp install-gui ...` then exercise Actions ▸ Send Message, `⌘⇧M`, routine/urgent/blocker, `all` → broadcast, empty-recipient + empty-body validation banners, stderr surfacing (point `twapp` at an unreachable mailbox).

## Out of scope (per briefing)

- Inbox viewer / message history (separate PR).
- Thread viewer / Reply-to prefill (depends on messaging PR-2 threading).
- Urgent-queue pane (wave-2, depends on priority-lane PR-4).
- Rich-text, attachments.

Briefing: `twapp-ui-msg-composer.md`. Coordinator handle: `twapp-ui-composer`.