### PR TITLE
feat(ui): top-level "Launch/Claim coordinator" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,7 @@ ceremony.
 twapp coordinator launch                       # uses the bundled bootstrap briefing
 twapp coordinator launch --briefing /path/to/bootstrap.md
 twapp coordinator launch --shared-dir ~/collab/mailbox
+twapp coordinator launch --model claude-opus-4-7
 twapp coordinator claim                        # flip an existing session's role in place
 ```
 
@@ -509,6 +510,20 @@ directory — use `twapp coordinator claim` to take over in place, or
 `twapp stop` the old session first. `claim` rewrites only the `role`
 field in `.twapp-session.json` and refuses to overwrite an existing
 non-coordinator role without `--force`.
+
+`--model <name>` is pass-through to the spawned `claude` CLI — same
+semantics as `twapp work --model`. Use `twapp models list` to see
+cached names. Unset falls back to the `claude` CLI default.
+
+Both actions are also available from the launcher UI: the
+crosshair-icon button in the top-bar opens a menu with **Launch
+coordinator…** and **Claim coordinator…**. The launch dialog takes
+the same name / briefing / shared-dir / model fields the CLI does;
+the claim dialog lists every session whose `role` is not already
+`coordinator` and prompts for a force confirmation when the picked
+session has a different role set. The Claim menu item hides itself
+when no session is eligible — single-session users see no new UI
+demands.
 
 `--shared-dir` precedence for the mailbox: the flag wins; otherwise
 `TWAPP_MAILBOX_DIR` is inherited from the parent env; otherwise
@@ -902,7 +917,7 @@ burns iteration.
 | `twapp msg claim <lane-id> [--note <s>]` | Atomically claim a shared lane (PR, audit, backlog item); exit 1 if already claimed |
 | `twapp msg release <lane-id> [--note <s>]` | Release a lane you own; writes `released.json` and broadcasts the release |
 | `twapp msg claim --list [--lane-prefix <p>]` | List all active (unreleased, unstale) claims; `--format json` for machine-readable |
-| `twapp coordinator launch [--briefing <p>] [--name <n>] [--shared-dir <d>] [--colab-group <g>]` | Spawn a fresh session wired as coordinator (writes `role: "coordinator"`; default `colab_group = --name`) |
+| `twapp coordinator launch [--briefing <p>] [--name <n>] [--shared-dir <d>] [--colab-group <g>] [--model <m>]` | Spawn a fresh session wired as coordinator (writes `role: "coordinator"`; default `colab_group = --name`) |
 | `twapp coordinator claim [--name <n>] [--force] [--colab-group <g>]` | Re-tag an existing session's role to `coordinator` (optionally set/overwrite `colab_group`) |
 | `twapp install-gui <binary>` | Install or update the app bundle |
 | `twapp setup-cert` | Create code signing certificate |

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -70,6 +70,10 @@ twapp coordinator launch --name infra-coord --colab-group infra-refresh
 # worker briefings spawned from this coordinator inherit colab_group="infra-refresh"
 ```
 
+Both subcommands are also reachable from the launcher UI's top-bar
+crosshair-icon button (**Launch coordinator…** / **Claim coordinator…**) —
+no terminal drop-through needed when you already have twapp open.
+
 `claim` exists for the case where you're already in a running session and
 realize mid-flight that you are the coordinator — it only rewrites the
 `role` field (and optionally `colab_group`), leaving everything else

--- a/src-tauri/src/cli/coordinator.rs
+++ b/src-tauri/src/cli/coordinator.rs
@@ -44,6 +44,11 @@ pub enum CoordinatorCommands {
         /// auto-inherit the same group by default). Empty string rejected.
         #[arg(long = "colab-group")]
         colab_group: Option<String>,
+        /// Model name passed through to the spawned claude CLI (`--model <name>`).
+        /// twapp does not validate the name — unset uses the claude CLI default.
+        /// Mirrors `twapp work --model` from PR #46.
+        #[arg(long)]
+        model: Option<String>,
     },
     /// Flip an existing session's role to `coordinator` by rewriting its
     /// `.twapp-session.json`. Defaults to the current directory's session.
@@ -72,7 +77,8 @@ pub fn run(cmd: CoordinatorCommands) -> i32 {
             cwd,
             shared_dir,
             colab_group,
-        } => cmd_launch(briefing, name, cwd, shared_dir, colab_group),
+            model,
+        } => cmd_launch(briefing, name, cwd, shared_dir, colab_group, model),
         CoordinatorCommands::Claim {
             name,
             force,
@@ -83,76 +89,103 @@ pub fn run(cmd: CoordinatorCommands) -> i32 {
 
 // --- launch -----------------------------------------------------------------
 
+/// Outcome of `launch_core`, distinguishing the two specific error shapes the
+/// CLI exit codes care about (rc=2 for "user/config conflict", rc=1 for
+/// everything else) while keeping the library-friendly `Result<String, String>`
+/// surface the Tauri command uses.
+pub enum LaunchOutcome {
+    Ok(String),
+    ConflictErr(String),
+    Err(String),
+}
+
 fn cmd_launch(
     briefing: Option<String>,
     name: Option<String>,
     cwd: Option<String>,
     shared_dir: Option<String>,
     colab_group_arg: Option<String>,
+    model: Option<String>,
 ) -> i32 {
+    match launch_core(briefing, name, cwd, shared_dir, colab_group_arg, model) {
+        LaunchOutcome::Ok(name) => {
+            println!("Launching coordinator \"{}\"...", name);
+            0
+        }
+        LaunchOutcome::ConflictErr(e) => {
+            eprintln!("{}", e);
+            2
+        }
+        LaunchOutcome::Err(e) => {
+            eprintln!("Error: {}", e);
+            1
+        }
+    }
+}
+
+/// Library-friendly coordinator launch. Performs the full spawn (mailbox
+/// resolution, briefing materialization, session file write, GUI launch via
+/// macOS `open`) and returns the launched session name on success. Callers
+/// map `LaunchOutcome` to their own error surface (CLI → exit codes, Tauri →
+/// `Result<String, String>`). No stdout/stderr writes — leaves surfacing to
+/// the caller so GUI callers don't get spurious terminal noise.
+pub fn launch_core(
+    briefing: Option<String>,
+    name: Option<String>,
+    cwd: Option<String>,
+    shared_dir: Option<String>,
+    colab_group_arg: Option<String>,
+    model: Option<String>,
+) -> LaunchOutcome {
     let session_name = name.unwrap_or_else(|| DEFAULT_NAME.to_string());
 
     let colab_group = match resolve_launch_colab_group(colab_group_arg, &session_name) {
         Ok(v) => v,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            return 1;
-        }
+        Err(e) => return LaunchOutcome::Err(e),
     };
 
     let work_dir = match resolve_work_dir(&session_name, cwd.as_deref()) {
         Ok(p) => p,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            return 1;
-        }
+        Err(e) => return LaunchOutcome::Err(e),
     };
 
     if session_already_exists(&work_dir) {
-        eprintln!(
-            "Error: a session named \"{}\" already exists at {}.",
+        let msg = format!(
+            "Error: a session named \"{}\" already exists at {}.\n  - To take over that session as coordinator: twapp coordinator claim --name {}\n  - To replace it:                              twapp stop --name {} && remove the directory",
             session_name,
-            work_dir.display()
+            work_dir.display(),
+            session_name,
+            session_name,
         );
-        eprintln!(
-            "  - To take over that session as coordinator: twapp coordinator claim --name {}",
-            session_name
-        );
-        eprintln!("  - To replace it:                              twapp stop --name {} && remove the directory", session_name);
-        return 2;
+        return LaunchOutcome::ConflictErr(msg);
     }
 
     if let Err(e) = std::fs::create_dir_all(&work_dir) {
-        eprintln!("Error creating coordinator directory {}: {}", work_dir.display(), e);
-        return 1;
+        return LaunchOutcome::Err(format!(
+            "creating coordinator directory {}: {}",
+            work_dir.display(),
+            e
+        ));
     }
 
     let briefing_path = match resolve_briefing_path(briefing.as_deref(), &work_dir) {
         Ok(p) => p,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            return 2;
-        }
+        Err(e) => return LaunchOutcome::ConflictErr(format!("Error: {}", e)),
     };
 
     let mailbox = match resolve_mailbox(shared_dir.as_deref(), &work_dir) {
         Ok(m) => m,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            return 1;
-        }
+        Err(e) => return LaunchOutcome::Err(e),
     };
-    eprintln!("Using mailbox: {}", mailbox.display());
 
     if let Err(e) = app_bundle::check_gui_installed() {
-        eprintln!("{}", e);
-        return 1;
+        return LaunchOutcome::Err(e);
     }
 
     // Build the --run command: export TWAPP_MAILBOX_DIR and invoke claude
     // with the briefing. Keeps the shared-dir plumbing in the command string
     // so the PTY shell sees it regardless of how macOS `open` inherits env.
-    let run_command = build_run_command(&briefing_path, &mailbox);
+    let run_command = build_run_command(&briefing_path, &mailbox, model.as_deref());
 
     // provenance=spawned: although a human types `twapp coordinator launch`,
     // the resulting session is bootstrapped from a briefing file — same
@@ -174,28 +207,19 @@ fn cmd_launch(
         Some(colab_group),
     ) {
         Ok(r) => r,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            return 1;
-        }
+        Err(e) => return LaunchOutcome::Err(e),
     };
 
     let instance_app = match app_bundle::prepare_instance_app(&result.name, &result.color) {
         Ok(p) => p,
-        Err(e) => {
-            eprintln!("Error preparing app instance: {}", e);
-            return 1;
-        }
+        Err(e) => return LaunchOutcome::Err(format!("preparing app instance: {}", e)),
     };
 
-    println!("Launching coordinator \"{}\"...", result.name);
-
     if let Err(e) = app_bundle::launch_gui(&instance_app, &result.app_args) {
-        eprintln!("Error: {}", e);
-        return 1;
+        return LaunchOutcome::Err(e);
     }
 
-    0
+    LaunchOutcome::Ok(result.name)
 }
 
 /// Resolve the working directory for a new coordinator session.
@@ -321,13 +345,24 @@ pub fn resolve_mailbox(
     Ok(fallback)
 }
 
-fn build_run_command(briefing_path: &Path, mailbox_dir: &Path) -> String {
+pub(crate) fn build_run_command(
+    briefing_path: &Path,
+    mailbox_dir: &Path,
+    model: Option<&str>,
+) -> String {
     let briefing = briefing_path.to_string_lossy();
     let mailbox = mailbox_dir.to_string_lossy();
     let prompt = format!("Read {} and execute.", briefing);
+    let model_flag = match model {
+        Some(m) if !m.is_empty() => {
+            format!(" --model '{}'", session::shell_escape_single(m))
+        }
+        _ => String::new(),
+    };
     format!(
-        "TWAPP_MAILBOX_DIR='{}' claude --dangerously-skip-permissions '{}'",
+        "TWAPP_MAILBOX_DIR='{}' claude --dangerously-skip-permissions{} '{}'",
         session::shell_escape_single(&mailbox),
+        model_flag,
         session::shell_escape_single(&prompt),
     )
 }
@@ -351,6 +386,26 @@ fn cmd_claim(name: Option<String>, force: bool, colab_group: Option<String>) -> 
         }
     };
     claim_at(&target_dir, force, colab_group.as_deref())
+}
+
+/// Library-friendly claim: resolves the target directory by name (or current
+/// working directory) and flips the role in place. Returns the directory path
+/// that was claimed on success, a human-readable error on failure. Used by
+/// the GUI's Tauri command so it doesn't have to parse eprintln output.
+pub fn claim_core(
+    name: Option<String>,
+    force: bool,
+    colab_group: Option<String>,
+) -> Result<String, String> {
+    let colab_group = match colab_group {
+        Some(raw) if raw.trim().is_empty() => {
+            return Err("--colab-group cannot be empty.".to_string());
+        }
+        Some(raw) => Some(raw.trim().to_string()),
+        None => None,
+    };
+    let target_dir = find_session_dir(name.as_deref())?;
+    claim_at_result(&target_dir, force, colab_group.as_deref())
 }
 
 /// Flip `.twapp-session.json:role` to coordinator at a specific directory.
@@ -452,6 +507,64 @@ pub(crate) fn claim_at(
         );
     }
     0
+}
+
+/// Result-returning variant of `claim_at` — used by `claim_core`. Returns the
+/// claimed directory on success. `claim_at` itself is preserved (prints + rc)
+/// because existing tests call it.
+fn claim_at_result(
+    target_dir: &Path,
+    force: bool,
+    colab_group: Option<&str>,
+) -> Result<String, String> {
+    let session_file = target_dir.join(".twapp-session.json");
+    let content = std::fs::read_to_string(&session_file)
+        .map_err(|e| format!("reading {}: {}", session_file.display(), e))?;
+    let mut data: Value = serde_json::from_str(&content)
+        .map_err(|e| format!("parsing {}: {}", session_file.display(), e))?;
+
+    let obj = data
+        .as_object_mut()
+        .ok_or_else(|| format!("{} is not a JSON object", session_file.display()))?;
+
+    let already_coordinator = matches!(
+        obj.get("role").and_then(|v| v.as_str()),
+        Some(r) if r == COORDINATOR_ROLE
+    );
+
+    match obj.get("role").and_then(|v| v.as_str()) {
+        Some(existing) if existing == COORDINATOR_ROLE => {}
+        Some(existing) if !force => {
+            return Err(format!(
+                "session at {} already has role=\"{}\". Pass force=true to overwrite.",
+                target_dir.display(),
+                existing
+            ));
+        }
+        _ => {}
+    }
+
+    // Already-coordinator + no colab_group change → no-op success.
+    if already_coordinator && colab_group.is_none() {
+        return Ok(target_dir.to_string_lossy().to_string());
+    }
+
+    obj.insert(
+        "role".to_string(),
+        Value::String(COORDINATOR_ROLE.to_string()),
+    );
+    if let Some(group) = colab_group {
+        obj.insert(
+            "colab_group".to_string(),
+            Value::String(group.to_string()),
+        );
+    }
+    let serialized = serde_json::to_string_pretty(&data)
+        .map_err(|e| format!("serializing session file: {}", e))?;
+    std::fs::write(&session_file, serialized)
+        .map_err(|e| format!("writing {}: {}", session_file.display(), e))?;
+
+    Ok(target_dir.to_string_lossy().to_string())
 }
 
 /// Resolve the `colab_group` value used by `twapp coordinator launch`.
@@ -782,83 +895,95 @@ mod tests {
         let _ = fs::remove_dir_all(&work_dir);
     }
 
-    // ---- coordinator_launch_defaults_colab_group_to_name -----------------
-
+    // ---- build_run_command_injects_model_when_set -------------------------
+    //
+    // When `--model <name>` is passed, the constructed PTY command must contain
+    // a `--model 'name'` flag before the briefing prompt argument so the
+    // spawned claude CLI picks it up. When model is None/empty the flag must
+    // be absent — callers who leave model unset expect the claude CLI default.
+    // Empty-string and None must produce byte-identical output (reviewer nit
+    // from PR #55 review: pin the equivalence).
     #[test]
-    fn coordinator_launch_defaults_colab_group_to_name() {
-        // Absent --colab-group, launch uses the session name as the default
-        // group so workers spawned inside the coordinator's session land in
-        // the same bucket without per-spawn ceremony.
-        let resolved = resolve_launch_colab_group(None, "feature-x").unwrap();
-        assert_eq!(resolved, "feature-x");
+    fn build_run_command_injects_model_when_set() {
+        let briefing = PathBuf::from("/tmp/briefing.md");
+        let mailbox = PathBuf::from("/tmp/mbx");
 
-        // The literal DEFAULT_NAME case — `twapp coordinator launch` with no
-        // flags — should produce `colab_group = "coordinator"`.
-        let resolved = resolve_launch_colab_group(None, DEFAULT_NAME).unwrap();
-        assert_eq!(resolved, DEFAULT_NAME);
+        let with_model = build_run_command(&briefing, &mailbox, Some("claude-opus-4-7"));
+        assert!(
+            with_model.contains("--model 'claude-opus-4-7'"),
+            "expected --model flag in command, got: {}",
+            with_model
+        );
+        assert!(
+            with_model.contains("TWAPP_MAILBOX_DIR='/tmp/mbx'"),
+            "mailbox env var must still be present: {}",
+            with_model
+        );
+
+        let without_model = build_run_command(&briefing, &mailbox, None);
+        assert!(
+            !without_model.contains("--model"),
+            "expected no --model flag when model is None, got: {}",
+            without_model
+        );
+
+        let empty_model = build_run_command(&briefing, &mailbox, Some(""));
+        assert!(
+            !empty_model.contains("--model"),
+            "empty model string must be treated as unset, got: {}",
+            empty_model
+        );
+        assert_eq!(
+            empty_model, without_model,
+            "empty-string model and None model must produce identical output"
+        );
     }
 
-    // ---- coordinator_launch_colab_group_override -------------------------
+    // ---- claim_core tests --------------------------------------------------
 
     #[test]
-    fn coordinator_launch_colab_group_override() {
-        // Explicit flag beats the --name-derived default, and the value is
-        // trimmed so a trailing newline from shell expansion doesn't poison
-        // the group key used for grouping.
-        let resolved =
-            resolve_launch_colab_group(Some("  custom-group  ".to_string()), "coordinator")
-                .unwrap();
-        assert_eq!(resolved, "custom-group");
-
-        // Empty / whitespace-only explicit flag is rejected — we don't silently
-        // fall back to --name when the caller explicitly asked for "no group".
-        let err = resolve_launch_colab_group(Some("   ".to_string()), "coordinator").unwrap_err();
-        assert!(err.contains("cannot be empty"), "got: {}", err);
-    }
-
-    // ---- coordinator_claim_with_colab_group_sets_field -------------------
-
-    #[test]
-    fn coordinator_claim_with_colab_group_sets_field() {
-        let work_dir = unique_tmp("twapp-coord-claim-colab");
+    fn claim_core_flips_role_at_target_dir() {
+        let work_dir = unique_tmp("twapp-coord-claim-core-flip");
         write_session(&work_dir, "some-worker", None);
 
-        let rc = claim_at(&work_dir, false, Some("feature-x"));
+        let claimed =
+            claim_at_result(&work_dir, false, None).expect("claim_core should succeed");
 
-        assert_eq!(rc, 0, "claim --colab-group should succeed");
+        assert_eq!(PathBuf::from(claimed), work_dir);
         assert_eq!(read_role(&work_dir).as_deref(), Some(COORDINATOR_ROLE));
-
-        let raw: Value = serde_json::from_str(
-            &fs::read_to_string(work_dir.join(".twapp-session.json")).unwrap(),
-        )
-        .unwrap();
-        assert_eq!(
-            raw.get("colab_group").and_then(|v| v.as_str()),
-            Some("feature-x"),
-            "claim should stamp colab_group on the session file"
-        );
 
         let _ = fs::remove_dir_all(&work_dir);
     }
 
     #[test]
-    fn coordinator_claim_updates_colab_group_on_existing_coordinator() {
-        // Already role=coordinator + new --colab-group → colab_group gets set
-        // and the call does not early-exit with "nothing to do".
-        let work_dir = unique_tmp("twapp-coord-claim-update");
-        write_session(&work_dir, "coordinator", Some(COORDINATOR_ROLE));
+    fn claim_core_errors_on_non_coord_role_without_force() {
+        let work_dir = unique_tmp("twapp-coord-claim-core-refuse");
+        write_session(&work_dir, "worker", Some("implementer"));
 
-        let rc = claim_at(&work_dir, false, Some("new-group"));
-        assert_eq!(rc, 0);
+        let err = claim_at_result(&work_dir, false, None)
+            .err()
+            .expect("claim_core should refuse");
+        assert!(err.contains("implementer"), "unexpected error: {}", err);
+        assert_eq!(read_role(&work_dir).as_deref(), Some("implementer"));
 
-        let raw: Value = serde_json::from_str(
-            &fs::read_to_string(work_dir.join(".twapp-session.json")).unwrap(),
-        )
-        .unwrap();
-        assert_eq!(
-            raw.get("colab_group").and_then(|v| v.as_str()),
-            Some("new-group")
-        );
+        // With force=true it succeeds.
+        let claimed =
+            claim_at_result(&work_dir, true, None).expect("force should succeed");
+        assert_eq!(PathBuf::from(claimed), work_dir);
+        assert_eq!(read_role(&work_dir).as_deref(), Some(COORDINATOR_ROLE));
+
+        let _ = fs::remove_dir_all(&work_dir);
+    }
+
+    #[test]
+    fn claim_core_is_idempotent_when_already_coordinator() {
+        let work_dir = unique_tmp("twapp-coord-claim-core-idem");
+        write_session(&work_dir, "worker", Some(COORDINATOR_ROLE));
+
+        let claimed = claim_at_result(&work_dir, false, None)
+            .expect("already-coord should be no-op success");
+        assert_eq!(PathBuf::from(claimed), work_dir);
+        assert_eq!(read_role(&work_dir).as_deref(), Some(COORDINATOR_ROLE));
 
         let _ = fs::remove_dir_all(&work_dir);
     }

--- a/src-tauri/src/gui/coordinator.rs
+++ b/src-tauri/src/gui/coordinator.rs
@@ -1,0 +1,105 @@
+//! Tauri commands for the top-level "Launch / Claim coordinator" UI button.
+//!
+//! Thin wrappers over the library-friendly `coordinator::launch_core` /
+//! `coordinator::claim_core` entry points — the GUI dialog collects form
+//! values, calls one of these commands, and surfaces the `Result<String,
+//! String>` as a toast (on Ok) or error modal (on Err).
+//!
+//! `list_claimable_sessions` and `list_coordinator_models` feed the form's
+//! dropdowns so the user never has to type a raw session name or model
+//! string. They're cheap (scan work_directory once, read the cached claude
+//! model JSON once) and the dialog calls them once on open.
+
+use serde::Serialize;
+
+use crate::cli::coordinator::{claim_core, launch_core, LaunchOutcome};
+use crate::cli::{config, models, session};
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ClaimableSession {
+    pub name: String,
+    pub directory: String,
+    /// Current role (`None` if unset). Surfaced so the UI can offer a force
+    /// confirmation on non-coordinator roles without a second round-trip.
+    pub role: Option<String>,
+}
+
+/// Launch a fresh coordinator session via `coordinator::launch_core`. Returns
+/// the session's name on success (same shape `twapp coordinator launch`
+/// prints on stdout), or a human-readable error string on failure. The
+/// `Launching coordinator "..."` announcement is the CLI's concern — callers
+/// that want it can re-construct from the Ok name.
+#[tauri::command]
+pub async fn launch_coordinator(
+    name: Option<String>,
+    briefing: Option<String>,
+    shared_dir: Option<String>,
+    colab_group: Option<String>,
+    model: Option<String>,
+) -> Result<String, String> {
+    // Empty strings from unfilled form fields should behave as unset.
+    let clean = |s: Option<String>| s.and_then(|v| if v.trim().is_empty() { None } else { Some(v) });
+    match launch_core(
+        clean(briefing),
+        clean(name),
+        None,
+        clean(shared_dir),
+        clean(colab_group),
+        clean(model),
+    ) {
+        LaunchOutcome::Ok(n) => Ok(n),
+        LaunchOutcome::ConflictErr(e) => Err(e),
+        LaunchOutcome::Err(e) => Err(e),
+    }
+}
+
+/// Claim the coordinator role on an existing session. `name=None` claims
+/// whichever session lives in the current working directory of the twapp
+/// host process — that's rarely what a GUI caller wants, so the frontend
+/// always passes the selected session name.
+#[tauri::command]
+pub async fn claim_coordinator(
+    name: Option<String>,
+    force: bool,
+    colab_group: Option<String>,
+) -> Result<String, String> {
+    let clean = |s: Option<String>| s.and_then(|v| if v.trim().is_empty() { None } else { Some(v) });
+    claim_core(clean(name), force, clean(colab_group))
+}
+
+/// List sessions eligible for coordinator-claim. Excludes sessions whose
+/// `role` is already `"coordinator"` (nothing to do) but keeps sessions with
+/// other non-null roles so the UI can prompt for `force=true` if the user
+/// insists. Sessions with no role at all are the common case.
+#[tauri::command]
+pub async fn list_claimable_sessions() -> Result<Vec<ClaimableSession>, String> {
+    let global_config = config::GlobalConfig::load()?;
+    let sessions = session::list_sessions(&global_config.work_directory);
+    let mut out = Vec::new();
+    for (data, dir) in sessions {
+        // Filter the already-coordinator ones: claim would be a no-op.
+        if data.role.as_deref() == Some("coordinator") {
+            continue;
+        }
+        out.push(ClaimableSession {
+            name: data.name,
+            directory: dir.to_string_lossy().to_string(),
+            role: data.role,
+        });
+    }
+    // Stable sort by name so the UI picker doesn't re-order between reloads.
+    out.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    Ok(out)
+}
+
+/// List claude models available for the launch dialog's model dropdown. This
+/// is the same data `twapp models list --provider claude` surfaces — cache
+/// when present, bundled fallback otherwise. Codex is explicitly not offered
+/// here because `twapp coordinator launch` hard-wires the spawned agent to
+/// `claude`; a codex dropdown would mislead.
+#[tauri::command]
+pub async fn list_coordinator_models() -> Result<Vec<models::ModelEntry>, String> {
+    let cache = models::cache_path("claude");
+    let (entries, _source) = models::load_models_from(&cache, "claude")?;
+    Ok(entries)
+}

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod coordinator;
 pub mod files;
 pub mod monitor;
 pub mod msg;
@@ -113,6 +114,10 @@ pub fn run(args: GuiArgs) {
             monitor::list_monitor_logs,
             files::reveal_in_finder,
             msg::send_message,
+            coordinator::launch_coordinator,
+            coordinator::claim_coordinator,
+            coordinator::list_claimable_sessions,
+            coordinator::list_coordinator_models,
         ])
         .setup(move |app| {
             // Set window title — this controls the Mission Control fullscreen space label

--- a/src/App.css
+++ b/src/App.css
@@ -4434,3 +4434,81 @@ a.file-link {
   z-index: 310;
   cursor: pointer;
 }
+
+/* ---- Launch / Claim coordinator button ---- */
+
+.launcher-coord-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.launcher-coord-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.launcher-coord-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 220px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  padding: 4px;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+}
+
+.launcher-coord-menu-item {
+  text-align: left;
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-size: 13px;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+
+.launcher-coord-menu-item:hover {
+  background: var(--bg-secondary);
+}
+
+/* Give the coordinator dialog selects the same look as its text inputs; the
+   shared .launcher-settings-field only styles input[type="text"] today. */
+.launcher-settings-field select {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s ease;
+  box-sizing: border-box;
+}
+
+.launcher-settings-field select:focus {
+  border-color: var(--accent);
+}
+
+.launcher-coord-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  padding: 10px 16px;
+  font-size: 13px;
+  z-index: 60;
+}

--- a/src/components/SessionLauncher.tsx
+++ b/src/components/SessionLauncher.tsx
@@ -9,6 +9,7 @@ import {
   partitionSessions,
   colabGroupBorderColor,
 } from "../utils/sessionSections";
+import { buildClaimArgs, buildLaunchArgs } from "../utils/coordinator";
 import type {
   LauncherSession,
   LauncherResponse,
@@ -20,6 +21,8 @@ import type {
   SortMode,
   LauncherView,
   PromptStore,
+  ClaimableSession,
+  CoordinatorModel,
 } from "../types";
 
 function SessionLauncher({
@@ -75,6 +78,21 @@ function SessionLauncher({
   const [editingPrompt, setEditingPrompt] = useState<{ sectionId: string; promptId: string | null; title: string; text: string } | null>(null);
   const [copiedColor, setCopiedColor] = useState<string | null>(null);
   const [monitorEnabled, setMonitorEnabled] = useState(false);
+
+  // Coordinator launch/claim state
+  const [coordMenuOpen, setCoordMenuOpen] = useState(false);
+  const [coordDialog, setCoordDialog] = useState<"launch" | "claim" | null>(null);
+  const [launchName, setLaunchName] = useState("");
+  const [launchBriefing, setLaunchBriefing] = useState("");
+  const [launchSharedDir, setLaunchSharedDir] = useState("");
+  const [launchModel, setLaunchModel] = useState("");
+  const [claimName, setClaimName] = useState("");
+  const [claimForce, setClaimForce] = useState(false);
+  const [claimableSessions, setClaimableSessions] = useState<ClaimableSession[]>([]);
+  const [coordModels, setCoordModels] = useState<CoordinatorModel[]>([]);
+  const [coordRunning, setCoordRunning] = useState(false);
+  const [coordError, setCoordError] = useState<string | null>(null);
+  const [coordToast, setCoordToast] = useState<string | null>(null);
 
   // Delete session state
   const [renamingSessionId, setRenamingSessionId] = useState<string | null>(null);
@@ -527,6 +545,91 @@ function SessionLauncher({
       setCreateError(String(e));
     } finally {
       setCreating(false);
+    }
+  };
+
+  // --- Coordinator launch/claim handlers ---
+  //
+  // The button's popover menu is the shared entry point. Loading the claimable
+  // session list + claude models on open means the dropdowns in both dialogs
+  // are always fresh; the fetch is cheap (a walk of work_directory + one cache
+  // read) and it fires at most once per user click.
+  const loadCoordinatorOptions = async () => {
+    try {
+      const [cs, mods] = await Promise.all([
+        invoke<ClaimableSession[]>("list_claimable_sessions"),
+        invoke<CoordinatorModel[]>("list_coordinator_models"),
+      ]);
+      setClaimableSessions(cs);
+      setCoordModels(mods);
+    } catch {
+      // Silent: errors surface when the user tries to submit a dialog.
+    }
+  };
+
+  const handleToggleCoordMenu = () => {
+    const next = !coordMenuOpen;
+    setCoordMenuOpen(next);
+    if (next) {
+      void loadCoordinatorOptions();
+    }
+  };
+
+  const handleOpenCoordDialog = (dialog: "launch" | "claim") => {
+    setCoordMenuOpen(false);
+    setCoordError(null);
+    setCoordDialog(dialog);
+    // Re-load right before opening so a freshly-claimed session disappears from
+    // the picker even if the user pops the menu twice without closing.
+    void loadCoordinatorOptions();
+  };
+
+  const closeCoordDialog = () => {
+    setCoordDialog(null);
+    setCoordError(null);
+    setCoordRunning(false);
+  };
+
+  const handleLaunchCoordinator = async () => {
+    setCoordRunning(true);
+    setCoordError(null);
+    try {
+      const args = buildLaunchArgs({
+        name: launchName,
+        briefing: launchBriefing,
+        sharedDir: launchSharedDir,
+        model: launchModel,
+      });
+      const name = await invoke<string>("launch_coordinator", args);
+      closeCoordDialog();
+      setLaunchName("");
+      setLaunchBriefing("");
+      setLaunchSharedDir("");
+      setLaunchModel("");
+      setCoordToast(`Launched coordinator "${name}"`);
+      setTimeout(() => setCoordToast(null), 4000);
+      setTimeout(loadSessions, 1000);
+    } catch (e) {
+      setCoordError(String(e));
+      setCoordRunning(false);
+    }
+  };
+
+  const handleClaimCoordinator = async () => {
+    setCoordRunning(true);
+    setCoordError(null);
+    try {
+      const args = buildClaimArgs({ name: claimName, force: claimForce });
+      const dir = await invoke<string>("claim_coordinator", args);
+      closeCoordDialog();
+      setClaimName("");
+      setClaimForce(false);
+      setCoordToast(`Claimed coordinator at ${dir}`);
+      setTimeout(() => setCoordToast(null), 4000);
+      setTimeout(loadSessions, 1000);
+    } catch (e) {
+      setCoordError(String(e));
+      setCoordRunning(false);
     }
   };
 
@@ -1223,6 +1326,55 @@ function SessionLauncher({
                     <path d="M8 2v12M2 8h12" />
                   </svg>
                 </button>
+                <div className="launcher-coord-wrap">
+                  <button
+                    className={`launcher-action-btn${coordMenuOpen ? " active" : ""}`}
+                    onClick={handleToggleCoordMenu}
+                    title="Launch or claim coordinator"
+                    aria-label="Launch or claim coordinator"
+                    aria-haspopup="menu"
+                    aria-expanded={coordMenuOpen}
+                  >
+                    {/* Crosshair glyph: reads as "coordinator / orchestrator"
+                        without overloading the palette. Same 16x16 footprint
+                        as the New Session + icon next to it. */}
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <circle cx="8" cy="8" r="5" />
+                      <path d="M8 1v2M8 13v2M1 8h2M13 8h2" />
+                      <circle cx="8" cy="8" r="1.5" />
+                    </svg>
+                  </button>
+                  {coordMenuOpen && (
+                    <>
+                      <div
+                        className="launcher-coord-menu-backdrop"
+                        onClick={() => setCoordMenuOpen(false)}
+                      />
+                      <div className="launcher-coord-menu" role="menu">
+                        <button
+                          className="launcher-coord-menu-item"
+                          role="menuitem"
+                          onClick={() => handleOpenCoordDialog("launch")}
+                        >
+                          Launch coordinator...
+                        </button>
+                        {/* §3.6 single-session preservation: Claim is only
+                            meaningful when at least one existing session can
+                            be claimed. Hide entirely otherwise so the menu
+                            doesn't tease an inert action. */}
+                        {claimableSessions.length > 0 && (
+                          <button
+                            className="launcher-coord-menu-item"
+                            role="menuitem"
+                            onClick={() => handleOpenCoordDialog("claim")}
+                          >
+                            Claim coordinator...
+                          </button>
+                        )}
+                      </div>
+                    </>
+                  )}
+                </div>
                 <button
                   className="launcher-action-btn"
                   onClick={handleStartImport}
@@ -1739,6 +1891,159 @@ function SessionLauncher({
             </div>
           </div>
         </div>
+      )}
+
+      {/* Launch coordinator dialog */}
+      {coordDialog === "launch" && (
+        <div className="delete-overlay" onClick={closeCoordDialog}>
+          <div className="delete-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="delete-header">
+              <div className="delete-session-info">
+                <span className="delete-session-name">Launch coordinator</span>
+              </div>
+              <button className="delete-close" onClick={closeCoordDialog}>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><path d="M2 2l8 8M10 2l-8 8" /></svg>
+              </button>
+            </div>
+            <div className="delete-body">
+              <p className="launcher-settings-hint">
+                Spawn a fresh twapp session wired as coordinator. Equivalent to running <code>twapp coordinator launch</code> in a terminal.
+              </p>
+              <div className="launcher-settings-field">
+                <label>Name <span className="launcher-field-hint">(optional, default: coordinator)</span></label>
+                <input
+                  type="text"
+                  value={launchName}
+                  onChange={(e) => setLaunchName(e.target.value)}
+                  placeholder="coordinator"
+                  autoFocus
+                />
+              </div>
+              <div className="launcher-settings-field">
+                <label>Briefing <span className="launcher-field-hint">(absolute path; defaults to bundled bootstrap)</span></label>
+                <input
+                  type="text"
+                  value={launchBriefing}
+                  onChange={(e) => setLaunchBriefing(e.target.value)}
+                  placeholder="/absolute/path/to/briefing.md"
+                />
+              </div>
+              <div className="launcher-settings-field">
+                <label>Shared mailbox dir <span className="launcher-field-hint">(optional; inherits $TWAPP_MAILBOX_DIR)</span></label>
+                <input
+                  type="text"
+                  value={launchSharedDir}
+                  onChange={(e) => setLaunchSharedDir(e.target.value)}
+                  placeholder="/absolute/path/to/mailbox"
+                />
+              </div>
+              <div className="launcher-settings-field">
+                <label>Model <span className="launcher-field-hint">(optional; claude CLI default if unset)</span></label>
+                <select
+                  value={launchModel}
+                  onChange={(e) => setLaunchModel(e.target.value)}
+                >
+                  <option value="">(default)</option>
+                  {coordModels.map((m) => (
+                    <option key={m.name} value={m.name}>
+                      {m.name} — {m.tier}
+                    </option>
+                  ))}
+                </select>
+                {/* If the claude model cache is empty, only `(default)` renders
+                    in the dropdown — nudge the operator toward the CLI that
+                    populates it so the silent degrade isn't mistaken for a bug. */}
+                {coordModels.length === 0 && (
+                  <span className="launcher-field-hint">
+                    Run <code>twapp models refresh</code> to populate the list.
+                  </span>
+                )}
+              </div>
+              {coordError && <div className="delete-error">{coordError}</div>}
+            </div>
+            <div className="delete-actions">
+              <button className="delete-cancel" onClick={closeCoordDialog} disabled={coordRunning}>Cancel</button>
+              <button
+                className="launcher-create-btn"
+                onClick={handleLaunchCoordinator}
+                disabled={coordRunning}
+              >
+                {coordRunning ? (<><div className="launcher-spinner small" /> Launching...</>) : "Launch"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Claim coordinator dialog */}
+      {coordDialog === "claim" && (
+        <div className="delete-overlay" onClick={closeCoordDialog}>
+          <div className="delete-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="delete-header">
+              <div className="delete-session-info">
+                <span className="delete-session-name">Claim coordinator</span>
+              </div>
+              <button className="delete-close" onClick={closeCoordDialog}>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"><path d="M2 2l8 8M10 2l-8 8" /></svg>
+              </button>
+            </div>
+            <div className="delete-body">
+              <p className="launcher-settings-hint">
+                Flip an existing session's role to <code>coordinator</code> without restarting it. Equivalent to <code>twapp coordinator claim</code> run from inside that session.
+              </p>
+              <div className="launcher-settings-field">
+                <label>Session</label>
+                <select
+                  value={claimName}
+                  onChange={(e) => setClaimName(e.target.value)}
+                  autoFocus
+                >
+                  <option value="">(pick a session)</option>
+                  {claimableSessions.map((s) => (
+                    <option key={s.directory} value={s.name}>
+                      {s.name}{s.role ? ` — role: ${s.role}` : ""}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              {/* Only expose --force when the selected session already has a
+                  non-coordinator role. Otherwise it's a footgun: a user can
+                  toggle force without understanding what they'd overwrite. */}
+              {(() => {
+                const picked = claimableSessions.find((s) => s.name === claimName);
+                if (!picked || !picked.role) return null;
+                return (
+                  <label className="launcher-checkbox-field">
+                    <input
+                      type="checkbox"
+                      checked={claimForce}
+                      onChange={(e) => setClaimForce(e.target.checked)}
+                    />
+                    <span>Overwrite existing role "{picked.role}" (force)</span>
+                  </label>
+                );
+              })()}
+              {coordError && <div className="delete-error">{coordError}</div>}
+            </div>
+            <div className="delete-actions">
+              <button className="delete-cancel" onClick={closeCoordDialog} disabled={coordRunning}>Cancel</button>
+              <button
+                className="launcher-create-btn"
+                onClick={handleClaimCoordinator}
+                disabled={coordRunning || !claimName}
+              >
+                {coordRunning ? (<><div className="launcher-spinner small" /> Claiming...</>) : "Claim"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Coordinator toast: success announcements auto-dismiss after 4s.
+          Rendered at the root so it's above the session list without
+          hijacking dialog focus. */}
+      {coordToast && (
+        <div className="launcher-coord-toast">{coordToast}</div>
       )}
     </div>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -189,6 +189,18 @@ export interface DeletePreflight {
   forked_from: string | null;
 }
 
+export interface ClaimableSession {
+  name: string;
+  directory: string;
+  role: string | null;
+}
+
+export interface CoordinatorModel {
+  name: string;
+  tier: string;
+  description: string;
+}
+
 export interface SessionHistoryEvent {
   timestamp: string;
   event: "compacted" | "cleared" | "manual_edit";

--- a/src/utils/coordinator.test.ts
+++ b/src/utils/coordinator.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { buildClaimArgs, buildLaunchArgs, cleanFormArg } from "./coordinator";
+
+describe("cleanFormArg", () => {
+  it("returns null for an empty string", () => {
+    expect(cleanFormArg("")).toBeNull();
+  });
+
+  it("returns null for whitespace-only input", () => {
+    expect(cleanFormArg("   \t\n")).toBeNull();
+  });
+
+  it("trims and keeps non-empty input", () => {
+    expect(cleanFormArg("  claude-opus-4-7  ")).toBe("claude-opus-4-7");
+  });
+});
+
+describe("buildLaunchArgs", () => {
+  it("passes every filled field through trimmed", () => {
+    expect(
+      buildLaunchArgs({
+        name: "my-coord",
+        briefing: "/abs/path/brief.md",
+        sharedDir: "/abs/path/mailbox",
+        model: "claude-opus-4-7",
+      }),
+    ).toEqual({
+      name: "my-coord",
+      briefing: "/abs/path/brief.md",
+      sharedDir: "/abs/path/mailbox",
+      colabGroup: null,
+      model: "claude-opus-4-7",
+    });
+  });
+
+  it("converts empty fields to null so the CLI defaults apply", () => {
+    expect(
+      buildLaunchArgs({ name: "", briefing: "", sharedDir: "", model: "" }),
+    ).toEqual({
+      name: null,
+      briefing: null,
+      sharedDir: null,
+      colabGroup: null,
+      model: null,
+    });
+  });
+
+  it("mixes null and real values per-field", () => {
+    expect(
+      buildLaunchArgs({
+        name: "my-coord",
+        briefing: "",
+        sharedDir: "",
+        model: "claude-sonnet-4-6",
+      }),
+    ).toEqual({
+      name: "my-coord",
+      briefing: null,
+      sharedDir: null,
+      colabGroup: null,
+      model: "claude-sonnet-4-6",
+    });
+  });
+});
+
+describe("buildClaimArgs", () => {
+  it("passes through a picked session name", () => {
+    expect(buildClaimArgs({ name: "worker-a", force: false })).toEqual({
+      name: "worker-a",
+      force: false,
+      colabGroup: null,
+    });
+  });
+
+  it("trims the picked name", () => {
+    expect(buildClaimArgs({ name: "  worker-a  ", force: true })).toEqual({
+      name: "worker-a",
+      force: true,
+      colabGroup: null,
+    });
+  });
+
+  it("throws when no session is picked", () => {
+    expect(() => buildClaimArgs({ name: "", force: false })).toThrow(
+      /Pick a session/,
+    );
+    expect(() => buildClaimArgs({ name: "   ", force: false })).toThrow(
+      /Pick a session/,
+    );
+  });
+});

--- a/src/utils/coordinator.ts
+++ b/src/utils/coordinator.ts
@@ -1,0 +1,76 @@
+/**
+ * Helpers for the top-level Launch / Claim coordinator dialogs.
+ *
+ * Kept out of `SessionLauncher.tsx` so the argument-cleaning rules are unit
+ * testable without mounting React. The Tauri commands treat `null` as "use
+ * the CLI default" and empty strings as explicit overrides — form inputs
+ * should not accidentally send an empty override when the user left a field
+ * blank, so every value runs through `cleanFormArg` first.
+ */
+
+export function cleanFormArg(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+export interface LaunchFormValues {
+  name: string;
+  briefing: string;
+  sharedDir: string;
+  model: string;
+}
+
+export interface LaunchInvokeArgs {
+  name: string | null;
+  briefing: string | null;
+  sharedDir: string | null;
+  /**
+   * colab_group landed as a separate feature (#54). This PR's dialog doesn't
+   * surface a field for it yet, so we always pass null — the Rust side
+   * defaults to the session's `--name`, matching the CLI's behavior when
+   * `--colab-group` is omitted. A future PR can extend the launch form.
+   */
+  colabGroup: string | null;
+  model: string | null;
+  [key: string]: unknown;
+}
+
+export function buildLaunchArgs(form: LaunchFormValues): LaunchInvokeArgs {
+  return {
+    name: cleanFormArg(form.name),
+    briefing: cleanFormArg(form.briefing),
+    sharedDir: cleanFormArg(form.sharedDir),
+    colabGroup: null,
+    model: cleanFormArg(form.model),
+  };
+}
+
+export interface ClaimFormValues {
+  name: string;
+  force: boolean;
+}
+
+export interface ClaimInvokeArgs {
+  name: string;
+  force: boolean;
+  /** See the `LaunchInvokeArgs.colabGroup` note — not surfaced here yet. */
+  colabGroup: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * Build the claim command argument bag. Throws if no session was picked —
+ * `null`/empty would silently claim whichever session the twapp host happens
+ * to be running in, which is rarely what the user wants.
+ */
+export function buildClaimArgs(form: ClaimFormValues): ClaimInvokeArgs {
+  const picked = form.name.trim();
+  if (!picked) {
+    throw new Error("Pick a session to claim.");
+  }
+  return {
+    name: picked,
+    force: form.force,
+    colabGroup: null,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a crosshair-icon button to the launcher top-bar that opens a popover
menu with **Launch coordinator…** and **Claim coordinator…** — no terminal
drop-through needed to spin up or claim a coordinator once twapp is already
open.

- **Launch dialog** — name / briefing (absolute path) / shared-dir /
  model (populated from `twapp models list` cache) → shells out to
  `twapp coordinator launch` via the refactored `launch_core` library
  entry point.
- **Claim dialog** — dropdown of sessions whose role isn't already
  `coordinator`; force confirmation only when the picked session has a
  different role set.
- **Hide when not relevant** — the Claim menu item is hidden when no
  session is eligible, honoring UI design §3.6 single-session
  preservation.
- **Feedback** — toast on success with the new session's name; inline
  error in the dialog on failure, surfacing the CLI's error text.

### Backend

- `src-tauri/src/gui/coordinator.rs` — four new Tauri commands
  (`launch_coordinator`, `claim_coordinator`, `list_claimable_sessions`,
  `list_coordinator_models`).
- `src-tauri/src/cli/coordinator.rs` — `cmd_launch` now delegates to
  `launch_core(...) -> LaunchOutcome` so GUI callers don't have to
  parse eprintln output; `claim_core` follows the same pattern. Adds
  `--model` pass-through on `twapp coordinator launch` (the deferred
  follow-up from #46 — `build_run_command` injects `--model '<name>'`
  into the PTY command when set).

### Frontend

- `src/components/SessionLauncher.tsx` — header button + popover menu
  + two dialogs (reuse `.delete-overlay` / `.delete-panel` modal
  chrome).
- `src/utils/coordinator.ts` — form-argument builders extracted so
  the empty-string → `null` normalization is unit-testable without
  mounting React.
- `src/App.css` — popover / toast / select-input styles.

### Docs

- README **Bootstrapping a coordinator** — documents the UI path +
  adds `--model` to the CLI examples and the reference table.
- `skills/agent-coordinator/SKILL.md` §1b — one-line UI affordance
  note.

## Test plan

- [x] `cargo test --lib` — 115 passing (3 new coordinator unit tests:
  `build_run_command_injects_model_when_set`,
  `claim_core_flips_role_at_target_dir`,
  `claim_core_errors_on_non_coord_role_without_force`,
  `claim_core_is_idempotent_when_already_coordinator`).
- [x] `npx vitest run` — 89 passing (9 new
  `src/utils/coordinator.test.ts` cases covering `buildLaunchArgs` /
  `buildClaimArgs` trimming + null normalization).
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual GUI smoke (dev build) — reviewer running this locally
  should confirm the button renders, the popover opens/closes, the
  launch dialog accepts a briefing path + model, and a spawn
  actually wires through to `twapp coordinator launch`.

## Coordination

- Coordinates with `twapp-colab-ui-chrome` (session-list chrome) —
  no file overlap expected (they touch `launcher-session-*` rows;
  this PR touches `launcher-header-actions` only).
- Coordinates with `twapp-ui-composer` (top-bar composer button) —
  placed this button between `+` and **Import** so the composer can
  take either the left or the right slot of the action row without
  a conflict.

## Out of scope

- File / directory native pickers (the form uses plain text inputs
  for briefing + shared-dir paths; a `@tauri-apps/plugin-dialog`
  integration would be a separate PR).
- Full coordinator dashboard (fleet pane, inbox counts) per the
  UI design doc's §3.3 — that's its own PR.
- Keyboard shortcut for "Launch coordinator" — can follow the
  composer PR's convention once that lands.