### PR TITLE
feat(msg): priority lane (urgent/ symlinks + --priority filter) — design PR-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,10 +519,12 @@ without leaving twapp.
 fenced-frontmatter markdown files into a shared `inbox/` directory and
 reads them back. See
 [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) for
-the full model. Today's CLI covers **PR-1** of that design — `send`,
-`broadcast`, and `fetch` against the current flat `inbox/` layout.
-Threading, directory split, cursors, priority lanes, presence, channels,
-and archive rotation all land in later PRs.
+the full model. Today's CLI covers **PR-1** (scaffolding) and **PR-4**
+(priority lane) of that design — `send`, `broadcast`, and `fetch`
+against the current flat `inbox/` layout, plus urgent-lane symlinks
+under `inbox/urgent/<recipient>/` for time-sensitive traffic.
+Threading, directory split, cursors, presence, channels, and archive
+rotation all land in later PRs.
 
 #### Configure the mailbox
 
@@ -566,6 +568,41 @@ twapp msg fetch --for reviewer --format json | jq
 If `--from` is not passed, the sender handle is taken from the current
 directory's `.twapp-session.json` `name`. Bodies may be passed as a
 positional argument or piped in on stdin.
+
+#### Priority lanes
+
+Messages carry a `priority:` frontmatter field — `routine` (default),
+`urgent`, or `blocker`. When a message is sent with `--priority urgent`
+or `--priority blocker`, `twapp msg send` (and `broadcast`) additionally
+writes a symlink under `inbox/urgent/<recipient>/<ts>-<id6>.md` pointing
+at the canonical file in the flat inbox. Broadcasts symlink into
+`inbox/urgent/all/`; multi-recipient direct messages get one symlink
+per recipient.
+
+```bash
+# Urgent — asks the recipient to interrupt their batch and read next poll.
+twapp msg send reviewer --priority urgent --subject "scope change" "see body"
+
+# Blocker — asks the recipient to stop current work and handle this first.
+twapp msg send worker-a --priority blocker --subject "rewind PR" "force-push coming"
+
+# Fetch only what deserves attention. `--priority urgent` is the "urgent
+# lane" — it returns both urgent AND blocker traffic. `--priority blocker`
+# is an exact match for the rare stop-the-world case.
+twapp msg fetch --priority urgent            # urgent + blocker
+twapp msg fetch --priority blocker           # blocker only
+twapp msg fetch --priority routine           # everything else
+```
+
+Under the hood, `fetch --priority urgent|blocker` scans
+`inbox/urgent/<you>/` (and `inbox/urgent/all/` for broadcasts) first —
+much cheaper than listing the flat inbox as it grows. Routine traffic
+stays out of the urgent lane entirely. Broken symlinks (canonical
+deleted, lane entry not yet swept) are skipped with a `log::debug!`
+trace, not a crash.
+
+> `twapp msg fetch --priority blocker` is the idiomatic first call at the
+> top of any long write cycle — before the first line of code.
 
 #### Reading legacy (bare) files
 

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -185,6 +185,33 @@ Messages addressed to *other* agents stay in `inbox/` — never archive on someo
 - `to: <handle>` — directed (only that agent archives; others ignore).
 - `cc: <handle>` — optional courtesy copy.
 
+### Priority lanes (urgent / blocker)
+
+When a coordinator message is time-sensitive (redirect mid-write-cycle,
+stop-work order, stale-merge nudge), send it on the priority lane so
+the recipient surfaces it on its next poll without scanning the whole
+inbox:
+
+```bash
+# "Read this on your next poll; it may change your plan."
+twapp msg send worker-a --priority urgent --subject "scope change" "<body>"
+
+# "Stop current work and handle this before anything else."
+twapp msg send worker-a --priority blocker --subject "rewind PR" "<body>"
+```
+
+`twapp msg send --priority {urgent|blocker}` drops a symlink under
+`inbox/urgent/<recipient>/` alongside the canonical file. Recipients
+running `twapp msg fetch --priority blocker` at the top of a long
+write cycle see blockers before anything else. `--priority urgent`
+returns both urgent and blocker (the whole urgent lane); `--priority
+blocker` is exact.
+
+> Do **not** encode priority in the filename by renaming the receiver to
+> `<handle>-URGENT` / `<handle>-REWORK` — that idiom is deprecated. Use
+> `--priority urgent` (or `blocker`) instead; it's the only channel
+> `twapp msg fetch --priority` knows how to find.
+
 ### Example message
 
 ```

--- a/src-tauri/src/cli/msg.rs
+++ b/src-tauri/src/cli/msg.rs
@@ -227,6 +227,10 @@ pub fn inbox_dir() -> Result<PathBuf, String> {
     Ok(resolve_mailbox_dir()?.join("inbox"))
 }
 
+pub fn urgent_dir(inbox: &Path) -> PathBuf {
+    inbox.join("urgent")
+}
+
 // --- ID / timestamp generation ---------------------------------------------
 
 // Crockford base32 alphabet (ULID).
@@ -409,7 +413,56 @@ pub fn write_message(inbox: &Path, args: SendArgs) -> Result<SentMessage, String
     content.push('\n');
 
     std::fs::write(&path, content).map_err(|e| format!("write {}: {}", path.display(), e))?;
+
+    // Priority lane (design §2.5, PR-4): urgent + blocker also get a symlink
+    // under inbox/urgent/<recipient>/<filename> so readers can scan the small
+    // urgent lane without listing the whole inbox. Routine messages are not
+    // linked. Channel recipients are out of scope for PR-4.
+    if matches!(fm.priority, MsgPriority::Urgent | MsgPriority::Blocker) {
+        create_urgent_symlinks(inbox, &filename, &fm.to);
+    }
+
     Ok(SentMessage { path, fm })
+}
+
+fn create_urgent_symlinks(inbox: &Path, filename: &str, to: &[String]) {
+    let urgent_root = urgent_dir(inbox);
+    for recipient in to {
+        // Channel lane lives in PR-6; skip for now.
+        if recipient.starts_with("channel:") {
+            continue;
+        }
+        let trimmed = recipient.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let recipient_dir = urgent_root.join(trimmed);
+        if let Err(e) = std::fs::create_dir_all(&recipient_dir) {
+            log::debug!(
+                "create urgent dir {} failed: {}",
+                recipient_dir.display(),
+                e
+            );
+            continue;
+        }
+        let link_path = recipient_dir.join(filename);
+        // Symlinks are idempotent — if one already exists at this path, leave
+        // it alone rather than failing (e.g. two writers racing to the same
+        // id6, which is astronomically unlikely but cheap to tolerate).
+        if link_path.exists() || link_path.is_symlink() {
+            continue;
+        }
+        // Relative target so moving the mailbox tree doesn't break the link.
+        let target = PathBuf::from("../..").join(filename);
+        if let Err(e) = std::os::unix::fs::symlink(&target, &link_path) {
+            log::debug!(
+                "symlink {} -> {} failed: {}",
+                link_path.display(),
+                target.display(),
+                e
+            );
+        }
+    }
 }
 
 // --- Reading / parsing -----------------------------------------------------
@@ -436,6 +489,124 @@ pub fn list_messages(inbox: &Path) -> Vec<ParsedMessage> {
     }
     out.sort_by(|a, b| a.fm.ts.cmp(&b.fm.ts).then_with(|| a.fm.id.cmp(&b.fm.id)));
     out
+}
+
+/// Scan the urgent-priority lane for a given recipient (or all lanes when
+/// `handle` is None). Follows symlinks, de-duplicates by canonical path, and
+/// skips broken links with a `log::debug!` trace instead of crashing.
+pub fn scan_urgent_lane(inbox: &Path, handle: Option<&str>) -> Vec<ParsedMessage> {
+    let urgent_root = urgent_dir(inbox);
+    let subdirs: Vec<PathBuf> = match handle {
+        Some(h) => {
+            // Messages directly to the handle plus any broadcasts (to: all).
+            let mut v = vec![urgent_root.join(h)];
+            if h != "all" {
+                v.push(urgent_root.join("all"));
+            }
+            v
+        }
+        None => match std::fs::read_dir(&urgent_root) {
+            Ok(it) => it
+                .flatten()
+                .map(|e| e.path())
+                .filter(|p| p.is_dir())
+                .collect(),
+            Err(_) => Vec::new(),
+        },
+    };
+
+    let mut out = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for dir in subdirs {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let link_path = entry.path();
+            let Some(name) = link_path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".md") {
+                continue;
+            }
+            let canonical = match std::fs::canonicalize(&link_path) {
+                Ok(p) => p,
+                Err(e) => {
+                    log::debug!(
+                        "urgent lane: skipping broken link {}: {}",
+                        link_path.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+            if !seen.insert(canonical.clone()) {
+                continue;
+            }
+            if let Some(msg) = parse_message_file(&canonical) {
+                out.push(msg);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.fm.ts.cmp(&b.fm.ts).then_with(|| a.fm.id.cmp(&b.fm.id)));
+    out
+}
+
+/// Apply the `fetch` filter pipeline (priority lane fast-path, --for,
+/// --since, --priority semantics, --thread, --channel, --limit). Extracted
+/// from `cmd_fetch` so tests can exercise the same filter logic without
+/// going through stdout.
+#[allow(clippy::too_many_arguments)]
+pub fn select_messages(
+    inbox: &Path,
+    for_handle: Option<&str>,
+    since: Option<&str>,
+    priority: Option<MsgPriority>,
+    thread: Option<&str>,
+    channel: Option<&str>,
+    limit: Option<usize>,
+) -> Vec<ParsedMessage> {
+    // Fast path for --priority urgent|blocker: scan the priority lane under
+    // inbox/urgent/<handle>/ (+ inbox/urgent/all/ for broadcasts) instead of
+    // the whole flat inbox. Design §2.5 / §2.9.
+    let mut msgs = match priority {
+        Some(MsgPriority::Urgent) | Some(MsgPriority::Blocker) => {
+            scan_urgent_lane(inbox, for_handle)
+        }
+        _ => list_messages(inbox),
+    };
+
+    if let Some(h) = for_handle {
+        msgs.retain(|m| matches_for_handle(&m.fm, h));
+    }
+    if let Some(ts_or_cursor) = since {
+        let cursor = ts_or_cursor.trim();
+        msgs.retain(|m| !m.fm.ts.is_empty() && m.fm.ts.as_str() >= cursor);
+    }
+    if let Some(p) = priority {
+        // `--priority urgent` returns the whole urgent lane (urgent + blocker);
+        // `--priority blocker` is an exact match; `--priority routine` is
+        // exact too. This matches how a reader thinks about "show me what
+        // deserves attention" vs "show me what must stop work now".
+        msgs.retain(|m| match p {
+            MsgPriority::Urgent => matches!(
+                m.fm.priority,
+                MsgPriority::Urgent | MsgPriority::Blocker
+            ),
+            MsgPriority::Blocker => m.fm.priority == MsgPriority::Blocker,
+            MsgPriority::Routine => m.fm.priority == MsgPriority::Routine,
+        });
+    }
+    if let Some(t) = thread {
+        msgs.retain(|m| m.fm.thread.as_deref() == Some(t) || m.fm.id == t);
+    }
+    if let Some(ch) = channel {
+        msgs.retain(|m| matches_channel(&m.fm, ch));
+    }
+    if let Some(n) = limit {
+        msgs.truncate(n);
+    }
+    msgs
 }
 
 pub fn parse_message_file(path: &Path) -> Option<ParsedMessage> {
@@ -915,29 +1086,15 @@ pub fn cmd_fetch(
             })
     };
 
-    let mut msgs = list_messages(&inbox);
-
-    if let Some(h) = effective_for.as_deref() {
-        msgs.retain(|m| matches_for_handle(&m.fm, h));
-    }
-    if let Some(ref ts_or_cursor) = since {
-        let cursor = ts_or_cursor.trim();
-        msgs.retain(|m| !m.fm.ts.is_empty() && m.fm.ts.as_str() >= cursor);
-    }
-    if let Some(p) = priority {
-        msgs.retain(|m| m.fm.priority == p);
-    }
-    if let Some(ref t) = thread {
-        msgs.retain(|m| {
-            m.fm.thread.as_deref() == Some(t.as_str()) || m.fm.id == *t
-        });
-    }
-    if let Some(ref ch) = channel {
-        msgs.retain(|m| matches_channel(&m.fm, ch));
-    }
-    if let Some(n) = limit {
-        msgs.truncate(n);
-    }
+    let msgs = select_messages(
+        &inbox,
+        effective_for.as_deref(),
+        since.as_deref(),
+        priority,
+        thread.as_deref(),
+        channel.as_deref(),
+        limit,
+    );
 
     match format {
         FetchFormat::Json => match serde_json::to_string_pretty(&msgs) {
@@ -1719,5 +1876,218 @@ new\n";
             }
             _ => panic!("expected Send"),
         }
+    }
+
+    // ---- PR-4: priority lane (urgent/ symlinks + --priority filter) -------
+
+    fn send(
+        inbox: &Path,
+        to: Vec<&str>,
+        priority: MsgPriority,
+        body: &str,
+    ) -> SentMessage {
+        write_message(
+            inbox,
+            SendArgs {
+                to: to.into_iter().map(|s| s.to_string()).collect(),
+                from: "implementer-a".to_string(),
+                priority,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: body.to_string(),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn send_urgent_creates_symlink_in_urgent_lane() {
+        let g = MailboxGuard::new();
+        let sent = send(&g.inbox(), vec!["reviewer"], MsgPriority::Urgent, "ping");
+
+        let filename = sent.path.file_name().unwrap().to_str().unwrap();
+        let link = g.inbox().join("urgent").join("reviewer").join(filename);
+        assert!(link.is_symlink(), "expected symlink at {}", link.display());
+
+        // The symlink resolves to the canonical file under the flat inbox.
+        let resolved = std::fs::canonicalize(&link).unwrap();
+        let canonical = std::fs::canonicalize(&sent.path).unwrap();
+        assert_eq!(resolved, canonical);
+
+        // Blocker behaves the same way (same lane).
+        let sent2 = send(
+            &g.inbox(),
+            vec!["reviewer"],
+            MsgPriority::Blocker,
+            "stop everything",
+        );
+        let f2 = sent2.path.file_name().unwrap().to_str().unwrap();
+        assert!(g.inbox().join("urgent").join("reviewer").join(f2).is_symlink());
+    }
+
+    #[test]
+    fn send_routine_does_not_create_urgent_symlink() {
+        let g = MailboxGuard::new();
+        let sent = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "fyi");
+
+        let filename = sent.path.file_name().unwrap().to_str().unwrap();
+        let link = g.inbox().join("urgent").join("reviewer").join(filename);
+        assert!(!link.exists(), "urgent link unexpectedly created: {}", link.display());
+        assert!(!link.is_symlink());
+
+        // Even the per-recipient urgent dir should not be auto-created for
+        // routine traffic. (Sweeping it out keeps `ls inbox/urgent/` tidy.)
+        let per_recipient = g.inbox().join("urgent").join("reviewer");
+        assert!(!per_recipient.exists(), "urgent/reviewer/ created for routine: {}", per_recipient.display());
+    }
+
+    #[test]
+    fn fetch_priority_urgent_returns_urgent_and_blocker_not_routine() {
+        let g = MailboxGuard::new();
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "r");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Urgent, "u");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Blocker, "b");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            None,
+            Some(MsgPriority::Urgent),
+            None,
+            None,
+            None,
+        );
+        let bodies: Vec<String> = msgs.iter().map(|m| m.body.trim().to_string()).collect();
+        assert_eq!(msgs.len(), 2, "got bodies: {:?}", bodies);
+        assert!(bodies.contains(&"u".to_string()));
+        assert!(bodies.contains(&"b".to_string()));
+        assert!(!bodies.contains(&"r".to_string()));
+    }
+
+    #[test]
+    fn fetch_priority_blocker_returns_only_blocker() {
+        let g = MailboxGuard::new();
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "r");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Urgent, "u");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Blocker, "b");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            None,
+            Some(MsgPriority::Blocker),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].fm.priority, MsgPriority::Blocker);
+        assert_eq!(msgs[0].body.trim(), "b");
+    }
+
+    #[test]
+    fn broken_symlink_in_urgent_lane_does_not_crash_fetch() {
+        let g = MailboxGuard::new();
+        let sent = send(
+            &g.inbox(),
+            vec!["reviewer"],
+            MsgPriority::Urgent,
+            "will be orphaned",
+        );
+        // Delete the canonical file — the urgent/ symlink now dangles.
+        std::fs::remove_file(&sent.path).unwrap();
+
+        // Also add a second message with a separately-dangling symlink that
+        // was never sent via write_message, to cover the "someone manually
+        // put a broken link in urgent/" case.
+        let orphan_target = PathBuf::from("../../ghost-20260420T000000Z-ZZZZZZ.md");
+        let orphan_link = g
+            .inbox()
+            .join("urgent")
+            .join("reviewer")
+            .join("20260420T000000Z-ZZZZZZ.md");
+        std::os::unix::fs::symlink(&orphan_target, &orphan_link).unwrap();
+
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            None,
+            Some(MsgPriority::Urgent),
+            None,
+            None,
+            None,
+        );
+        // Nothing crashes, nothing resolves.
+        assert_eq!(msgs.len(), 0, "got: {:?}", msgs);
+    }
+
+    #[test]
+    fn multi_recipient_direct_urgent_symlinks_one_per_recipient() {
+        let g = MailboxGuard::new();
+        let sent = send(
+            &g.inbox(),
+            vec!["reviewer", "qa", "coordinator"],
+            MsgPriority::Urgent,
+            "heads up",
+        );
+        let filename = sent.path.file_name().unwrap().to_str().unwrap();
+        for recipient in ["reviewer", "qa", "coordinator"] {
+            let link = g.inbox().join("urgent").join(recipient).join(filename);
+            assert!(
+                link.is_symlink(),
+                "missing urgent symlink for {} at {}",
+                recipient,
+                link.display()
+            );
+            let canonical = std::fs::canonicalize(&link).unwrap();
+            assert_eq!(canonical, std::fs::canonicalize(&sent.path).unwrap());
+        }
+        // And every recipient's fetch sees exactly one message.
+        for recipient in ["reviewer", "qa", "coordinator"] {
+            let msgs = select_messages(
+                &g.inbox(),
+                Some(recipient),
+                None,
+                Some(MsgPriority::Urgent),
+                None,
+                None,
+                None,
+            );
+            assert_eq!(
+                msgs.len(),
+                1,
+                "recipient {} saw {} msgs",
+                recipient,
+                msgs.len()
+            );
+        }
+    }
+
+    #[test]
+    fn broadcast_urgent_lands_in_urgent_all() {
+        let g = MailboxGuard::new();
+        let sent = send(&g.inbox(), vec!["all"], MsgPriority::Urgent, "merge freeze");
+        let filename = sent.path.file_name().unwrap().to_str().unwrap();
+        let link = g.inbox().join("urgent").join("all").join(filename);
+        assert!(link.is_symlink(), "expected urgent/all symlink at {}", link.display());
+
+        // A recipient fetching --priority urgent sees it via the urgent/all/ scan.
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            None,
+            Some(MsgPriority::Urgent),
+            None,
+            None,
+            None,
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].body.trim(), "merge freeze");
     }
 }


### PR DESCRIPTION
## Summary

Implements **PR-4** of the [agent-messaging design](docs/designs/agent-messaging.md) (§2.5, §5).

- `twapp msg send --priority {urgent|blocker}` (and `broadcast`) write the canonical file under the flat `inbox/` **and** create a symlink under `inbox/urgent/<recipient>/<ts>-<id6>.md` → canonical path.
  - Broadcasts → `inbox/urgent/all/`.
  - Direct to N recipients → one symlink per recipient.
  - `channel:` recipients are skipped (land in PR-6).
  - Routine traffic never touches the urgent lane.
- `twapp msg fetch --priority {urgent|blocker}` takes a fast path: scans `inbox/urgent/<for-handle>/` + `inbox/urgent/all/` instead of the flat inbox, then frontmatter-filters.
  - `--priority urgent` returns the whole urgent lane (urgent + blocker).
  - `--priority blocker` is exact.
  - `--priority routine` is exact.
- Broken symlinks (canonical deleted, lane entry not swept yet) are skipped with a `log::debug!` trace, not a crash.

## Docs

- README: new "Priority lanes" subsection under "Messaging between sessions".
- `skills/agent-coordinator/SKILL.md` §3: `--priority blocker` idiom for time-sensitive coordinator asks, and a deprecation line noting that the `-URGENT` / `-REWORK` filename-hack idiom is replaced by `--priority urgent`.

## Test plan

All 6 tests from the briefing + one bonus for the broadcast path:

- [x] `send_urgent_creates_symlink_in_urgent_lane`
- [x] `send_routine_does_not_create_urgent_symlink`
- [x] `fetch_priority_urgent_returns_urgent_and_blocker_not_routine`
- [x] `fetch_priority_blocker_returns_only_blocker`
- [x] `broken_symlink_in_urgent_lane_does_not_crash_fetch`
- [x] `multi_recipient_direct_urgent_symlinks_one_per_recipient`
- [x] `broadcast_urgent_lands_in_urgent_all` (bonus)
- [x] Full test suite: 118 passed / 0 failed.
- [x] E2E smoke against a temp mailbox: urgent direct + blocker broadcast symlink correctly; routine does not; `fetch --priority urgent --for reviewer` returns both the direct urgent and the broadcast blocker via `urgent/all/`.

## Out of scope

- Presence (PR-5), channels (PR-6), directory split (PR-3). Channel recipients are deliberately skipped from urgent-lane symlinking; that wiring lands with PR-6.