### PR TITLE
feat(msg): threading (reply-to + twapp msg thread) — design PR-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,8 +580,14 @@ twapp msg send reviewer "PR-1 is up, ready to review"
 twapp msg send worker-a,worker-b --priority urgent --subject "build broke" "see CI 1234"
 twapp msg send reviewer --cc coordinator,qa "heads up on scope change"
 
-# Replies inherit the parent's thread id and set in_reply_to.
+# Replies inherit the parent's thread id and set in_reply_to. If the
+# parent is itself a root (no thread: field), the reply's thread id
+# becomes the parent's own id. Replies at any depth thread to the root.
 twapp msg send reviewer --reply-to 01JS4M7Q8W "ack, rebasing now"
+
+# List every message in a thread (root + all replies), chronologically.
+twapp msg thread 01JS4M7Q8W
+twapp msg thread 01JS4M7Q8W --format json | jq
 
 # Broadcast — writes to: [all], or to: [channel:<name>] with --channel.
 twapp msg broadcast "standup in 5"
@@ -922,6 +928,7 @@ burns iteration.
 | `twapp msg send <to> [body]` | Send a message (writes to the shared mailbox inbox) |
 | `twapp msg broadcast [body]` | Broadcast to every handle (`to: [all]`) |
 | `twapp msg fetch [--for <h>] [--since <ts>]` | List inbox messages, filtered |
+| `twapp msg thread <thread-id>` | List every message in a thread chronologically; `--format json` for machine-readable |
 | `twapp msg claim <lane-id> [--note <s>]` | Atomically claim a shared lane (PR, audit, backlog item); exit 1 if already claimed |
 | `twapp msg release <lane-id> [--note <s>]` | Release a lane you own; writes `released.json` and broadcasts the release |
 | `twapp msg claim --list [--lane-prefix <p>]` | List all active (unreleased, unstale) claims; `--format json` for machine-readable |

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -245,6 +245,30 @@ strongest red accent. Sending `--priority blocker` is therefore both a
 poll-time hint and an interactive interrupt — the recipient sees the
 panel light up on next poll even without reopening a terminal.
 
+### Threading (`--reply-to` + `msg thread`)
+
+Long coordinator ↔ worker conversations span multiple messages. Keep
+them coherent by threading instead of leaning on `re:` prose:
+
+```bash
+# Start a thread (the root is whatever you sent first — no flag needed).
+twapp msg send worker-a --subject "scope change" "<body>"
+
+# Reply to a specific parent — inherits the parent's thread id and sets
+# in_reply_to. If the parent is itself a root (no thread: field), the
+# reply's thread id becomes the parent's own id.
+twapp msg send worker-a --reply-to 01JS4M7Q8W "ack, rebasing now"
+
+# List every message in a thread chronologically (root + all replies).
+twapp msg thread 01JS4M7Q8W
+twapp msg thread 01JS4M7Q8W --format json | jq
+```
+
+Use this for REDIRECTs, scope changes, and multi-turn reviews — anywhere
+the second message only makes sense in the context of the first. The
+thread id is stable for the lifetime of the conversation; a reply at
+depth N still threads to the root, not to the immediate parent.
+
 ### Example message
 
 ```

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -528,6 +528,7 @@ pub fn run(cmd: Commands) -> i32 {
                     msg_archive::cmd_list(since, format)
                 }
             },
+            MsgCommands::Thread { thread_id, format } => msg::cmd_thread(thread_id, format),
         },
         Commands::Models { command } => match command {
             ModelsCommands::List { provider, format } => models::cmd_list(provider, format),

--- a/src-tauri/src/cli/msg.rs
+++ b/src-tauri/src/cli/msg.rs
@@ -214,6 +214,20 @@ pub enum MsgCommands {
         #[command(subcommand)]
         command: super::msg_archive::ArchiveCommands,
     },
+    /// List every message in a thread in chronological order.
+    ///
+    /// Matches both messages whose `thread:` equals `<thread-id>` and the
+    /// root message whose `id:` equals `<thread-id>` (thread roots carry no
+    /// `thread:` field on their own). Prints a short one-line-per-message
+    /// summary by default; `--format json` dumps the full parsed messages.
+    #[command(after_help = "Examples:\n  twapp msg thread 01JS4K2AAA\n  twapp msg thread 01JS4K2AAA --format json")]
+    Thread {
+        /// Thread id (root message id).
+        thread_id: String,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = FetchFormat::Pretty)]
+        format: FetchFormat,
+    },
 }
 
 // --- Mailbox discovery ------------------------------------------------------
@@ -1128,6 +1142,68 @@ pub fn cmd_fetch(
             0
         }
     }
+}
+
+/// List every message with `thread == <thread_id>` (plus the thread root
+/// whose `id == <thread_id>` — roots omit `thread:` on themselves) in
+/// chronological order. `--format json` dumps the full parsed messages;
+/// default output is a one-line-per-message summary.
+pub fn cmd_thread(thread_id: String, format: FetchFormat) -> i32 {
+    let inbox = match inbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let msgs = list_thread(&inbox, &thread_id);
+    match format {
+        FetchFormat::Json => match serde_json::to_string_pretty(&msgs) {
+            Ok(s) => {
+                println!("{}", s);
+                0
+            }
+            Err(e) => {
+                eprintln!("Error serializing: {}", e);
+                1
+            }
+        },
+        FetchFormat::Pretty => {
+            if msgs.is_empty() {
+                println!("(no messages in thread {})", thread_id);
+                return 0;
+            }
+            println!("thread {} ({} message{})", thread_id, msgs.len(), if msgs.len() == 1 { "" } else { "s" });
+            for m in &msgs {
+                print_thread_summary(m);
+            }
+            0
+        }
+    }
+}
+
+/// Collect every parsed message belonging to `thread_id`, chronologically.
+/// A message belongs to a thread when its `thread:` equals the id *or* its
+/// own `id:` equals the id (the root case, since roots do not set `thread:`
+/// on themselves by design §2.4).
+pub fn list_thread(inbox: &Path, thread_id: &str) -> Vec<ParsedMessage> {
+    let mut msgs = list_messages(inbox);
+    msgs.retain(|m| {
+        m.fm.id == thread_id || m.fm.thread.as_deref() == Some(thread_id)
+    });
+    msgs
+}
+
+fn print_thread_summary(m: &ParsedMessage) {
+    let subj = m.fm.subject.as_deref().unwrap_or("(no subject)");
+    println!(
+        "  {}  {}  from={}  priority={}  subject={}",
+        m.fm.ts,
+        m.fm.id,
+        m.fm.from,
+        m.fm.priority.as_str(),
+        subj,
+    );
 }
 
 fn print_pretty(m: &ParsedMessage) {
@@ -2099,5 +2175,122 @@ new\n";
         );
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].body.trim(), "merge freeze");
+    }
+
+    // ---- PR-2: threading (reply-to + twapp msg thread) -------------------
+
+    /// `cmd_send`'s reply-to path, reused by the PR-2 tests without going
+    /// through the process-wide env + session plumbing of the real CLI.
+    fn send_reply(
+        inbox: &Path,
+        parent_id: &str,
+        from: &str,
+        body: &str,
+    ) -> Result<SentMessage, String> {
+        let parent = find_by_id(inbox, parent_id)
+            .ok_or_else(|| format!("--reply-to id {} not found", parent_id))?;
+        let thread_id = parent.thread.clone().unwrap_or(parent.id.clone());
+        write_message(
+            inbox,
+            SendArgs {
+                to: parent.to.clone(),
+                from: from.to_string(),
+                priority: MsgPriority::Routine,
+                subject: parent.subject.clone(),
+                thread: Some(thread_id),
+                in_reply_to: Some(parent.id.clone()),
+                cc: Vec::new(),
+                body: body.to_string(),
+            },
+        )
+    }
+
+    #[test]
+    fn reply_to_inherits_thread_from_parent() {
+        // Parent is already a reply — it has an explicit thread id distinct
+        // from its own id. The child must inherit that thread id, not the
+        // parent's own id.
+        let g = MailboxGuard::new();
+        let root = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "root");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let mid = send_reply(&g.inbox(), &root.fm.id, "reviewer", "mid").unwrap();
+        assert_eq!(mid.fm.thread.as_deref(), Some(root.fm.id.as_str()));
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let leaf = send_reply(&g.inbox(), &mid.fm.id, "implementer-a", "leaf").unwrap();
+        // Leaf inherits root thread id from mid — not mid's own id.
+        assert_eq!(leaf.fm.thread.as_deref(), Some(root.fm.id.as_str()));
+        assert_eq!(leaf.fm.in_reply_to.as_deref(), Some(mid.fm.id.as_str()));
+    }
+
+    #[test]
+    fn reply_to_new_thread_uses_parent_id_as_root() {
+        // Parent has no thread — it's a fresh root. The reply's thread id
+        // must therefore be the parent's own id.
+        let g = MailboxGuard::new();
+        let root = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "root");
+        assert!(root.fm.thread.is_none(), "root should not carry own thread id");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let reply = send_reply(&g.inbox(), &root.fm.id, "reviewer", "reply").unwrap();
+        assert_eq!(reply.fm.thread.as_deref(), Some(root.fm.id.as_str()));
+        assert_eq!(reply.fm.in_reply_to.as_deref(), Some(root.fm.id.as_str()));
+    }
+
+    #[test]
+    fn reply_to_nonexistent_parent_errors() {
+        let g = MailboxGuard::new();
+        let err = match send_reply(&g.inbox(), "NOSUCHIDXXXXXXXX", "a", "x") {
+            Ok(_) => panic!("reply to nonexistent parent should have errored"),
+            Err(e) => e,
+        };
+        assert!(
+            err.contains("NOSUCHIDXXXXXXXX"),
+            "error should name the missing id: {}",
+            err
+        );
+        assert!(
+            err.to_ascii_lowercase().contains("not found"),
+            "error should say not found: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn thread_lists_in_chronological_order() {
+        let g = MailboxGuard::new();
+        let root = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "r");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let r1 = send_reply(&g.inbox(), &root.fm.id, "reviewer", "one").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let r2 = send_reply(&g.inbox(), &r1.fm.id, "implementer-a", "two").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // An unrelated message in the mailbox must not leak into the thread.
+        let _unrelated = send(&g.inbox(), vec!["qa"], MsgPriority::Routine, "off-topic");
+
+        let thread = list_thread(&g.inbox(), &root.fm.id);
+        assert_eq!(thread.len(), 3, "got ids: {:?}", thread.iter().map(|m| &m.fm.id).collect::<Vec<_>>());
+        assert_eq!(thread[0].fm.id, root.fm.id);
+        assert_eq!(thread[1].fm.id, r1.fm.id);
+        assert_eq!(thread[2].fm.id, r2.fm.id);
+        // Timestamps are strictly non-decreasing.
+        assert!(thread[0].fm.ts <= thread[1].fm.ts);
+        assert!(thread[1].fm.ts <= thread[2].fm.ts);
+    }
+
+    #[test]
+    fn thread_returns_empty_on_unknown_id_without_crash() {
+        let g = MailboxGuard::new();
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "hi");
+        let thread = list_thread(&g.inbox(), "NOSUCHTHREADID");
+        assert!(thread.is_empty());
+
+        // Also tolerate an empty inbox.
+        let empty_mailbox = std::env::temp_dir().join(format!(
+            "twapp-msg-empty-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(empty_mailbox.join("inbox")).unwrap();
+        let thread = list_thread(&empty_mailbox.join("inbox"), "ANY");
+        assert!(thread.is_empty());
+        let _ = std::fs::remove_dir_all(&empty_mailbox);
     }
 }


### PR DESCRIPTION
## Summary

- `twapp msg thread <thread-id>` lists every message in the thread in chronological order (both messages whose `thread:` equals `<id>` and the root whose `id` equals `<id>`). `--format json` supported.
- `twapp msg send --reply-to <parent-id>` already lands in PR-1: inherits `thread` from parent (or uses parent's own id if the parent is a root), sets `in_reply_to: <parent-id>`, errors if parent is missing. This PR exercises it with the named tests.
- Design: [`docs/designs/agent-messaging.md`](../blob/main/docs/designs/agent-messaging.md) §2.4, §5 PR-2.

## Scope

In:
- New `MsgCommands::Thread { thread_id, format }` subcommand + `cmd_thread` / `list_thread` impl.
- Five PR-2 tests from the design:
  - `reply_to_inherits_thread_from_parent` — multi-hop: leaf inherits root thread via an intermediate reply (not the intermediate's id).
  - `reply_to_new_thread_uses_parent_id_as_root` — parent is root, reply's thread == parent's id.
  - `reply_to_nonexistent_parent_errors` — error mentions the id + "not found".
  - `thread_lists_in_chronological_order` — unrelated messages excluded; timestamps non-decreasing.
  - `thread_returns_empty_on_unknown_id_without_crash` — also tolerates an empty inbox.

Out (design-doc PR-3+):
- Directory split (`inbox/direct/`, `inbox/broadcast/`) — PR-3.
- Priority lane filter work — PR-4.
- Optional `threads/<thread-id>/<ts>-<id6>.md` symlink secondary index — skipped as nice-to-have to keep PR small; can follow up if useful.

## Test plan

- [x] `cargo test --lib cli::msg::` → 38 passed, 0 failed, including all 5 new tests.
- [x] `cargo build --bin twapp` clean.
- [x] `twapp msg thread --help` renders the new subcommand.