### PR TITLE
feat(ui): group launcher sessions — my sessions + per-coordinator co-lab sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,23 @@ A typical co-lab flow:
 
 The rest of this section covers each piece of that flow.
 
+### The launcher groups co-lab sessions
+
+The top-level twapp launcher splits the sessions list into sections so a
+running co-lab doesn't drown out your own work: **My sessions** at the top
+(sessions you started yourself — no `colab_group`, not spawned), one
+collapsible **Co-lab: `<group>`** section per active coordination with the
+coordinator pinned at the top of its group and workers sorted by recent
+activity underneath, and a final **Orphan co-lab sessions** section that
+surfaces any `--from-file` spawns that didn't pick up a `colab_group` tag
+(legacy or misconfigured). Each section shows a count badge, search
+auto-expands any section with a match, the existing Recent / A-Z sort
+toggle applies within each section, and a subtle color-coded left border
+keeps members of the same co-lab visually tied together across group
+expand/collapse. Collapsed state is remembered across app restarts. If
+you're not running a co-lab, the launcher reverts to its flat list — no
+empty headers, no regression in the single-session UX.
+
 ### Spawning a worker agent
 
 twapp works well as a terminal wrapper for *interactive* sessions, but

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -135,6 +135,12 @@ fn launcher_session_from_data(
         message_count,
         imported,
         forked_from,
+        role: session_data.role.clone(),
+        provenance: session_data.provenance.clone(),
+        // Stub: `colab_group` field on SessionData is landing in the parallel
+        // `twapp-session-colab-group` PR. Until then, propagate None so the
+        // launcher treats every session as non-grouped (current behavior).
+        colab_group: None,
     }
 }
 

--- a/src-tauri/src/gui/types.rs
+++ b/src-tauri/src/gui/types.rs
@@ -157,6 +157,9 @@ pub struct LauncherSession {
     pub message_count: Option<u32>,
     pub imported: bool,
     pub forked_from: Option<String>,
+    pub role: Option<String>,
+    pub provenance: Option<String>,
+    pub colab_group: Option<String>,
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src/App.css
+++ b/src/App.css
@@ -3287,6 +3287,86 @@ a.file-link {
   padding-top: 4px;
 }
 
+.launcher-section {
+  margin-bottom: 8px;
+}
+
+.launcher-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 10px 14px 8px;
+  cursor: pointer;
+  color: var(--text);
+  font-family: inherit;
+  text-align: left;
+}
+
+.launcher-section-header:hover {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+}
+
+.launcher-section-chevron {
+  font-size: 10px;
+  width: 12px;
+  color: var(--text-muted);
+}
+
+.launcher-section-title {
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.launcher-section-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+  border-radius: 10px;
+  padding: 1px 8px;
+  margin-left: auto;
+}
+
+.launcher-section-header.collapsed .launcher-section-chevron {
+  transform: translateY(-1px);
+}
+
+.launcher-section-body {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Coordinator card gets a subtle chrome step-up within a co-lab group.
+   Kept gentle so colab-ui-chrome's chip treatment can still own the
+   role-specific visual language without a double-accent. */
+.launcher-session-coordinator {
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0.04),
+    transparent 40%
+  );
+}
+
+.launcher-role-badge {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.4px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--hover-bg, rgba(0, 0, 0, 0.08));
+  color: var(--text-muted);
+}
+
+.launcher-role-coordinator {
+  background: rgba(80, 120, 220, 0.15);
+  color: var(--accent, #4a7de8);
+}
+
 .launcher-spinner {
   width: 24px;
   height: 24px;

--- a/src/components/SessionLauncher.tsx
+++ b/src/components/SessionLauncher.tsx
@@ -5,6 +5,10 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 import { getDarkModeAccentColor } from "../color";
 import { formatRelativeTime, formatBytes, shortenPath } from "../utils/format";
 import { maskProviderSessionId } from "../utils/session";
+import {
+  partitionSessions,
+  colabGroupBorderColor,
+} from "../utils/sessionSections";
 import type {
   LauncherSession,
   LauncherResponse,
@@ -80,6 +84,34 @@ function SessionLauncher({
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  // Launcher co-lab group collapse state (persisted per section id via localStorage)
+  const collapsedStorageKey = "twapp:launcher:collapsed-sections";
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => {
+    try {
+      const raw = localStorage.getItem(collapsedStorageKey);
+      if (!raw) return new Set();
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? new Set(parsed.filter((v) => typeof v === "string")) : new Set();
+    } catch {
+      return new Set();
+    }
+  });
+  useEffect(() => {
+    try {
+      localStorage.setItem(collapsedStorageKey, JSON.stringify(Array.from(collapsedSections)));
+    } catch {
+      // Quota / private mode — collapse state just becomes session-local, no user-visible error.
+    }
+  }, [collapsedSections]);
+  const toggleSectionCollapsed = (id: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   // Import sessions state
   const [importPreview, setImportPreview] = useState<ImportPreview | null>(null);
@@ -262,10 +294,20 @@ function SessionLauncher({
     );
   }, [sessions, searchQuery, showImported]);
 
-  const groupedSessions = useMemo(() => {
+  const sections = useMemo(
+    () => partitionSessions(filteredSessions, sortMode),
+    [filteredSessions, sortMode],
+  );
+
+  // The flat "My sessions" list keeps its existing bucketing (Today / This Week /
+  // Older or A-Z) so single-session users see no regression. Co-lab and orphan
+  // sections are rendered flat — a group already carries its own context.
+  const mineBuckets = useMemo(() => {
+    const mine = sections.find((s) => s.kind === "mine")?.sessions ?? [];
+
     if (sortMode === "alpha") {
-      const sorted = [...filteredSessions].sort((a, b) =>
-        a.name.localeCompare(b.name, undefined, { sensitivity: "base" })
+      const sorted = [...mine].sort((a, b) =>
+        a.name.localeCompare(b.name, undefined, { sensitivity: "base" }),
       );
       const groups = new Map<string, LauncherSession[]>();
       for (const s of sorted) {
@@ -277,7 +319,6 @@ function SessionLauncher({
       return Array.from(groups, ([label, sessions]) => ({ label, sessions }));
     }
 
-    // Default: recent (time buckets)
     const now = new Date();
     const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const startOfYesterday = new Date(startOfToday.getTime() - 86400000);
@@ -292,7 +333,7 @@ function SessionLauncher({
       { label: "Older", sessions: [] },
     ];
 
-    for (const s of filteredSessions) {
+    for (const s of mine) {
       const t = s.last_active ? new Date(s.last_active).getTime() : 0;
       if (t >= startOfToday.getTime()) buckets[0].sessions.push(s);
       else if (t >= startOfYesterday.getTime()) buckets[1].sessions.push(s);
@@ -302,7 +343,24 @@ function SessionLauncher({
     }
 
     return buckets.filter((b) => b.sessions.length > 0);
-  }, [filteredSessions, sortMode]);
+  }, [sections, sortMode]);
+
+  // If the user has no co-lab sessions at all, preserve the lean flat-list UX:
+  // hide the "My sessions" header and just render the existing time/alpha
+  // buckets directly.
+  const hasColabSections = sections.some((s) => s.kind === "colab" || s.kind === "orphans");
+
+  // Search auto-expands any section whose members match, so results aren't
+  // hidden behind a collapsed header.
+  const searching = searchQuery.trim().length > 0;
+  const effectiveCollapsed = useMemo(() => {
+    if (!searching) return collapsedSections;
+    const filtered = new Set(collapsedSections);
+    for (const section of sections) {
+      if (section.sessions.length > 0) filtered.delete(section.id);
+    }
+    return filtered;
+  }, [collapsedSections, sections, searching]);
 
   const handleLaunch = async (session: LauncherSession) => {
     setLaunching(session.session_id);
@@ -1013,6 +1071,117 @@ function SessionLauncher({
     </div>
   );
 
+  const renderSession = (session: LauncherSession, borderOverride?: string) => {
+    const isCoordinator = session.role === "coordinator";
+    // Border precedence: explicit override (co-lab group hue) > session color
+    // > transparent. Coordinator within a group gets a thicker visual tier via
+    // a class — colab-ui-chrome's chip lives on a separate badge in the meta
+    // row, so they don't conflict.
+    const borderColor = borderOverride || session.color || "transparent";
+    const classes = [
+      "launcher-session",
+      session.is_running ? "running" : "",
+      launching === session.session_id ? "launching" : "",
+      isCoordinator ? "launcher-session-coordinator" : "",
+    ].filter(Boolean).join(" ");
+    return (
+      <div
+        key={session.session_id}
+        className={classes}
+        onClick={() => handleLaunch(session)}
+        style={{ borderLeftColor: borderColor }}
+      >
+        <div className="launcher-session-main">
+          <div className="launcher-session-name">
+            {renamingSessionId === session.session_id ? (
+              <input
+                className="launcher-rename-input"
+                value={renameValue}
+                onChange={(e) => setRenameValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleRenameConfirm(session);
+                  if (e.key === "Escape") setRenamingSessionId(null);
+                }}
+                onBlur={() => handleRenameConfirm(session)}
+                onClick={(e) => e.stopPropagation()}
+                autoFocus
+              />
+            ) : (
+              <>
+                {session.name}
+                {session.is_running && (
+                  <span className="launcher-running-badge">Running</span>
+                )}
+              </>
+            )}
+          </div>
+          <div className="launcher-session-meta">
+            <span className="launcher-imported-badge">{session.provider}</span>
+            {isCoordinator && (
+              <span className="launcher-role-badge launcher-role-coordinator" title="Coordinator for this co-lab group">
+                Coordinator
+              </span>
+            )}
+            {session.forked_from && (
+              <span className="launcher-forked-badge" title={`Forked from ${session.forked_from.slice(0, 12)}`}>Forked</span>
+            )}
+            {session.imported && (
+              <span className="launcher-imported-badge">Imported</span>
+            )}
+            {session.ticket_key && (
+              <span className="launcher-ticket">{session.ticket_key}</span>
+            )}
+            {session.needs_migration && (
+              <span className="launcher-forked-badge" title={`Will migrate existing ${session.provider === "codex" ? "Claude" : "Codex"} context into ${session.provider} on next launch`}>
+                Migrate on Open
+              </span>
+            )}
+            <span className="launcher-path">{shortenPath(session.directory, homeDir)}</span>
+          </div>
+        </div>
+        <div className="launcher-session-right">
+          <span className="launcher-time">
+            {formatRelativeTime(session.last_active)}
+          </span>
+          {session.provider_session_id && (
+            <button
+              className="launcher-session-id"
+              type="button"
+              onClick={(e) => handleCopyProviderSessionId(e, session.provider_session_id!)}
+              aria-label={`Copy ${session.provider} session id ${session.provider_session_id}`}
+              title={`Copy ${session.provider} session ID`}
+            >
+              {maskProviderSessionId(session.provider_session_id)}
+            </button>
+          )}
+          {session.message_count != null && (
+            <span className="launcher-messages">
+              {session.message_count} msgs
+            </span>
+          )}
+          <button
+            className="launcher-session-action"
+            title="Rename session"
+            onClick={(e) => handleRenameClick(e, session)}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M8.5 1.5l2 2L4 10H2v-2L8.5 1.5z" />
+            </svg>
+          </button>
+          <button
+            className="launcher-session-action"
+            title="Delete session"
+            onClick={(e) => handleDeleteClick(e, session)}
+          >
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M2 3h8M4.5 3V2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v1M3 3v7a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1V3" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="launcher">
       <div className="launcher-header">
@@ -1389,102 +1558,91 @@ function SessionLauncher({
             {searchQuery ? "No matching sessions" : "No sessions found"}
           </div>
         ) : (
-          groupedSessions.map((group) => (
-            <div key={group.label} className="launcher-group">
-              <div className="launcher-group-label">{group.label}</div>
-              {group.sessions.map((session) => (
-                <div
-                  key={session.session_id}
-                  className={`launcher-session${session.is_running ? " running" : ""}${launching === session.session_id ? " launching" : ""}`}
-                  onClick={() => handleLaunch(session)}
-                  style={{ borderLeftColor: session.color || "transparent" }}
-                >
-                  <div className="launcher-session-main">
-                    <div className="launcher-session-name">
-                      {renamingSessionId === session.session_id ? (
-                        <input
-                          className="launcher-rename-input"
-                          value={renameValue}
-                          onChange={(e) => setRenameValue(e.target.value)}
-                          onKeyDown={(e) => {
-                            if (e.key === "Enter") handleRenameConfirm(session);
-                            if (e.key === "Escape") setRenamingSessionId(null);
-                          }}
-                          onBlur={() => handleRenameConfirm(session)}
-                          onClick={(e) => e.stopPropagation()}
-                          autoFocus
-                        />
-                      ) : (
-                        <>
-                          {session.name}
-                          {session.is_running && (
-                            <span className="launcher-running-badge">Running</span>
-                          )}
-                        </>
-                      )}
-                    </div>
-                    <div className="launcher-session-meta">
-                      <span className="launcher-imported-badge">{session.provider}</span>
-                      {session.forked_from && (
-                        <span className="launcher-forked-badge" title={`Forked from ${session.forked_from.slice(0, 12)}`}>Forked</span>
-                      )}
-                      {session.imported && (
-                        <span className="launcher-imported-badge">Imported</span>
-                      )}
-                      {session.ticket_key && (
-                        <span className="launcher-ticket">{session.ticket_key}</span>
-                      )}
-                      {session.needs_migration && (
-                        <span className="launcher-forked-badge" title={`Will migrate existing ${session.provider === "codex" ? "Claude" : "Codex"} context into ${session.provider} on next launch`}>
-                          Migrate on Open
-                        </span>
-                      )}
-                      <span className="launcher-path">{shortenPath(session.directory, homeDir)}</span>
-                    </div>
+          <>
+            {/* "My sessions" section. When no co-lab sessions exist anywhere,
+                we drop the section header and fall back to the original flat
+                time/alpha buckets — preserves the lean UX for single-session
+                users. */}
+            {(() => {
+              const mineSection = sections.find((s) => s.kind === "mine");
+              const mineCount = mineSection?.sessions.length ?? 0;
+              const mineCollapsed = effectiveCollapsed.has("mine");
+              if (!hasColabSections) {
+                return mineBuckets.map((bucket) => (
+                  <div key={bucket.label} className="launcher-group">
+                    <div className="launcher-group-label">{bucket.label}</div>
+                    {bucket.sessions.map((s) => renderSession(s))}
                   </div>
-                  <div className="launcher-session-right">
-                    <span className="launcher-time">
-                      {formatRelativeTime(session.last_active)}
+                ));
+              }
+              return (
+                <div className="launcher-section launcher-section-mine">
+                  <button
+                    type="button"
+                    className={`launcher-section-header${mineCollapsed ? " collapsed" : ""}`}
+                    onClick={() => toggleSectionCollapsed("mine")}
+                    aria-expanded={!mineCollapsed}
+                  >
+                    <span className="launcher-section-chevron" aria-hidden="true">
+                      {mineCollapsed ? "▸" : "▾"}
                     </span>
-                    {session.provider_session_id && (
-                      <button
-                        className="launcher-session-id"
-                        type="button"
-                        onClick={(e) => handleCopyProviderSessionId(e, session.provider_session_id!)}
-                        aria-label={`Copy ${session.provider} session id ${session.provider_session_id}`}
-                        title={`Copy ${session.provider} session ID`}
-                      >
-                        {maskProviderSessionId(session.provider_session_id)}
-                      </button>
-                    )}
-                    {session.message_count != null && (
-                      <span className="launcher-messages">
-                        {session.message_count} msgs
-                      </span>
-                    )}
-                    <button
-                      className="launcher-session-action"
-                      title="Rename session"
-                      onClick={(e) => handleRenameClick(e, session)}
-                    >
-                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M8.5 1.5l2 2L4 10H2v-2L8.5 1.5z" />
-                      </svg>
-                    </button>
-                    <button
-                      className="launcher-session-action"
-                      title="Delete session"
-                      onClick={(e) => handleDeleteClick(e, session)}
-                    >
-                      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M2 3h8M4.5 3V2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v1M3 3v7a1 1 0 0 0 1 1h4a1 1 0 0 0 1-1V3" />
-                      </svg>
-                    </button>
-                  </div>
+                    <span className="launcher-section-title">My sessions</span>
+                    <span className="launcher-section-count">{mineCount}</span>
+                  </button>
+                  {!mineCollapsed &&
+                    mineBuckets.map((bucket) => (
+                      <div key={bucket.label} className="launcher-group">
+                        <div className="launcher-group-label">{bucket.label}</div>
+                        {bucket.sessions.map((s) => renderSession(s))}
+                      </div>
+                    ))}
                 </div>
-              ))}
-            </div>
-          ))
+              );
+            })()}
+            {sections
+              .filter((s) => s.kind !== "mine")
+              .map((section) => {
+                const collapsed = effectiveCollapsed.has(section.id);
+                const borderColor =
+                  section.kind === "colab" && section.groupName
+                    ? colabGroupBorderColor(section.groupName)
+                    : undefined;
+                return (
+                  <div
+                    key={section.id}
+                    className={`launcher-section launcher-section-${section.kind}`}
+                    style={borderColor ? { ["--colab-group-border" as string]: borderColor } : undefined}
+                  >
+                    <button
+                      type="button"
+                      className={`launcher-section-header${collapsed ? " collapsed" : ""}`}
+                      onClick={() => toggleSectionCollapsed(section.id)}
+                      aria-expanded={!collapsed}
+                    >
+                      <span className="launcher-section-chevron" aria-hidden="true">
+                        {collapsed ? "▸" : "▾"}
+                      </span>
+                      <span
+                        className="launcher-section-title"
+                        style={
+                          borderColor
+                            ? { borderLeft: `3px solid ${borderColor}`, paddingLeft: 8 }
+                            : undefined
+                        }
+                      >
+                        {section.label}
+                      </span>
+                      <span className="launcher-section-count">{section.sessions.length}</span>
+                    </button>
+                    {!collapsed && (
+                      <div className="launcher-section-body">
+                        {section.sessions.map((s) => renderSession(s, borderColor))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+          </>
         )}
       </div>
       )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,9 @@ export interface LauncherSession {
   message_count: number | null;
   imported: boolean;
   forked_from: string | null;
+  role: string | null;
+  provenance: string | null;
+  colab_group: string | null;
 }
 
 export interface LauncherResponse {

--- a/src/utils/sessionSections.test.ts
+++ b/src/utils/sessionSections.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { partitionSessions, colabGroupHue, colabGroupBorderColor } from "./sessionSections";
+import type { LauncherSession } from "../types";
+
+function mkSession(partial: Partial<LauncherSession> & { name: string }): LauncherSession {
+  return {
+    session_id: partial.session_id ?? `sid-${partial.name}`,
+    provider: "claude",
+    provider_session_id: null,
+    needs_migration: false,
+    name: partial.name,
+    color: "#ccc",
+    ticket_key: null,
+    directory: `/tmp/${partial.name}`,
+    claude_cwd: `/tmp/${partial.name}`,
+    last_active: partial.last_active ?? "2026-04-21T00:00:00Z",
+    created: "2026-04-20T00:00:00Z",
+    is_running: false,
+    message_count: null,
+    imported: false,
+    forked_from: null,
+    role: partial.role ?? null,
+    provenance: partial.provenance ?? null,
+    colab_group: partial.colab_group ?? null,
+  };
+}
+
+describe("partitionSessions", () => {
+  it("returns only 'My sessions' when no colab sessions exist", () => {
+    const sessions = [
+      mkSession({ name: "alpha" }),
+      mkSession({ name: "beta", provenance: "user" }),
+    ];
+    const sections = partitionSessions(sessions, "recent");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].kind).toBe("mine");
+    expect(sections[0].sessions.map((s) => s.name).sort()).toEqual(["alpha", "beta"]);
+  });
+
+  it("groups colab sessions by colab_group with coordinator first", () => {
+    const sessions = [
+      mkSession({ name: "human-1" }),
+      mkSession({ name: "worker-a", provenance: "spawned", colab_group: "feature-x" }),
+      mkSession({
+        name: "coord-x",
+        provenance: "spawned",
+        role: "coordinator",
+        colab_group: "feature-x",
+      }),
+      mkSession({ name: "worker-b", provenance: "spawned", colab_group: "feature-x" }),
+    ];
+    const sections = partitionSessions(sessions, "recent");
+    expect(sections.map((s) => s.kind)).toEqual(["mine", "colab"]);
+    const colab = sections[1];
+    expect(colab.label).toBe("Co-lab: feature-x");
+    expect(colab.sessions[0].name).toBe("coord-x");
+    expect(colab.sessions.slice(1).map((s) => s.name).sort()).toEqual(["worker-a", "worker-b"]);
+  });
+
+  it("separates orphan co-lab sessions (spawned but colab_group=None) into their own section", () => {
+    const sessions = [
+      mkSession({ name: "human-1" }),
+      mkSession({ name: "orphan-1", provenance: "spawned" }),
+      mkSession({ name: "orphan-2", provenance: "spawned", colab_group: "" }),
+    ];
+    const sections = partitionSessions(sessions, "recent");
+    expect(sections.map((s) => s.kind)).toEqual(["mine", "orphans"]);
+    expect(sections[0].sessions.map((s) => s.name)).toEqual(["human-1"]);
+    expect(sections[1].sessions.map((s) => s.name).sort()).toEqual(["orphan-1", "orphan-2"]);
+  });
+
+  it("orders colab sections alphabetically by group name", () => {
+    const sessions = [
+      mkSession({ name: "a", provenance: "spawned", colab_group: "zebra" }),
+      mkSession({ name: "b", provenance: "spawned", colab_group: "alpha" }),
+      mkSession({ name: "c", provenance: "spawned", colab_group: "mango" }),
+    ];
+    const sections = partitionSessions(sessions, "recent");
+    expect(sections.filter((s) => s.kind === "colab").map((s) => s.groupName)).toEqual([
+      "alpha",
+      "mango",
+      "zebra",
+    ]);
+  });
+
+  it("applies sort mode within sections", () => {
+    const sessions = [
+      mkSession({ name: "zeta", last_active: "2026-04-21T01:00:00Z" }),
+      mkSession({ name: "alpha", last_active: "2026-04-21T03:00:00Z" }),
+      mkSession({ name: "mango", last_active: "2026-04-21T02:00:00Z" }),
+    ];
+    const recent = partitionSessions(sessions, "recent");
+    expect(recent[0].sessions.map((s) => s.name)).toEqual(["alpha", "mango", "zeta"]);
+    const alpha = partitionSessions(sessions, "alpha");
+    expect(alpha[0].sessions.map((s) => s.name)).toEqual(["alpha", "mango", "zeta"]);
+  });
+
+  it("treats colab_group='' and null as equivalent 'not-in-a-group'", () => {
+    const sessions = [
+      mkSession({ name: "a", colab_group: "" }),
+      mkSession({ name: "b", colab_group: null }),
+    ];
+    const sections = partitionSessions(sessions, "recent");
+    expect(sections).toHaveLength(1);
+    expect(sections[0].kind).toBe("mine");
+  });
+});
+
+describe("colabGroupHue / colabGroupBorderColor", () => {
+  it("is deterministic for a given group name", () => {
+    expect(colabGroupHue("feature-x")).toBe(colabGroupHue("feature-x"));
+    expect(colabGroupBorderColor("feature-x")).toBe(colabGroupBorderColor("feature-x"));
+  });
+
+  it("spreads different group names across the hue range", () => {
+    const hues = new Set(["alpha", "bravo", "charlie", "delta", "echo"].map(colabGroupHue));
+    expect(hues.size).toBeGreaterThan(1);
+  });
+
+  it("returns a CSS hsl() string", () => {
+    expect(colabGroupBorderColor("feature-x")).toMatch(/^hsl\(\d+, 55%, 55%\)$/);
+  });
+});

--- a/src/utils/sessionSections.ts
+++ b/src/utils/sessionSections.ts
@@ -1,0 +1,134 @@
+import type { LauncherSession, SortMode } from "../types";
+
+export type SectionKind = "mine" | "colab" | "orphans";
+
+export interface SessionSection {
+  kind: SectionKind;
+  /** Machine id, stable across renders; used for collapsed-state persistence. */
+  id: string;
+  /** Human label shown in the section header. */
+  label: string;
+  /** Group name for "colab" sections, null otherwise. */
+  groupName: string | null;
+  sessions: LauncherSession[];
+}
+
+function isColabSession(s: LauncherSession): boolean {
+  return !!(s.colab_group && s.colab_group.trim().length > 0);
+}
+
+function isSpawned(s: LauncherSession): boolean {
+  return s.provenance === "spawned";
+}
+
+function isCoordinator(s: LauncherSession): boolean {
+  return s.role === "coordinator";
+}
+
+function compareRecent(a: LauncherSession, b: LauncherSession): number {
+  const ta = a.last_active || "";
+  const tb = b.last_active || "";
+  if (ta === tb) return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  return ta < tb ? 1 : -1;
+}
+
+function compareAlpha(a: LauncherSession, b: LauncherSession): number {
+  return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
+/** Group all colab sessions by `colab_group`, sorting coordinators first then by sortMode. */
+function buildColabSections(
+  sessions: LauncherSession[],
+  sortMode: SortMode,
+): SessionSection[] {
+  const byGroup = new Map<string, LauncherSession[]>();
+  for (const s of sessions) {
+    if (!isColabSession(s)) continue;
+    const key = s.colab_group!;
+    const list = byGroup.get(key);
+    if (list) list.push(s);
+    else byGroup.set(key, [s]);
+  }
+
+  const cmp = sortMode === "alpha" ? compareAlpha : compareRecent;
+
+  const sections: SessionSection[] = [];
+  for (const [groupName, members] of byGroup) {
+    const coordinators = members.filter(isCoordinator).sort(cmp);
+    const workers = members.filter((s) => !isCoordinator(s)).sort(cmp);
+    sections.push({
+      kind: "colab",
+      id: `colab:${groupName}`,
+      label: `Co-lab: ${groupName}`,
+      groupName,
+      sessions: [...coordinators, ...workers],
+    });
+  }
+
+  // Stable section order: alphabetical by group name. Simpler than inventing
+  // a per-section activity metric and matches how a user scans for a group.
+  sections.sort((a, b) =>
+    a.groupName!.localeCompare(b.groupName!, undefined, { sensitivity: "base" }),
+  );
+  return sections;
+}
+
+/**
+ * Partition sessions into the three launcher sections, per the briefing:
+ *  - "My sessions": colab_group is None/empty AND provenance != "spawned"
+ *  - "Co-lab: <group>": one section per distinct colab_group
+ *  - "Orphan co-lab sessions": provenance == "spawned" but colab_group is None/empty
+ *
+ * Always returns the "mine" section (possibly empty — callers decide whether
+ * to hide it). The colab + orphan sections are omitted when they have no
+ * members, so a user with no co-lab history sees just the flat list.
+ */
+export function partitionSessions(
+  sessions: LauncherSession[],
+  sortMode: SortMode,
+): SessionSection[] {
+  const cmp = sortMode === "alpha" ? compareAlpha : compareRecent;
+
+  const mine: LauncherSession[] = [];
+  const orphans: LauncherSession[] = [];
+  for (const s of sessions) {
+    if (isColabSession(s)) continue;
+    if (isSpawned(s)) orphans.push(s);
+    else mine.push(s);
+  }
+  mine.sort(cmp);
+  orphans.sort(cmp);
+
+  const sections: SessionSection[] = [
+    { kind: "mine", id: "mine", label: "My sessions", groupName: null, sessions: mine },
+    ...buildColabSections(sessions, sortMode),
+  ];
+  if (orphans.length > 0) {
+    sections.push({
+      kind: "orphans",
+      id: "orphans",
+      label: "Orphan co-lab sessions",
+      groupName: null,
+      sessions: orphans,
+    });
+  }
+  return sections;
+}
+
+/**
+ * Stable hue (0–360) derived from a group name. Deterministic across runs so
+ * the same co-lab group paints the same left-border color every time.
+ * djb2 × 33 — fine for a palette index, not a cryptographic hash.
+ */
+export function colabGroupHue(groupName: string): number {
+  let h = 5381;
+  for (let i = 0; i < groupName.length; i++) {
+    h = ((h << 5) + h + groupName.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h) % 360;
+}
+
+/** CSS color string for a group's left-border treatment. */
+export function colabGroupBorderColor(groupName: string): string {
+  return `hsl(${colabGroupHue(groupName)}, 55%, 55%)`;
+}


### PR DESCRIPTION
## Summary

Splits the top-level launcher into sections so a running co-lab
doesn't drown out the human's own work:

- **My sessions** — what you started directly (`colab_group` empty/None AND `provenance != "spawned"`). Keeps the existing Today / Yesterday / This Week / Older (or A-Z) bucketing inside.
- **Co-lab: `<group>`** — one collapsible section per distinct `colab_group`, coordinator pinned first, workers sorted by active sort mode. Stable hue-hashed left-border color per group; coordinator card gets a subtle chrome step-up and a `Coordinator` role badge.
- **Orphan co-lab sessions** — `provenance == "spawned"` but no `colab_group`; surfaces legacy / misconfigured spawns.

Behavior:

- Count badge per section.
- Search auto-expands any section with a match.
- Collapsed state persisted across app restarts via `localStorage` (`twapp:launcher:collapsed-sections`).
- Recent / A-Z sort applies within each section.
- **When no co-lab sessions exist anywhere, sections collapse to the original flat list** — no empty header, no regression in the single-session UX.

## Schema plumbing / stub

`LauncherSession` gains `role`, `provenance`, `colab_group` (Rust + TS):

- `role` + `provenance` — already on `SessionData` via #43 but never propagated through the launcher API. Now wired through.
- `colab_group` — stubbed as always-`None` at launcher-serialize time. The parallel [`twapp-session-colab-group`](#) PR adds it to `SessionData`; once that lands, the integration is a **one-line flip** of

  ```rust
  colab_group: None,  // stub
  ```

  to `colab_group: session_data.colab_group.clone()`. No UI / layout rework needed.

Chose to land now (vs. blocking on the schema PR) so the container layout can get reviewer eyes independently of the field rollout. Reviewer: happy to flip to the blocking order if you prefer.

## Coordination

- **twapp-session-colab-group** (parallel, schema): will rebase to consume `colab_group` directly once merged.
- **twapp-colab-ui-chrome** (in flight, card styling): non-overlapping in concept but touches the same session-card markup. I wrapped sections *around* the existing card rendering; the `Coordinator` role badge is a new span in the meta row that slots next to its chip without collision. Happy to rebase either direction.
- **twapp-ui-launcher-button**: different region (top-bar button vs. list container). No overlap.

## Tests

- 9 new unit tests in `src/utils/sessionSections.test.ts` covering: empty-colab flat list, coordinator-first ordering within a group, orphan partition, alphabetical group ordering, recent + alpha sort within sections, `colab_group=""` treated as not-in-a-group, and deterministic hue derivation.
- All 89 vitest tests pass.
- All 111 Rust tests pass.
- `npx tsc --noEmit` clean; `npx vite build` succeeds.

## Test plan

- [x] `npx vitest run` — 89 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds
- [x] `cargo test --lib` — 111 passed
- [x] `cargo check --lib` — clean
- [ ] Manual UX verification against a dev build: seed three sessions (one user-created, one coordinator + two workers in a group) and confirm two sections render with correct contents, counts, and coordinator first. Running the Tauri dev build isn't something I can exercise headlessly here; flagging for reviewer.

## Out of scope (per briefing)

- Fleet dashboard / unread counts / urgent queue (wave-2/3).
- Quick-action context menu.
- Per-group mailbox scoping.