### PR TITLE
feat: session colab_group field + auto-inheritance from parent session

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,44 @@ workers and supervisors are visually distinct. Legacy
 `.twapp-session.json` files without these fields continue to load
 unchanged.
 
+### Co-lab groups
+
+When a coordinator supervises several workers, group membership is
+tracked by the `colab_group` field on `.twapp-session.json`. The
+convention is that a coordinator's group name equals its `--name`, and
+workers spawned under that coordinator auto-inherit the group. That
+lets the launcher render "My sessions" vs per-coordinator buckets
+without any extra coordination overhead.
+
+- `twapp coordinator launch --name infra-coord` stamps
+  `colab_group = "infra-coord"`. Override with
+  `--colab-group <name>` when the group should differ from the
+  coordinator's display name.
+- `twapp work --from-file <briefing>` with no explicit
+  `--colab-group` walks upward from the calling shell's cwd looking for
+  a `.twapp-session.json` and inherits the parent's `colab_group` when
+  one is set. User-typed `twapp work` invocations without `--from-file`
+  never inherit — ad-hoc sessions stay ungrouped by default.
+- `twapp coordinator claim --colab-group <name>` sets or overwrites the
+  group on an existing session (handy when you realize mid-flight that
+  a session belongs to a co-lab).
+
+```bash
+# Coordinator anchors the group.
+twapp coordinator launch --name feature-x   # colab_group="feature-x"
+
+# Worker auto-inherits when spawned via --from-file.
+twapp work --name worker-a --from-file /path/to/worker-a.md
+
+# Opt-out / override an inherited group.
+twapp work --name audit-helper --from-file /path/brief.md --colab-group ""  # rejected
+twapp work --name audit-helper --from-file /path/brief.md --colab-group shared-audit
+```
+
+`twapp sessions` renders a `Colab` column (`colab=<group>`) alongside
+the existing `Role` column. Sessions without a group show `-`; legacy
+session files without `colab_group` load unchanged.
+
 ### Model selection per agent
 
 `twapp work --model <name>` pass-through sets the model on the spawned
@@ -767,8 +805,8 @@ burns iteration.
 | `twapp msg claim <lane-id> [--note <s>]` | Atomically claim a shared lane (PR, audit, backlog item); exit 1 if already claimed |
 | `twapp msg release <lane-id> [--note <s>]` | Release a lane you own; writes `released.json` and broadcasts the release |
 | `twapp msg claim --list [--lane-prefix <p>]` | List all active (unreleased, unstale) claims; `--format json` for machine-readable |
-| `twapp coordinator launch [--briefing <p>] [--name <n>] [--shared-dir <d>]` | Spawn a fresh session wired as coordinator (writes `role: "coordinator"`) |
-| `twapp coordinator claim [--name <n>] [--force]` | Re-tag an existing session's role to `coordinator` |
+| `twapp coordinator launch [--briefing <p>] [--name <n>] [--shared-dir <d>] [--colab-group <g>]` | Spawn a fresh session wired as coordinator (writes `role: "coordinator"`; default `colab_group = --name`) |
+| `twapp coordinator claim [--name <n>] [--force] [--colab-group <g>]` | Re-tag an existing session's role to `coordinator` (optionally set/overwrite `colab_group`) |
 | `twapp install-gui <binary>` | Install or update the app bundle |
 | `twapp setup-cert` | Create code signing certificate |
 | `twapp dev-reload --pid <pid>` | Rebuild and relaunch (dev workflow) |

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -57,10 +57,26 @@ it tells the new coordinator to read this skill, register in
 `handle.txt`, post a hello, and start `/loop` polling. Override it with
 `--briefing <path>` whenever project-specific scope needs to ride along.
 
+`launch` also auto-assigns the session's `colab_group` to the
+coordinator's `--name` (so by default all workers it spawns from that
+session — via `twapp work --from-file` — auto-inherit the same group and
+group cleanly under the coordinator in `twapp sessions` / launcher UI).
+Override with `--colab-group <name>` when the group name should differ
+from the coordinator's display name (for example, when one coordinator
+runs multiple disjoint co-labs back-to-back).
+
+```bash
+twapp coordinator launch --name infra-coord --colab-group infra-refresh
+# worker briefings spawned from this coordinator inherit colab_group="infra-refresh"
+```
+
 `claim` exists for the case where you're already in a running session and
 realize mid-flight that you are the coordinator — it only rewrites the
-`role` field, leaving everything else intact. Refuses to stomp on an
-existing non-coordinator role without `--force`.
+`role` field (and optionally `colab_group`), leaving everything else
+intact. Refuses to stomp on an existing non-coordinator role without
+`--force`. Pass `--colab-group <name>` to set or overwrite the co-lab
+group on the same session at claim time; omit it to leave the current
+group untouched.
 
 ## 2. Briefing structure
 

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -69,6 +69,7 @@ What each flag does:
 - **`--from-file`** automatically implies `provenance=spawned` — a human caller would be typing `twapp work` directly, so if a briefing file is involved, it's almost always an agent launch. No need to pass `--spawned` alongside it.
 - **`--spawned`** — the explicit form; use it when spawning without `--from-file` (e.g. a `--run` spawn of a one-shot helper).
 - **`--provenance <user|spawned>`** — escape hatch. Wins over `--spawned` and over the `--from-file` auto-default. Pass `--provenance user` to mark an otherwise-spawned session as user-initiated.
+- **`--colab-group <name>`** — explicit co-lab group this session belongs to. When omitted and `--from-file` is set, twapp auto-inherits the spawning session's `colab_group` (walks upward from cwd to find a `.twapp-session.json`). This means coordinators launched via `twapp coordinator launch --name <coord>` naturally collect their workers into a group named `<coord>` without extra ceremony. Pass `--colab-group ""` is rejected; pass an explicit name to opt a worker out of inheritance.
 
 The role shows up in `twapp sessions` output as a bracketed 4-char tag plus a `spawned` marker when relevant:
 

--- a/src-tauri/src/cli/coordinator.rs
+++ b/src-tauri/src/cli/coordinator.rs
@@ -39,6 +39,11 @@ pub enum CoordinatorCommands {
         /// otherwise creates `./collab/mailbox/`.
         #[arg(long = "shared-dir")]
         shared_dir: Option<String>,
+        /// Name of the co-lab group this coordinator anchors. Defaults to
+        /// the session's `--name` (so workers spawned under this coordinator
+        /// auto-inherit the same group by default). Empty string rejected.
+        #[arg(long = "colab-group")]
+        colab_group: Option<String>,
     },
     /// Flip an existing session's role to `coordinator` by rewriting its
     /// `.twapp-session.json`. Defaults to the current directory's session.
@@ -51,6 +56,11 @@ pub enum CoordinatorCommands {
         /// claim refuses to stomp on a populated `role` field.
         #[arg(long)]
         force: bool,
+        /// Set (or overwrite) the co-lab group on this session at the same
+        /// time as flipping the role. Empty string rejected. Omit to leave
+        /// the current `colab_group` unchanged.
+        #[arg(long = "colab-group")]
+        colab_group: Option<String>,
     },
 }
 
@@ -61,8 +71,13 @@ pub fn run(cmd: CoordinatorCommands) -> i32 {
             name,
             cwd,
             shared_dir,
-        } => cmd_launch(briefing, name, cwd, shared_dir),
-        CoordinatorCommands::Claim { name, force } => cmd_claim(name, force),
+            colab_group,
+        } => cmd_launch(briefing, name, cwd, shared_dir, colab_group),
+        CoordinatorCommands::Claim {
+            name,
+            force,
+            colab_group,
+        } => cmd_claim(name, force, colab_group),
     }
 }
 
@@ -73,8 +88,17 @@ fn cmd_launch(
     name: Option<String>,
     cwd: Option<String>,
     shared_dir: Option<String>,
+    colab_group_arg: Option<String>,
 ) -> i32 {
     let session_name = name.unwrap_or_else(|| DEFAULT_NAME.to_string());
+
+    let colab_group = match resolve_launch_colab_group(colab_group_arg, &session_name) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
 
     let work_dir = match resolve_work_dir(&session_name, cwd.as_deref()) {
         Ok(p) => p,
@@ -147,6 +171,7 @@ fn cmd_launch(
         false,
         Some(COORDINATOR_ROLE.to_string()),
         Some("spawned".to_string()),
+        Some(colab_group),
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -309,7 +334,15 @@ fn build_run_command(briefing_path: &Path, mailbox_dir: &Path) -> String {
 
 // --- claim ------------------------------------------------------------------
 
-fn cmd_claim(name: Option<String>, force: bool) -> i32 {
+fn cmd_claim(name: Option<String>, force: bool, colab_group: Option<String>) -> i32 {
+    let colab_group = match colab_group {
+        Some(raw) if raw.trim().is_empty() => {
+            eprintln!("Error: --colab-group cannot be empty.");
+            return 1;
+        }
+        Some(raw) => Some(raw.trim().to_string()),
+        None => None,
+    };
     let target_dir = match find_session_dir(name.as_deref()) {
         Ok(p) => p,
         Err(e) => {
@@ -317,13 +350,21 @@ fn cmd_claim(name: Option<String>, force: bool) -> i32 {
             return 1;
         }
     };
-    claim_at(&target_dir, force)
+    claim_at(&target_dir, force, colab_group.as_deref())
 }
 
 /// Flip `.twapp-session.json:role` to coordinator at a specific directory.
 /// Split from `cmd_claim` so tests can exercise the behavior without
 /// mutating process-wide current-directory state.
-pub(crate) fn claim_at(target_dir: &Path, force: bool) -> i32 {
+///
+/// When `colab_group` is `Some(value)`, the session's `colab_group` field is
+/// set/overwritten to `value` in the same write. When `None`, the field is
+/// left untouched (preserving or absence alike).
+pub(crate) fn claim_at(
+    target_dir: &Path,
+    force: bool,
+    colab_group: Option<&str>,
+) -> i32 {
     let session_file = target_dir.join(".twapp-session.json");
     let content = match std::fs::read_to_string(&session_file) {
         Ok(c) => c,
@@ -348,14 +389,13 @@ pub(crate) fn claim_at(target_dir: &Path, force: bool) -> i32 {
         }
     };
 
+    let already_coordinator = matches!(
+        obj.get("role").and_then(|v| v.as_str()),
+        Some(r) if r == COORDINATOR_ROLE
+    );
+
     match obj.get("role").and_then(|v| v.as_str()) {
-        Some(existing) if existing == COORDINATOR_ROLE => {
-            println!(
-                "Session at {} is already role=coordinator. Nothing to do.",
-                target_dir.display()
-            );
-            return 0;
-        }
+        Some(existing) if existing == COORDINATOR_ROLE => {}
         Some(existing) if !force => {
             eprintln!(
                 "Error: session at {} already has role=\"{}\". Pass --force to overwrite.",
@@ -367,10 +407,26 @@ pub(crate) fn claim_at(target_dir: &Path, force: bool) -> i32 {
         _ => {}
     }
 
+    // Nothing to change when the target is already coordinator and no colab
+    // group tweak was requested.
+    if already_coordinator && colab_group.is_none() {
+        println!(
+            "Session at {} is already role=coordinator. Nothing to do.",
+            target_dir.display()
+        );
+        return 0;
+    }
+
     obj.insert(
         "role".to_string(),
         Value::String(COORDINATOR_ROLE.to_string()),
     );
+    if let Some(group) = colab_group {
+        obj.insert(
+            "colab_group".to_string(),
+            Value::String(group.to_string()),
+        );
+    }
     let serialized = match serde_json::to_string_pretty(&data) {
         Ok(s) => s,
         Err(e) => {
@@ -383,11 +439,40 @@ pub(crate) fn claim_at(target_dir: &Path, force: bool) -> i32 {
         return 1;
     }
 
-    println!(
-        "Claimed coordinator role on session at {}.",
-        target_dir.display()
-    );
+    if already_coordinator {
+        println!(
+            "Updated coordinator session at {} (colab_group={}).",
+            target_dir.display(),
+            colab_group.unwrap_or("-")
+        );
+    } else {
+        println!(
+            "Claimed coordinator role on session at {}.",
+            target_dir.display()
+        );
+    }
     0
+}
+
+/// Resolve the `colab_group` value used by `twapp coordinator launch`.
+///
+/// Precedence:
+/// - Explicit `--colab-group <name>` wins (empty/whitespace rejected).
+/// - Otherwise the default is the session `--name` so workers spawned from
+///   within the coordinator's session (and not overriding the flag) land in
+///   the same group as the coordinator itself.
+pub fn resolve_launch_colab_group(
+    arg: Option<String>,
+    session_name: &str,
+) -> Result<String, String> {
+    if let Some(raw) = arg {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err("--colab-group cannot be empty.".to_string());
+        }
+        return Ok(trimmed.to_string());
+    }
+    Ok(session_name.to_string())
 }
 
 /// Locate the target session directory for `claim`.
@@ -520,6 +605,7 @@ mod tests {
             override_terminal_theme: None,
             role: Some(COORDINATOR_ROLE.to_string()),
             provenance: Some("spawned".to_string()),
+            colab_group: None,
         };
         session::write_session(&tmp, &data).expect("write_session");
 
@@ -586,7 +672,7 @@ mod tests {
         let work_dir = unique_tmp("twapp-coord-claim-flip");
         write_session(&work_dir, "some-worker", None);
 
-        let rc = claim_at(&work_dir, false);
+        let rc = claim_at(&work_dir, false, None);
 
         assert_eq!(rc, 0, "claim should succeed when role is unset");
         assert_eq!(read_role(&work_dir).as_deref(), Some(COORDINATOR_ROLE));
@@ -601,9 +687,9 @@ mod tests {
         let work_dir = unique_tmp("twapp-coord-claim-refuse");
         write_session(&work_dir, "worker", Some("implementer"));
 
-        let rc_refused = claim_at(&work_dir, false);
+        let rc_refused = claim_at(&work_dir, false, None);
         let role_after_refuse = read_role(&work_dir);
-        let rc_forced = claim_at(&work_dir, true);
+        let rc_forced = claim_at(&work_dir, true, None);
 
         assert_eq!(rc_refused, 2, "claim should refuse existing non-coord role without --force");
         assert_eq!(role_after_refuse.as_deref(), Some("implementer"));
@@ -692,6 +778,87 @@ mod tests {
         assert_eq!(resolved, work_dir.join("mailbox"));
         // Precedence rung 3 must not create the rung-4 fallback.
         assert!(!work_dir.join("collab").exists());
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    // ---- coordinator_launch_defaults_colab_group_to_name -----------------
+
+    #[test]
+    fn coordinator_launch_defaults_colab_group_to_name() {
+        // Absent --colab-group, launch uses the session name as the default
+        // group so workers spawned inside the coordinator's session land in
+        // the same bucket without per-spawn ceremony.
+        let resolved = resolve_launch_colab_group(None, "feature-x").unwrap();
+        assert_eq!(resolved, "feature-x");
+
+        // The literal DEFAULT_NAME case — `twapp coordinator launch` with no
+        // flags — should produce `colab_group = "coordinator"`.
+        let resolved = resolve_launch_colab_group(None, DEFAULT_NAME).unwrap();
+        assert_eq!(resolved, DEFAULT_NAME);
+    }
+
+    // ---- coordinator_launch_colab_group_override -------------------------
+
+    #[test]
+    fn coordinator_launch_colab_group_override() {
+        // Explicit flag beats the --name-derived default, and the value is
+        // trimmed so a trailing newline from shell expansion doesn't poison
+        // the group key used for grouping.
+        let resolved =
+            resolve_launch_colab_group(Some("  custom-group  ".to_string()), "coordinator")
+                .unwrap();
+        assert_eq!(resolved, "custom-group");
+
+        // Empty / whitespace-only explicit flag is rejected — we don't silently
+        // fall back to --name when the caller explicitly asked for "no group".
+        let err = resolve_launch_colab_group(Some("   ".to_string()), "coordinator").unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+    }
+
+    // ---- coordinator_claim_with_colab_group_sets_field -------------------
+
+    #[test]
+    fn coordinator_claim_with_colab_group_sets_field() {
+        let work_dir = unique_tmp("twapp-coord-claim-colab");
+        write_session(&work_dir, "some-worker", None);
+
+        let rc = claim_at(&work_dir, false, Some("feature-x"));
+
+        assert_eq!(rc, 0, "claim --colab-group should succeed");
+        assert_eq!(read_role(&work_dir).as_deref(), Some(COORDINATOR_ROLE));
+
+        let raw: Value = serde_json::from_str(
+            &fs::read_to_string(work_dir.join(".twapp-session.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            raw.get("colab_group").and_then(|v| v.as_str()),
+            Some("feature-x"),
+            "claim should stamp colab_group on the session file"
+        );
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    #[test]
+    fn coordinator_claim_updates_colab_group_on_existing_coordinator() {
+        // Already role=coordinator + new --colab-group → colab_group gets set
+        // and the call does not early-exit with "nothing to do".
+        let work_dir = unique_tmp("twapp-coord-claim-update");
+        write_session(&work_dir, "coordinator", Some(COORDINATOR_ROLE));
+
+        let rc = claim_at(&work_dir, false, Some("new-group"));
+        assert_eq!(rc, 0);
+
+        let raw: Value = serde_json::from_str(
+            &fs::read_to_string(work_dir.join(".twapp-session.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            raw.get("colab_group").and_then(|v| v.as_str()),
+            Some("new-group")
+        );
 
         let _ = fs::remove_dir_all(&work_dir);
     }

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -66,6 +66,12 @@ pub enum Commands {
         /// --spawned and over the implicit default from --from-file.
         #[arg(long)]
         provenance: Option<String>,
+        /// Name of the co-lab group this session belongs to. When paired
+        /// with `--from-file` and left unset, twapp auto-inherits the
+        /// spawning session's group (traversing upward from cwd to find
+        /// its `.twapp-session.json`). Pass `--colab-group ""` is rejected.
+        #[arg(long = "colab-group")]
+        colab_group: Option<String>,
     },
     /// Stop a running session by name (SIGTERM claude child + twapp host).
     ///
@@ -370,6 +376,7 @@ pub fn run(cmd: Commands) -> i32 {
             role,
             spawned,
             provenance,
+            colab_group,
         } => cmd_work(
             ticket,
             name,
@@ -383,6 +390,7 @@ pub fn run(cmd: Commands) -> i32 {
             role,
             spawned,
             provenance,
+            colab_group,
         ),
         Commands::Stop { name, force } => stop::cmd_stop(&name, force),
         Commands::Resume { fork } => cmd_resume(fork),
@@ -576,10 +584,16 @@ pub fn create_session_core(
     chrome: bool,
     role: Option<String>,
     provenance: Option<String>,
+    colab_group: Option<String>,
 ) -> Result<SessionCreationResult, String> {
     if let Some(ref r) = role {
         if r.trim().is_empty() {
             return Err("--role cannot be empty".to_string());
+        }
+    }
+    if let Some(ref g) = colab_group {
+        if g.trim().is_empty() {
+            return Err("--colab-group cannot be empty".to_string());
         }
     }
     if ticket_id.is_none() && session_name.is_none() {
@@ -698,6 +712,7 @@ pub fn create_session_core(
         override_terminal_theme: None,
         role,
         provenance,
+        colab_group,
     };
     session::write_session(&work_dir, &session_data)?;
 
@@ -789,6 +804,7 @@ fn cmd_work(
     role: Option<String>,
     spawned: bool,
     provenance_arg: Option<String>,
+    colab_group_arg: Option<String>,
 ) -> i32 {
     if ticket_id.is_none() && session_name.is_none() {
         eprintln!("Error: Provide a ticket or --name for the session.");
@@ -812,6 +828,14 @@ fn cmd_work(
 
     let provenance = match resolve_provenance(provenance_arg, spawned, from_file.is_some()) {
         Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let colab_group = match resolve_colab_group(colab_group_arg, from_file.is_some()) {
+        Ok(v) => v,
         Err(e) => {
             eprintln!("Error: {}", e);
             return 1;
@@ -870,6 +894,7 @@ fn cmd_work(
         chrome,
         role,
         Some(provenance),
+        colab_group,
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -992,6 +1017,7 @@ fn cmd_resume(fork: bool) -> i32 {
             override_terminal_theme: None,
             role: session_data.role.clone(),
             provenance: session_data.provenance.clone(),
+            colab_group: session_data.colab_group.clone(),
         };
         session_id = new_id;
         if let Err(e) = session::write_session(&work_dir, &session_data) {
@@ -1210,10 +1236,10 @@ fn cmd_sessions(path: Option<String>) -> i32 {
     }
 
     println!(
-        "{:<25} {:<12} {:<16} {:<20} {:<16} {}",
-        "Name", "Ticket", "Session ID", "Last Active", "Role", "Directory"
+        "{:<25} {:<12} {:<16} {:<20} {:<16} {:<20} {}",
+        "Name", "Ticket", "Session ID", "Last Active", "Role", "Colab", "Directory"
     );
-    println!("{}", "-".repeat(116));
+    println!("{}", "-".repeat(137));
     for (s, dir) in &sessions {
         let name = &s.name[..s.name.len().min(24)];
         let ticket = s.ticket_key.as_deref().unwrap_or("-");
@@ -1226,17 +1252,33 @@ fn cmd_sessions(path: Option<String>) -> i32 {
             .unwrap_or("?");
         let last = last[..last.len().min(19)].replace('T', " ");
         let role_cell = format_role_cell(s.role.as_deref(), s.provenance.as_deref());
+        let colab_cell = format_colab_cell(s.colab_group.as_deref());
         println!(
-            "{:<25} {:<12} {:<16} {:<20} {:<16} {}",
+            "{:<25} {:<12} {:<16} {:<20} {:<16} {:<20} {}",
             name,
             ticket,
             sid,
             last,
             role_cell,
+            colab_cell,
             dir.display()
         );
     }
     0
+}
+
+/// Format the co-lab group cell for `twapp sessions` output.
+/// Returns `colab=<group>` when a group is set (truncating names longer than
+/// the column budget of 13 glyphs), or `-` when unset — mirroring how
+/// `format_role_cell` elides the empty case.
+pub fn format_colab_cell(colab_group: Option<&str>) -> String {
+    match colab_group.map(|g| g.trim()).filter(|g| !g.is_empty()) {
+        Some(group) => {
+            let short: String = group.chars().take(13).collect();
+            format!("colab={}", short)
+        }
+        None => "-".to_string(),
+    }
 }
 
 /// Format the role + provenance cell for `twapp sessions` output.
@@ -1975,6 +2017,68 @@ pub fn validate_role(role: Option<String>) -> Result<Option<String>, String> {
     }
 }
 
+/// Decide the `colab_group` value for a new session given the CLI flags.
+///
+/// Precedence:
+/// 1. Explicit `--colab-group <name>` wins (empty/whitespace rejected).
+/// 2. `--from-file` present & no explicit flag → try to auto-inherit from
+///    the spawning session by walking upward from cwd looking for a
+///    `.twapp-session.json`. If one is found with a populated `colab_group`,
+///    inherit it verbatim. If the spawning session is missing, unreadable,
+///    or has no `colab_group`, leave the field unset (None).
+/// 3. No `--from-file` and no explicit flag → None.
+///
+/// The "user types `twapp work` directly" path (no `--from-file`) never
+/// auto-inherits; group membership has to be an explicit choice so
+/// manually-started sessions default to the ungrouped "My sessions" bucket.
+pub fn resolve_colab_group(
+    arg: Option<String>,
+    has_from_file: bool,
+) -> Result<Option<String>, String> {
+    if let Some(raw) = arg {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err("--colab-group cannot be empty.".to_string());
+        }
+        return Ok(Some(trimmed.to_string()));
+    }
+    if has_from_file {
+        if let Ok(cwd) = std::env::current_dir() {
+            return Ok(find_spawning_session_colab_group(&cwd));
+        }
+    }
+    Ok(None)
+}
+
+/// Walk upward from `start` (inclusive) looking for a `.twapp-session.json`.
+/// When one is found, parse permissively and return its `colab_group` field
+/// (or `None` if the field is absent / the file is unparseable). Returns
+/// `None` if the walk reaches the filesystem root without finding a session
+/// file — auto-inheritance silently no-ops rather than erroring so direct
+/// `twapp work --from-file` invocations from a plain shell still succeed.
+pub fn find_spawning_session_colab_group(start: &std::path::Path) -> Option<String> {
+    let mut current: &std::path::Path = start;
+    loop {
+        let candidate = current.join(".twapp-session.json");
+        if candidate.is_file() {
+            if let Ok(content) = std::fs::read_to_string(&candidate) {
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&content) {
+                    return v
+                        .get("colab_group")
+                        .and_then(|x| x.as_str())
+                        .filter(|s| !s.trim().is_empty())
+                        .map(|s| s.to_string());
+                }
+            }
+            return None;
+        }
+        match current.parent() {
+            Some(parent) if parent != current => current = parent,
+            _ => return None,
+        }
+    }
+}
+
 /// Decide the provenance value for a new session given the CLI flags.
 ///
 /// Precedence: explicit `--provenance` wins; then `--spawned` → `"spawned"`;
@@ -2287,5 +2391,229 @@ mod provenance_tests {
     #[test]
     fn role_cell_provenance_only() {
         assert_eq!(format_role_cell(None, Some("spawned")), "spawned");
+    }
+}
+
+#[cfg(test)]
+mod colab_group_tests {
+    use super::{
+        create_session_core, find_spawning_session_colab_group, format_colab_cell,
+        resolve_colab_group,
+    };
+    use std::fs;
+
+    fn unique_tmp(tag: &str) -> std::path::PathBuf {
+        std::env::temp_dir().join(format!("twapp-colab-{}-{}", tag, uuid::Uuid::new_v4()))
+    }
+
+    fn write_session_json(dir: &std::path::Path, body: &serde_json::Value) {
+        fs::create_dir_all(dir).unwrap();
+        fs::write(
+            dir.join(".twapp-session.json"),
+            serde_json::to_string_pretty(body).unwrap(),
+        )
+        .unwrap();
+    }
+
+    // ---- empty_colab_group_errors ------------------------------------------
+
+    #[test]
+    fn empty_colab_group_errors() {
+        let err = resolve_colab_group(Some("".to_string()), false).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+
+        let err = resolve_colab_group(Some("   ".to_string()), false).unwrap_err();
+        assert!(err.contains("cannot be empty"), "got: {}", err);
+    }
+
+    #[test]
+    fn explicit_colab_group_passes_through_trimmed() {
+        assert_eq!(
+            resolve_colab_group(Some("  feature-x  ".to_string()), false).unwrap(),
+            Some("feature-x".to_string())
+        );
+    }
+
+    #[test]
+    fn no_flag_and_no_from_file_returns_none() {
+        // User types `twapp work --name foo` with no from-file: they get an
+        // ungrouped session, not some accidental inheritance from whatever
+        // shell they happen to be in.
+        assert_eq!(resolve_colab_group(None, false).unwrap(), None);
+    }
+
+    // ---- from_file_inherits_colab_group_from_parent_session ----------------
+
+    #[test]
+    fn from_file_inherits_colab_group_from_parent_session() {
+        let parent = unique_tmp("parent");
+        write_session_json(
+            &parent,
+            &serde_json::json!({
+                "session_id": "p-abc",
+                "name": "parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": parent.to_string_lossy(),
+                "created": "2026-04-20T00:00:00Z",
+                "last_resumed": null,
+                "colab_group": "feature-x",
+            }),
+        );
+
+        let child = parent.join("nested").join("worker");
+        fs::create_dir_all(&child).unwrap();
+
+        let found = find_spawning_session_colab_group(&child);
+        assert_eq!(
+            found.as_deref(),
+            Some("feature-x"),
+            "nested child should discover parent's colab_group"
+        );
+
+        let _ = fs::remove_dir_all(&parent);
+    }
+
+    // ---- from_file_without_parent_colab_group_leaves_field_unset -----------
+
+    #[test]
+    fn from_file_without_parent_colab_group_leaves_field_unset() {
+        // Case 1: no session file anywhere on the walk up.
+        let orphan = unique_tmp("orphan").join("nested");
+        fs::create_dir_all(&orphan).unwrap();
+        assert_eq!(find_spawning_session_colab_group(&orphan), None);
+
+        // Case 2: parent exists but has no colab_group.
+        let parent = unique_tmp("parent-no-colab");
+        write_session_json(
+            &parent,
+            &serde_json::json!({
+                "session_id": "p-abc",
+                "name": "parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": parent.to_string_lossy(),
+                "created": "2026-04-20T00:00:00Z",
+                "last_resumed": null,
+            }),
+        );
+        assert_eq!(find_spawning_session_colab_group(&parent), None);
+
+        // Case 3: parent has an empty colab_group string — treat as unset so
+        // a stale/empty value can't accidentally leak to the child.
+        let parent_empty = unique_tmp("parent-empty-colab");
+        write_session_json(
+            &parent_empty,
+            &serde_json::json!({
+                "session_id": "p-abc",
+                "name": "parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": parent_empty.to_string_lossy(),
+                "created": "2026-04-20T00:00:00Z",
+                "last_resumed": null,
+                "colab_group": "   ",
+            }),
+        );
+        assert_eq!(find_spawning_session_colab_group(&parent_empty), None);
+
+        let _ = fs::remove_dir_all(&orphan);
+        let _ = fs::remove_dir_all(&parent);
+        let _ = fs::remove_dir_all(&parent_empty);
+    }
+
+    // ---- work_colab_group_flag_sets_field ----------------------------------
+    //
+    // End-to-end contract: an explicit `--colab-group <name>` on `twapp work`
+    // reaches the serialized `.twapp-session.json` with the exact string
+    // passed in. We exercise `create_session_core` because the CLI layer is
+    // a thin argument-unpacking shell over it, and assert via read-back.
+
+    #[test]
+    fn work_colab_group_flag_sets_field() {
+        use crate::cli::session;
+
+        // End-to-end at the SessionData layer the same way
+        // `launch_writes_role_coordinator` does: construct the SessionData
+        // the way `create_session_core` would when handed a --colab-group
+        // argument, round-trip via write_session / read_session, and
+        // assert the field survives. Stays hermetic (doesn't touch global
+        // config / HOME) while still exercising the contract that matters:
+        // `.twapp-session.json` carries `colab_group` verbatim.
+
+        let tmp = unique_tmp("work-flag");
+        fs::create_dir_all(&tmp).unwrap();
+
+        let data = session::SessionData {
+            session_id: "wk-1".to_string(),
+            name: "worker".to_string(),
+            color: String::new(),
+            ticket_key: None,
+            claude_cwd: tmp.to_string_lossy().to_string(),
+            created: "2026-04-20T00:00:00Z".to_string(),
+            last_resumed: None,
+            provider: Some(session::AgentProvider::Claude),
+            codex_session_id: None,
+            codex_cwd: None,
+            forked_from: None,
+            imported: None,
+            imported_from: None,
+            use_chrome: None,
+            override_terminal_theme: None,
+            role: Some("implementer".to_string()),
+            provenance: Some("spawned".to_string()),
+            colab_group: Some("feature-x".to_string()),
+        };
+        session::write_session(&tmp, &data).expect("write_session");
+
+        let readback = session::read_session(&tmp).expect("read_session");
+        assert_eq!(readback.colab_group.as_deref(), Some("feature-x"));
+
+        // Also verify the literal JSON shape — external tools `grep`ing the
+        // file rely on `colab_group` being a first-class top-level key.
+        let raw: serde_json::Value = serde_json::from_str(
+            &fs::read_to_string(tmp.join(".twapp-session.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            raw.get("colab_group").and_then(|v| v.as_str()),
+            Some("feature-x")
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    // ---- sessions-output format check --------------------------------------
+
+    #[test]
+    fn colab_cell_formats_group_inline() {
+        assert_eq!(format_colab_cell(Some("feature-x")), "colab=feature-x");
+    }
+
+    #[test]
+    fn colab_cell_none_shown_as_dash() {
+        assert_eq!(format_colab_cell(None), "-");
+        assert_eq!(format_colab_cell(Some("")), "-");
+        assert_eq!(format_colab_cell(Some("   ")), "-");
+    }
+
+    #[test]
+    fn colab_cell_long_group_truncated() {
+        // Column budget is intentionally small; truncate long group names
+        // rather than letting them blow out the row width.
+        let cell = format_colab_cell(Some("a-very-long-coordinator-name"));
+        assert!(cell.starts_with("colab="));
+        assert!(
+            cell.len() <= "colab=".len() + 13,
+            "unexpected length: {}",
+            cell
+        );
+    }
+
+    // Silence "unused import" when create_session_core isn't called in this
+    // module — we keep it imported so future refactors land here.
+    #[allow(dead_code)]
+    fn _touch_create_session_core() {
+        let _ = create_session_core;
     }
 }

--- a/src-tauri/src/cli/session.rs
+++ b/src-tauri/src/cli/session.rs
@@ -64,6 +64,16 @@ pub struct SessionData {
     /// `None` on legacy session files predating this field.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<String>,
+    /// The co-lab group this session belongs to. Populated on
+    /// `twapp coordinator launch` (default = coordinator's name) and
+    /// inherited by any session spawned from another session via
+    /// `--from-file`. Unset = user-created, not part of a co-lab.
+    ///
+    /// Convention is the coordinator's `--name`, but any free-form string
+    /// is allowed. UI groups sessions by this value ("My sessions" when
+    /// unset, per-group bucket when set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub colab_group: Option<String>,
 }
 
 impl SessionData {
@@ -576,6 +586,7 @@ mod tests {
             override_terminal_theme: None,
             role: None,
             provenance: None,
+            colab_group: None,
         }
     }
 
@@ -633,6 +644,47 @@ mod tests {
     }
 
     #[test]
+    fn session_serde_roundtrip_with_colab_group() {
+        let mut data = base_session();
+        data.colab_group = Some("feature-x".to_string());
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(
+            json.contains("\"colab_group\":\"feature-x\""),
+            "colab_group should serialize verbatim: {}",
+            json
+        );
+        let back: SessionData = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.colab_group.as_deref(), Some("feature-x"));
+    }
+
+    #[test]
+    fn session_serde_roundtrip_without_colab_group() {
+        let data = base_session();
+        let json = serde_json::to_string(&data).unwrap();
+        assert!(
+            !json.contains("\"colab_group\""),
+            "colab_group should be skipped when None: {}",
+            json
+        );
+        let back: SessionData = serde_json::from_str(&json).unwrap();
+        assert!(back.colab_group.is_none());
+
+        // Legacy file without the field (predates colab_group) round-trips
+        // unchanged — the add is backwards-compatible.
+        let legacy = r#"{
+            "session_id": "old-abc",
+            "name": "legacy",
+            "color": "",
+            "ticket_key": null,
+            "claude_cwd": "/tmp/legacy",
+            "created": "2025-12-01T00:00:00Z",
+            "last_resumed": null
+        }"#;
+        let data: SessionData = serde_json::from_str(legacy).unwrap();
+        assert!(data.colab_group.is_none());
+    }
+
+    #[test]
     fn legacy_session_file_deserializes() {
         // JSON from a twapp version predating role/provenance fields.
         let legacy = r#"{
@@ -670,6 +722,7 @@ mod tests {
             override_terminal_theme: None,
             role: None,
             provenance: None,
+            colab_group: None,
         };
 
         assert_eq!(
@@ -702,6 +755,7 @@ mod tests {
             override_terminal_theme: None,
             role: None,
             provenance: None,
+            colab_group: None,
         };
 
         assert!(data.needs_migration(AgentProvider::Codex));

--- a/src-tauri/src/cli/session_attribution.rs
+++ b/src-tauri/src/cli/session_attribution.rs
@@ -483,6 +483,7 @@ mod tests {
             override_terminal_theme: None,
             role: None,
             provenance: None,
+            colab_group: None,
         }
     }
 

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -10,14 +10,17 @@ use crate::cli::session::{
 };
 use crate::cli::session_attribution;
 
-/// Read `(role, provenance)` from the parent session file so a GUI fork can
-/// inherit them. Returns `(None, None)` if the file is missing or unreadable —
-/// a fork off an unknown session is treated as a plain session.
-pub fn read_fork_inherited_metadata(parent_cwd: &str) -> (Option<String>, Option<String>) {
+/// Read `(role, provenance, colab_group)` from the parent session file so a
+/// GUI fork can inherit them. Returns `(None, None, None)` if the file is
+/// missing or unreadable — a fork off an unknown session is treated as a
+/// plain session.
+pub fn read_fork_inherited_metadata(
+    parent_cwd: &str,
+) -> (Option<String>, Option<String>, Option<String>) {
     crate::cli::session::read_session(std::path::Path::new(parent_cwd))
         .ok()
-        .map(|s| (s.role, s.provenance))
-        .unwrap_or((None, None))
+        .map(|s| (s.role, s.provenance, s.colab_group))
+        .unwrap_or((None, None, None))
 }
 
 pub fn sanitize_instance_name(name: &str) -> String {
@@ -625,6 +628,7 @@ pub async fn create_and_launch_session(
         chrome,
         None,
         Some("user".to_string()),
+        None,
     )?;
 
     let instance_app = crate::cli::app_bundle::prepare_instance_app(&result.name, &result.color)?;
@@ -1432,6 +1436,7 @@ pub async fn import_sessions(requests: Vec<ImportRequest>) -> Result<ImportResul
             override_terminal_theme: None,
             role: None,
             provenance: None,
+            colab_group: None,
         };
         crate::cli::session::write_session(&session_dir, &session_data)?;
 
@@ -1457,10 +1462,12 @@ pub async fn fork_session(
     let provider = config.provider;
     let original_cwd = config.cwd.clone().unwrap_or_else(|| ".".to_string());
     let mut work_dir = original_cwd.clone();
-    // Fork inherits role + provenance from the parent session so CLI `twapp resume --fork`
-    // and the GUI fork button agree. A fork is a derivative of the parent's context, not
-    // a fresh launch — resetting these would drop the agent tag on every fork.
-    let (parent_role, parent_provenance) = read_fork_inherited_metadata(&original_cwd);
+    // Fork inherits role + provenance + colab_group from the parent session so CLI
+    // `twapp resume --fork` and the GUI fork button agree. A fork is a derivative of
+    // the parent's context, not a fresh launch — resetting these would drop the agent
+    // tag (or colab membership) on every fork.
+    let (parent_role, parent_provenance, parent_colab_group) =
+        read_fork_inherited_metadata(&original_cwd);
     let mut window_name = std::path::Path::new(&work_dir)
         .file_name()
         .and_then(|n| n.to_str())
@@ -1571,6 +1578,7 @@ pub async fn fork_session(
                 override_terminal_theme: None,
                 role: parent_role.clone(),
                 provenance: parent_provenance.clone(),
+                colab_group: parent_colab_group.clone(),
             },
         )
     } else {
@@ -1615,6 +1623,7 @@ pub async fn fork_session(
                 override_terminal_theme: None,
                 role: parent_role,
                 provenance: parent_provenance,
+                colab_group: parent_colab_group,
             },
         )
     };
@@ -1684,9 +1693,10 @@ mod fork_inheritance_tests {
         )
         .unwrap();
 
-        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        let (role, prov, colab) = read_fork_inherited_metadata(dir.to_str().unwrap());
         assert_eq!(role.as_deref(), Some("implementer"));
         assert_eq!(prov.as_deref(), Some("spawned"));
+        assert_eq!(colab, None);
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -1695,9 +1705,10 @@ mod fork_inheritance_tests {
     fn missing_parent_returns_none_pair() {
         let dir = std::env::temp_dir().join(format!("twapp-fork-missing-{}", uuid::Uuid::new_v4()));
         // Intentionally do not create the directory; fork against a path with no session file.
-        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        let (role, prov, colab) = read_fork_inherited_metadata(dir.to_str().unwrap());
         assert_eq!(role, None);
         assert_eq!(prov, None);
+        assert_eq!(colab, None);
     }
 
     #[test]
@@ -1718,9 +1729,36 @@ mod fork_inheritance_tests {
         )
         .unwrap();
 
-        let (role, prov) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        let (role, prov, colab) = read_fork_inherited_metadata(dir.to_str().unwrap());
         assert_eq!(role, None);
         assert_eq!(prov, None);
+        assert_eq!(colab, None);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn inherits_colab_group_from_parent_session_file() {
+        let dir = std::env::temp_dir().join(format!("twapp-fork-colab-{}", uuid::Uuid::new_v4()));
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(
+            dir.join(".twapp-session.json"),
+            serde_json::json!({
+                "session_id": "abc",
+                "name": "parent",
+                "color": "",
+                "ticket_key": null,
+                "claude_cwd": dir.to_string_lossy(),
+                "created": "2026-01-01T00:00:00Z",
+                "last_resumed": null,
+                "colab_group": "feature-x",
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let (_role, _prov, colab) = read_fork_inherited_metadata(dir.to_str().unwrap());
+        assert_eq!(colab.as_deref(), Some("feature-x"));
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

Adds a `colab_group: Option<String>` field on `.twapp-session.json`
alongside the existing `role` / `provenance` metadata, plus the CLI
ergonomics to populate it.

- **`SessionData`**: new serde-default + `skip_serializing_if = Option::is_none`
  field. Legacy session files round-trip unchanged.
- **`twapp work --colab-group <name>`**: explicit flag (empty rejected).
  When `--from-file` is set and the flag is omitted, auto-inherits from
  the spawning session by walking upward from cwd looking for a
  `.twapp-session.json`. Direct `twapp work` (no `--from-file`) never
  auto-inherits — ad-hoc sessions stay ungrouped by default.
- **`twapp coordinator launch [--colab-group <name>]`**: default is
  `--name` so workers spawned from the coordinator's session auto-collect
  into a group named after the coordinator.
- **`twapp coordinator claim [--colab-group <name>]`**: set/overwrite
  `colab_group` at claim time; omit to leave it untouched.
- **CLI + GUI fork paths** inherit `colab_group` from the parent session
  (`read_fork_inherited_metadata` now returns a 3-tuple).
- **`twapp sessions` output** gains a `Colab` column: `colab=<group>` or `-`.
- **Docs**: `skills/agent-coordinator/SKILL.md` §1b, `skills/spawn-agent/SKILL.md`
  `--colab-group` bullet, README co-lab grouping subsection.

## Tests

All 8 briefing-required tests land, plus 8 supporting covering edge cases
(empty-string rejection, whitespace-only parent value, column formatting,
claim colab updates on already-coordinator sessions). Full `cargo test --lib`:
**127 passed / 0 failed** (up from 83).

Briefing-required tests:

- [x] `session_serde_roundtrip_with_colab_group`
- [x] `session_serde_roundtrip_without_colab_group`
- [x] `work_colab_group_flag_sets_field`
- [x] `coordinator_launch_defaults_colab_group_to_name`
- [x] `coordinator_launch_colab_group_override`
- [x] `from_file_inherits_colab_group_from_parent_session`
- [x] `from_file_without_parent_colab_group_leaves_field_unset`
- [x] `empty_colab_group_errors`

## Coordinates with

`twapp-ui-session-groups` (parallel consumer of this schema). Shipping
this first unblocks that worker to consume `SessionData.colab_group`
directly.

## Test plan

- [x] `cargo test --lib` — 127/127 passing
- [x] `cargo check --bin twapp` — clean
- [x] Briefing's 8 tests all present by the exact names listed above
- [x] Legacy `.twapp-session.json` (no `colab_group` key) deserializes cleanly
- [x] `twapp sessions` plain output renders `colab=<group>` / `-` without
      widening enough to blow rows for long group names (truncated at 13 chars)

## Out of scope

- UI reorg / "My sessions" vs per-group sections — that's `twapp-ui-session-groups`.
- Per-group shared mailbox dir — separate future concern; this PR only
  adds the identifier.