### PR TITLE
feat(ui): urgent message panel + priority filter chip

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,6 +642,14 @@ trace, not a crash.
 > `twapp msg fetch --priority blocker` is the idiomatic first call at the
 > top of any long write cycle — before the first line of code.
 
+Inside the session window, the sidebar shows an **Urgent** panel directly
+above Notes whenever the session has a handle. It polls `twapp msg fetch
+--for <self> --priority urgent|blocker` every 10s, renders each message
+as a row (from + subject + priority chip + relative time), and auto-
+collapses after the queue has been empty for a minute. Click a row to
+open a read-only message view. Blockers get the strongest red accent,
+urgents a muted one. Single-session users with no handle see no panel.
+
 #### Reading legacy (bare) files
 
 `fetch` accepts both the new fenced-frontmatter shape and the older bare

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -236,6 +236,15 @@ blocker` is exact.
 > `--priority urgent` (or `blocker`) instead; it's the only channel
 > `twapp msg fetch --priority` knows how to find.
 
+When the recipient is running a twapp session window (not a headless
+loop), the priority lane also surfaces visually: the session sidebar
+renders an **Urgent** panel above Notes that polls `--priority urgent`
+and `--priority blocker` every 10s and renders each message as a
+clickable row with the priority chip and relative time. Blockers get the
+strongest red accent. Sending `--priority blocker` is therefore both a
+poll-time hint and an interactive interrupt — the recipient sees the
+panel light up on next poll even without reopening a terminal.
+
 ### Example message
 
 ```

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -114,6 +114,7 @@ pub fn run(args: GuiArgs) {
             monitor::list_monitor_logs,
             files::reveal_in_finder,
             msg::send_message,
+            msg::fetch_messages,
             coordinator::launch_coordinator,
             coordinator::claim_coordinator,
             coordinator::list_claimable_sessions,

--- a/src-tauri/src/gui/msg.rs
+++ b/src-tauri/src/gui/msg.rs
@@ -1,11 +1,15 @@
-//! Tauri command that shells out to `twapp msg send` / `twapp msg broadcast`.
+//! Tauri commands that shell out to `twapp msg`:
 //!
-//! Invoked by the message composer modal (`src/components/MessageComposer.tsx`).
-//! Writes the message body through stdin so no shell-escaping is needed and
-//! large bodies do not hit argv length limits.
+//! - `send_message` — `msg send` / `msg broadcast`. Used by the composer modal
+//!   (`src/components/MessageComposer.tsx`). Writes the body through stdin so
+//!   no shell-escaping is needed and large bodies do not hit argv limits.
+//! - `fetch_messages` — `msg fetch --format json`. Used by the urgent-inbox
+//!   panel (`src/components/UrgentInbox.tsx`), which calls it once per
+//!   priority (urgent + blocker) and merges the results.
 
 use super::types::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::io::Write;
 use std::process::{Command, Stdio};
 
@@ -119,6 +123,133 @@ pub fn send_message(
     validate(&args)?;
     let argv = build_argv(&args);
     run(argv, &args.body, config.cwd.as_deref())
+}
+
+// --- msg fetch ---------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchArgs {
+    /// Explicit handle to filter for. When None, the CLI falls back to the
+    /// session handle from the current `.twapp-session.json`.
+    pub for_handle: Option<String>,
+    /// "routine" | "urgent" | "blocker". None means no priority filter.
+    pub priority: Option<String>,
+    /// Cap the number of messages returned (oldest first, per the CLI).
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FetchedMessage {
+    pub id: String,
+    pub from: String,
+    pub to: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub cc: Vec<String>,
+    pub priority: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thread: Option<String>,
+    pub ts: String,
+    pub body: String,
+    pub path: String,
+}
+
+pub fn build_fetch_argv(args: &FetchArgs) -> Result<Vec<String>, String> {
+    let mut argv = vec!["msg".to_string(), "fetch".to_string(), "--format".to_string(), "json".to_string()];
+    if let Some(h) = args.for_handle.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        argv.push("--for".to_string());
+        argv.push(h.to_string());
+    }
+    if let Some(p) = args.priority.as_ref().map(|s| s.trim().to_lowercase()).filter(|s| !s.is_empty()) {
+        match p.as_str() {
+            "routine" | "urgent" | "blocker" => {
+                argv.push("--priority".to_string());
+                argv.push(p);
+            }
+            other => return Err(format!("Unknown priority: {}", other)),
+        }
+    }
+    if let Some(n) = args.limit {
+        argv.push("--limit".to_string());
+        argv.push(n.to_string());
+    }
+    Ok(argv)
+}
+
+/// Normalize a single message from the CLI's JSON into the UI-facing shape.
+/// The CLI flattens `Frontmatter` into `ParsedMessage`, so fields live at the
+/// top level next to `body` / `path` / `legacy`. See `cli/msg.rs::ParsedMessage`.
+pub fn message_from_value(v: &Value) -> Option<FetchedMessage> {
+    let obj = v.as_object()?;
+    let id = obj.get("id")?.as_str()?.to_string();
+    let from = obj.get("from")?.as_str()?.to_string();
+    let to = obj
+        .get("to")
+        .and_then(|t| t.as_array())
+        .map(|arr| arr.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let cc = obj
+        .get("cc")
+        .and_then(|t| t.as_array())
+        .map(|arr| arr.iter().filter_map(|s| s.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let priority = obj
+        .get("priority")
+        .and_then(|p| p.as_str())
+        .unwrap_or("routine")
+        .to_string();
+    let subject = obj.get("subject").and_then(|s| s.as_str()).map(String::from);
+    let thread = obj.get("thread").and_then(|s| s.as_str()).map(String::from);
+    let ts = obj.get("ts")?.as_str()?.to_string();
+    let body = obj.get("body").and_then(|s| s.as_str()).unwrap_or("").to_string();
+    let path = obj.get("path").and_then(|s| s.as_str()).unwrap_or("").to_string();
+    Some(FetchedMessage { id, from, to, cc, priority, subject, thread, ts, body, path })
+}
+
+pub fn parse_fetch_stdout(stdout: &str) -> Result<Vec<FetchedMessage>, String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let v: Value = serde_json::from_str(trimmed)
+        .map_err(|e| format!("Could not parse msg fetch JSON: {}", e))?;
+    let arr = v
+        .as_array()
+        .ok_or_else(|| format!("Expected JSON array from msg fetch, got: {}", v))?;
+    Ok(arr.iter().filter_map(message_from_value).collect())
+}
+
+fn run_fetch(argv: Vec<String>, cwd: Option<&str>) -> Result<Vec<FetchedMessage>, String> {
+    let bin = twapp_binary();
+    let mut cmd = Command::new(&bin);
+    cmd.args(&argv).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if let Some(d) = cwd {
+        cmd.current_dir(d);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("Failed to launch {}: {}", bin.display(), e))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("twapp msg fetch exited with {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    parse_fetch_stdout(&stdout)
+}
+
+#[tauri::command]
+pub fn fetch_messages(
+    args: FetchArgs,
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<Vec<FetchedMessage>, String> {
+    let argv = build_fetch_argv(&args)?;
+    run_fetch(argv, config.cwd.as_deref())
 }
 
 #[cfg(test)]
@@ -319,6 +450,116 @@ mod tests {
         let argv = build_argv(&base());
         let err = run_with_fake_bin(&bin, argv, "hello").expect_err("should fail");
         assert!(err.contains("mailbox not found"), "expected stderr in error, got: {}", err);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // --- fetch_messages tests ------------------------------------------------
+
+    fn fetch_base() -> FetchArgs {
+        FetchArgs { for_handle: None, priority: None, limit: None }
+    }
+
+    #[test]
+    fn fetch_argv_minimal() {
+        let argv = build_fetch_argv(&fetch_base()).unwrap();
+        assert_eq!(argv, vec!["msg", "fetch", "--format", "json"]);
+    }
+
+    #[test]
+    fn fetch_argv_passes_for_and_priority() {
+        let a = FetchArgs {
+            for_handle: Some("twapp-ui-urgent".into()),
+            priority: Some("urgent".into()),
+            limit: Some(50),
+        };
+        let argv = build_fetch_argv(&a).unwrap();
+        assert!(argv.windows(2).any(|w| w[0] == "--for" && w[1] == "twapp-ui-urgent"));
+        assert!(argv.windows(2).any(|w| w[0] == "--priority" && w[1] == "urgent"));
+        assert!(argv.windows(2).any(|w| w[0] == "--limit" && w[1] == "50"));
+    }
+
+    #[test]
+    fn fetch_argv_priority_normalized_to_lowercase() {
+        let a = FetchArgs { priority: Some("BLOCKER".into()), ..fetch_base() };
+        let argv = build_fetch_argv(&a).unwrap();
+        let i = argv.iter().position(|s| s == "--priority").unwrap();
+        assert_eq!(argv[i + 1], "blocker");
+    }
+
+    #[test]
+    fn fetch_argv_rejects_unknown_priority() {
+        let a = FetchArgs { priority: Some("sometime".into()), ..fetch_base() };
+        assert!(build_fetch_argv(&a).is_err());
+    }
+
+    #[test]
+    fn fetch_argv_skips_blank_for_handle() {
+        let a = FetchArgs { for_handle: Some("   ".into()), ..fetch_base() };
+        let argv = build_fetch_argv(&a).unwrap();
+        assert!(!argv.iter().any(|s| s == "--for"));
+    }
+
+    #[test]
+    fn parse_stdout_empty_string_is_empty_vec() {
+        assert_eq!(parse_fetch_stdout("").unwrap().len(), 0);
+        assert_eq!(parse_fetch_stdout("   \n").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn parse_stdout_two_messages() {
+        let json = r#"[
+          {
+            "id": "AAA", "from": "coord", "to": ["twapp-ui-urgent"], "cc": [],
+            "priority": "urgent", "subject": "build broke", "ts": "20260421T090000Z",
+            "body": "see CI", "path": "/m/inbox/a.md", "legacy": false
+          },
+          {
+            "id": "BBB", "from": "tui", "to": ["twapp-ui-urgent","all"],
+            "priority": "blocker", "ts": "20260421T090100Z",
+            "body": "stop the line", "path": "/m/inbox/b.md", "legacy": true
+          }
+        ]"#;
+        let msgs = parse_fetch_stdout(json).unwrap();
+        assert_eq!(msgs.len(), 2);
+        assert_eq!(msgs[0].id, "AAA");
+        assert_eq!(msgs[0].priority, "urgent");
+        assert_eq!(msgs[0].subject.as_deref(), Some("build broke"));
+        assert_eq!(msgs[1].id, "BBB");
+        assert_eq!(msgs[1].priority, "blocker");
+        assert!(msgs[1].subject.is_none());
+        assert_eq!(msgs[1].to, vec!["twapp-ui-urgent", "all"]);
+    }
+
+    #[test]
+    fn parse_stdout_rejects_non_array() {
+        assert!(parse_fetch_stdout(r#"{"id": "X"}"#).is_err());
+    }
+
+    #[test]
+    fn parse_stdout_skips_malformed_entries() {
+        // Missing required `id` — filtered out rather than failing the whole batch.
+        let json = r#"[{"from":"x","to":["y"],"ts":"T"}, {"id":"OK","from":"a","to":["b"],"priority":"urgent","ts":"T","body":"","path":""}]"#;
+        let msgs = parse_fetch_stdout(json).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].id, "OK");
+    }
+
+    #[test]
+    fn fetch_fake_cli_success() {
+        let tmp = unique_tmp("fetch-ok");
+        let bin = write_fake_bin(
+            &tmp,
+            "fake-twapp-fetch",
+            "#!/bin/sh\ncat <<'JSON'\n[{\"id\":\"X1\",\"from\":\"c\",\"to\":[\"me\"],\"priority\":\"urgent\",\"ts\":\"T\",\"body\":\"b\",\"path\":\"/p\"}]\nJSON\nexit 0\n",
+        );
+        let argv = build_fetch_argv(&fetch_base()).unwrap();
+        let mut cmd = Command::new(&bin);
+        cmd.args(&argv).stdout(Stdio::piped()).stderr(Stdio::piped());
+        let out = cmd.output().expect("spawn fake");
+        assert!(out.status.success());
+        let msgs = parse_fetch_stdout(&String::from_utf8_lossy(&out.stdout)).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].id, "X1");
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -4512,3 +4512,262 @@ a.file-link {
   font-size: 13px;
   z-index: 60;
 }
+
+/* Urgent-inbox panel (sidebar) */
+.urgent-panel {
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  padding: 8px 12px 6px;
+  background: var(--bg-primary);
+}
+
+.urgent-panel.urgent-tone-blocker {
+  background: rgba(220, 38, 38, 0.10);
+  border-top-color: rgba(220, 38, 38, 0.55);
+  border-bottom-color: rgba(220, 38, 38, 0.55);
+}
+
+.urgent-panel.urgent-tone-urgent {
+  background: rgba(220, 38, 38, 0.05);
+  border-top-color: rgba(220, 38, 38, 0.30);
+  border-bottom-color: rgba(220, 38, 38, 0.30);
+}
+
+.urgent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.urgent-header h2 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.urgent-panel.urgent-tone-blocker .urgent-header h2,
+.urgent-panel.urgent-tone-urgent .urgent-header h2 {
+  color: #b91c1c;
+}
+
+.urgent-title {
+  font-weight: 600;
+}
+
+.urgent-count {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 6px;
+}
+
+.priority-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border: 1px solid transparent;
+}
+
+.priority-chip.priority-blocker {
+  background: #dc2626;
+  color: #fff;
+  border-color: #dc2626;
+}
+
+.priority-chip.priority-urgent {
+  background: rgba(220, 38, 38, 0.15);
+  color: #b91c1c;
+  border-color: rgba(220, 38, 38, 0.55);
+}
+
+.priority-chip.priority-routine {
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  border-color: var(--border-color);
+}
+
+.urgent-body {
+  margin-top: 6px;
+}
+
+.urgent-empty {
+  padding: 8px 0 2px;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.urgent-error {
+  padding: 6px 8px;
+  background: rgba(220, 38, 38, 0.10);
+  border: 1px solid rgba(220, 38, 38, 0.45);
+  color: #b91c1c;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.urgent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.urgent-row {
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+}
+
+.urgent-row:hover {
+  background: var(--bg-secondary);
+}
+
+.urgent-row-blocker {
+  border-left: 3px solid #dc2626;
+}
+
+.urgent-row-urgent {
+  border-left: 3px solid rgba(220, 38, 38, 0.55);
+}
+
+.urgent-row-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+}
+
+.urgent-from {
+  font-weight: 600;
+  color: var(--text-primary);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.urgent-time {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+}
+
+.urgent-row-subject {
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Urgent message-view modal */
+.urgent-viewer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.urgent-viewer-panel {
+  width: 620px;
+  max-width: 92vw;
+  max-height: 90vh;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 10px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.urgent-viewer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-color);
+  font-weight: 600;
+}
+
+.urgent-viewer-subject {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.urgent-viewer-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.urgent-viewer-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.urgent-viewer-meta {
+  display: grid;
+  grid-template-columns: auto auto;
+  gap: 4px 16px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.urgent-viewer-meta > div {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+}
+
+.urgent-viewer-label {
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 10px;
+}
+
+.urgent-viewer-body {
+  padding: 12px 14px;
+  margin: 0;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+  color: var(--text-primary);
+  flex: 1;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import PromptSections from "./components/PromptSections";
 import type { EditingPromptState } from "./components/PromptSections";
 import SessionLauncher from "./components/SessionLauncher";
 import MessageComposer from "./components/MessageComposer";
+import UrgentInbox from "./components/UrgentInbox";
 
 
 const SESSION_COLORS = [
@@ -2372,6 +2373,9 @@ function App() {
             </div>
           </div>
         )}
+
+        {/* Urgent messages panel — renders only when session has a handle. */}
+        <UrgentInbox selfHandle={appConfig?.name && appConfig.name !== "twapp" ? appConfig.name : null} />
 
         {/* Notes Section */}
         <div className="notes-section-header">

--- a/src/components/UrgentInbox.test.ts
+++ b/src/components/UrgentInbox.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  mergeByPriority,
+  priorityRank,
+  parseTs,
+  relativeTime,
+  rowPreview,
+  type UrgentMessage,
+} from "./UrgentInbox";
+
+const msg = (o: Partial<UrgentMessage> & { id: string; priority: string; ts: string }): UrgentMessage => ({
+  from: "coord",
+  to: ["twapp-ui-urgent"],
+  body: "",
+  path: "/m/x.md",
+  ...o,
+});
+
+describe("priorityRank", () => {
+  it("sorts blocker < urgent < routine (lower = more important)", () => {
+    expect(priorityRank("blocker")).toBeLessThan(priorityRank("urgent"));
+    expect(priorityRank("urgent")).toBeLessThan(priorityRank("routine"));
+  });
+
+  it("treats unknown priorities as routine-level", () => {
+    expect(priorityRank("weird")).toBe(priorityRank("routine"));
+  });
+});
+
+describe("mergeByPriority", () => {
+  it("renders 3 messages in blocker-first then newest-first order", () => {
+    const urgent = [
+      msg({ id: "A", priority: "urgent", ts: "20260421T090000Z" }),
+      msg({ id: "B", priority: "urgent", ts: "20260421T091000Z" }),
+    ];
+    const blocker = [msg({ id: "C", priority: "blocker", ts: "20260421T085959Z" })];
+    const out = mergeByPriority([urgent, blocker]);
+    expect(out.map((m) => m.id)).toEqual(["C", "B", "A"]);
+  });
+
+  it("dedupes by id, preferring the stronger priority", () => {
+    // Real-world: the `inbox/urgent/` lane contains symlinks that surface both
+    // priority=urgent AND priority=blocker messages. Either query can return
+    // the same id with a different `priority` string; keep the strongest one.
+    const urgent = [msg({ id: "X", priority: "urgent", ts: "20260421T090000Z" })];
+    const blocker = [msg({ id: "X", priority: "blocker", ts: "20260421T090000Z" })];
+    const out = mergeByPriority([urgent, blocker]);
+    expect(out).toHaveLength(1);
+    expect(out[0].priority).toBe("blocker");
+  });
+
+  it("returns empty array when both inputs are empty", () => {
+    expect(mergeByPriority([[], []])).toEqual([]);
+  });
+
+  it("handles a single empty list alongside populated", () => {
+    const blocker = [msg({ id: "Z", priority: "blocker", ts: "20260421T100000Z" })];
+    expect(mergeByPriority([[], blocker]).map((m) => m.id)).toEqual(["Z"]);
+  });
+});
+
+describe("parseTs", () => {
+  it("parses the CLI timestamp format", () => {
+    const n = parseTs("20260421T090400Z");
+    expect(n).toBe(Date.parse("2026-04-21T09:04:00Z"));
+  });
+
+  it("returns null on malformed input", () => {
+    expect(parseTs("not-a-timestamp")).toBeNull();
+    expect(parseTs("")).toBeNull();
+  });
+});
+
+describe("relativeTime", () => {
+  const now = Date.parse("2026-04-21T10:00:00Z");
+  it("formats seconds / minutes / hours / days", () => {
+    expect(relativeTime("20260421T095959Z", now)).toBe("1s");
+    expect(relativeTime("20260421T094500Z", now)).toBe("15m");
+    expect(relativeTime("20260421T060000Z", now)).toBe("4h");
+    expect(relativeTime("20260418T100000Z", now)).toBe("3d");
+  });
+
+  it("clamps negative deltas to 0s so future-dated messages don't render nonsense", () => {
+    expect(relativeTime("20260421T100100Z", now)).toBe("0s");
+  });
+
+  it("passes through unparseable timestamps verbatim", () => {
+    expect(relativeTime("weird", now)).toBe("weird");
+  });
+});
+
+describe("rowPreview", () => {
+  it("prefers subject when set", () => {
+    expect(rowPreview(msg({ id: "1", priority: "urgent", ts: "T", subject: "PR #55 DIRTY" }))).toBe(
+      "PR #55 DIRTY",
+    );
+  });
+
+  it("falls back to the first non-blank body line", () => {
+    expect(rowPreview(msg({ id: "1", priority: "urgent", ts: "T", body: "\n\nreal line\nnext" }))).toBe(
+      "real line",
+    );
+  });
+
+  it("truncates long previews", () => {
+    const long = "x".repeat(200);
+    const out = rowPreview(msg({ id: "1", priority: "urgent", ts: "T", body: long }));
+    expect(out.length).toBeLessThanOrEqual(120);
+  });
+
+  it("returns a placeholder when both subject and body are empty", () => {
+    expect(rowPreview(msg({ id: "1", priority: "urgent", ts: "T" }))).toBe("(no subject)");
+  });
+});

--- a/src/components/UrgentInbox.tsx
+++ b/src/components/UrgentInbox.tsx
@@ -1,0 +1,320 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export type UrgentPriority = "urgent" | "blocker";
+
+export type UrgentMessage = {
+  id: string;
+  from: string;
+  to: string[];
+  cc?: string[];
+  priority: string;
+  subject?: string | null;
+  thread?: string | null;
+  ts: string;
+  body: string;
+  path: string;
+};
+
+type FetchArgs = {
+  forHandle?: string | null;
+  priority?: UrgentPriority;
+  limit?: number;
+};
+
+type UrgentInboxProps = {
+  selfHandle: string | null;
+  // Injected in tests; defaults to the Tauri invoke bridge.
+  fetcher?: (args: FetchArgs) => Promise<UrgentMessage[]>;
+  // Clock injection for deterministic relative-time tests.
+  now?: () => number;
+  // Poll interval in ms while expanded. 10s per briefing.
+  pollMs?: number;
+  // Collapse after empty state persists this long. 60s per briefing.
+  collapseAfterEmptyMs?: number;
+};
+
+export function priorityRank(p: string): number {
+  if (p === "blocker") return 0;
+  if (p === "urgent") return 1;
+  return 2;
+}
+
+/** Merge two priority streams by id, preserving the strongest priority per id. */
+export function mergeByPriority(lists: UrgentMessage[][]): UrgentMessage[] {
+  const byId = new Map<string, UrgentMessage>();
+  for (const list of lists) {
+    for (const m of list) {
+      const existing = byId.get(m.id);
+      if (!existing || priorityRank(m.priority) < priorityRank(existing.priority)) {
+        byId.set(m.id, m);
+      }
+    }
+  }
+  const merged = Array.from(byId.values());
+  merged.sort((a, b) => {
+    const r = priorityRank(a.priority) - priorityRank(b.priority);
+    if (r !== 0) return r;
+    // Newest first within the same priority bucket. ts is YYYYMMDDTHHMMSSZ so
+    // string comparison is the same as chronological.
+    return b.ts.localeCompare(a.ts);
+  });
+  return merged;
+}
+
+/** Parse the CLI's fixed-width timestamp format: YYYYMMDDTHHMMSSZ (or .%fZ). */
+export function parseTs(ts: string): number | null {
+  const m = ts.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/);
+  if (!m) return null;
+  const iso = `${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}Z`;
+  const n = Date.parse(iso);
+  return Number.isNaN(n) ? null : n;
+}
+
+export function relativeTime(ts: string, now: number): string {
+  const t = parseTs(ts);
+  if (t === null) return ts;
+  const secs = Math.max(0, Math.floor((now - t) / 1000));
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+export function rowPreview(m: UrgentMessage): string {
+  if (m.subject && m.subject.trim()) return m.subject.trim();
+  const firstLine = (m.body || "").split("\n").find((l) => l.trim().length > 0);
+  return firstLine ? firstLine.trim().slice(0, 120) : "(no subject)";
+}
+
+const tauriFetcher = (args: FetchArgs): Promise<UrgentMessage[]> =>
+  invoke<UrgentMessage[]>("fetch_messages", { args });
+
+/** Collapsible urgent-inbox panel for the session sidebar.
+ *
+ *  Fetches `priority: urgent` + `priority: blocker` messages addressed to the
+ *  session's own handle and surfaces them with a red accent. Polls every 10s
+ *  while expanded; auto-collapses when empty for >60s. No user handle = no
+ *  panel (single-session users never see urgent UI). */
+export default function UrgentInbox({
+  selfHandle,
+  fetcher = tauriFetcher,
+  now = () => Date.now(),
+  pollMs = 10_000,
+  collapseAfterEmptyMs = 60_000,
+}: UrgentInboxProps) {
+  const [messages, setMessages] = useState<UrgentMessage[]>([]);
+  const [expanded, setExpanded] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [viewing, setViewing] = useState<UrgentMessage | null>(null);
+
+  // `userCollapsed` is set when the user clicks the header to collapse.
+  // It survives auto-collapse-due-to-empty: a subsequent manual expand re-enables
+  // the auto-collapse timer. We only track "last empty at" when not user-collapsed.
+  const [userCollapsed, setUserCollapsed] = useState(false);
+  const emptySinceRef = useRef<number | null>(null);
+
+  // Deduped latest fetch key, so stale in-flight fetches don't overwrite fresh ones.
+  const fetchSeqRef = useRef(0);
+
+  const doFetch = useCallback(async () => {
+    if (!selfHandle) {
+      setMessages([]);
+      return;
+    }
+    const seq = ++fetchSeqRef.current;
+    try {
+      const [urgent, blocker] = await Promise.all([
+        fetcher({ forHandle: selfHandle, priority: "urgent" }),
+        fetcher({ forHandle: selfHandle, priority: "blocker" }),
+      ]);
+      if (seq !== fetchSeqRef.current) return;
+      const merged = mergeByPriority([urgent || [], blocker || []]);
+      setMessages(merged);
+      setError(null);
+    } catch (e) {
+      if (seq !== fetchSeqRef.current) return;
+      setError(String(e));
+    }
+  }, [selfHandle, fetcher]);
+
+  // Poll — runs whether expanded or not, because the chevron needs a live
+  // count and auto-collapse decisions depend on knowing the queue is empty.
+  useEffect(() => {
+    if (!selfHandle) return;
+    doFetch();
+    const h = window.setInterval(doFetch, pollMs);
+    return () => window.clearInterval(h);
+  }, [selfHandle, doFetch, pollMs]);
+
+  // Auto-collapse after sustained emptiness.
+  useEffect(() => {
+    if (userCollapsed || !expanded) {
+      emptySinceRef.current = null;
+      return;
+    }
+    if (messages.length > 0) {
+      emptySinceRef.current = null;
+      return;
+    }
+    if (emptySinceRef.current === null) {
+      emptySinceRef.current = now();
+    }
+    const elapsed = now() - emptySinceRef.current;
+    const remaining = collapseAfterEmptyMs - elapsed;
+    if (remaining <= 0) {
+      setExpanded(false);
+      return;
+    }
+    const h = window.setTimeout(() => setExpanded(false), remaining);
+    return () => window.clearTimeout(h);
+  }, [messages, expanded, userCollapsed, collapseAfterEmptyMs, now]);
+
+  const badge = useMemo(() => {
+    const blockers = messages.filter((m) => m.priority === "blocker").length;
+    const urgents = messages.length - blockers;
+    if (messages.length === 0) return null;
+    return { blockers, urgents };
+  }, [messages]);
+
+  const toggle = () => {
+    if (expanded) {
+      setUserCollapsed(true);
+      setExpanded(false);
+    } else {
+      setUserCollapsed(false);
+      setExpanded(true);
+    }
+  };
+
+  if (!selfHandle) return null;
+
+  const tone =
+    messages.some((m) => m.priority === "blocker")
+      ? "urgent-tone-blocker"
+      : messages.length > 0
+        ? "urgent-tone-urgent"
+        : "urgent-tone-empty";
+
+  return (
+    <div className={`urgent-panel ${tone}`}>
+      <div
+        className="urgent-header"
+        onClick={toggle}
+        role="button"
+        aria-expanded={expanded}
+      >
+        <h2>
+          <span className={`prompt-chevron ${expanded ? "expanded" : ""}`}>▶</span>
+          <span className="urgent-title">Urgent</span>
+          {badge && (
+            <span className="urgent-count">
+              {badge.blockers > 0 && (
+                <span className="priority-chip priority-blocker" title="blocker">
+                  {badge.blockers} blocker{badge.blockers === 1 ? "" : "s"}
+                </span>
+              )}
+              {badge.urgents > 0 && (
+                <span className="priority-chip priority-urgent" title="urgent">
+                  {badge.urgents} urgent
+                </span>
+              )}
+            </span>
+          )}
+        </h2>
+        <button
+          className="section-refresh-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            doFetch();
+          }}
+          title="Refresh urgent queue"
+        >
+          &#8635;
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="urgent-body">
+          {error && <div className="urgent-error">{error}</div>}
+          {!error && messages.length === 0 && (
+            <div className="urgent-empty">No urgent messages.</div>
+          )}
+          {!error && messages.length > 0 && (
+            <ul className="urgent-list">
+              {messages.map((m) => (
+                <li
+                  key={m.id}
+                  className={`urgent-row urgent-row-${m.priority}`}
+                  onClick={() => setViewing(m)}
+                  role="button"
+                >
+                  <div className="urgent-row-top">
+                    <span className={`priority-chip priority-${m.priority}`}>
+                      {m.priority}
+                    </span>
+                    <span className="urgent-from">{m.from}</span>
+                    <span className="urgent-time" title={m.ts}>
+                      {relativeTime(m.ts, now())}
+                    </span>
+                  </div>
+                  <div className="urgent-row-subject">{rowPreview(m)}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {viewing && (
+        <div className="urgent-viewer-overlay" onClick={() => setViewing(null)}>
+          <div className="urgent-viewer-panel" onClick={(e) => e.stopPropagation()}>
+            <div className="urgent-viewer-header">
+              <span className={`priority-chip priority-${viewing.priority}`}>
+                {viewing.priority}
+              </span>
+              <span className="urgent-viewer-subject">
+                {viewing.subject && viewing.subject.trim() ? viewing.subject : "(no subject)"}
+              </span>
+              <button
+                className="urgent-viewer-close"
+                onClick={() => setViewing(null)}
+                aria-label="Close"
+              >
+                x
+              </button>
+            </div>
+            <div className="urgent-viewer-meta">
+              <div>
+                <span className="urgent-viewer-label">from</span>
+                <span>{viewing.from}</span>
+              </div>
+              <div>
+                <span className="urgent-viewer-label">to</span>
+                <span>{viewing.to.join(", ")}</span>
+              </div>
+              {viewing.cc && viewing.cc.length > 0 && (
+                <div>
+                  <span className="urgent-viewer-label">cc</span>
+                  <span>{viewing.cc.join(", ")}</span>
+                </div>
+              )}
+              <div>
+                <span className="urgent-viewer-label">ts</span>
+                <span>{viewing.ts}</span>
+              </div>
+              <div>
+                <span className="urgent-viewer-label">id</span>
+                <code>{viewing.id}</code>
+              </div>
+            </div>
+            <pre className="urgent-viewer-body">{viewing.body}</pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Surfaces the PR #53 priority lane directly in the session window so
urgent/blocker messages don't require a terminal drop-through.

- **`UrgentInbox` panel** (sidebar, above Notes) — polls
  `twapp msg fetch --for <self> --priority urgent|blocker --format json`
  every 10s via a new `fetch_messages` Tauri command. Merges both lanes
  by id (keeps the strongest priority when the symlink surfaces both),
  sorts blocker-first then newest-first.
- **Visual treatment** — red accent on the panel chrome, stronger for
  blockers than urgents. Rows show `from`, subject-or-first-body-line,
  priority chip, and relative time. Clicking a row opens a read-only
  message-view modal.
- **Empty state** — `"No urgent messages."`, auto-collapses after 60s of
  sustained emptiness. User can manually re-expand; polling continues
  regardless so the collapse decision stays fresh.
- **Gating** — panel renders only when the session has a non-default
  handle, so single-session users with no mailbox presence see nothing.

## Out of scope

- **Priority filter chip on the general inbox** — no general inbox view
  exists in the session window yet (only Notes / Prompts / Ticket /
  Urgent), so per the briefing fallback clause this PR is scoped to the
  urgent panel only. The chip row lands with the inbox view.
- **`twapp msg ack`** — the briefing lists an ack button as nice-to-have
  and the CLI doesn't expose an `ack` subcommand today. Deferred.

## Test plan

- [x] `npm test` — 118/118 pass (15 new in `UrgentInbox.test.ts`)
- [x] `cargo test` — 177/177 pass (9 new in `gui::msg::tests` covering
  `build_fetch_argv` + `parse_fetch_stdout` + fake-CLI smoke)
- [x] `npm run build` — clean tsc + vite build
- [ ] Manual (reviewer): spawn a session with a handle, have the
  coordinator send a `--priority blocker` message, confirm the panel
  lights up on next 10s tick. Unit coverage replaces a React Testing
  Library harness (not installed in this repo — matches the
  MessageComposer PR #50 convention of pure-logic vitest tests).

Depends on PR #53 (priority-lane CLI) and PR #50 (composer — Tauri
boilerplate + CSS variable tokens reused here).