### PR TITLE
feat(ui): co-lab window title prefix + coordinator tag in sessions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,28 @@ expand/collapse. Collapsed state is remembered across app restarts. If
 you're not running a co-lab, the launcher reverts to its flat list — no
 empty headers, no regression in the single-session UX.
 
+### Identifying a co-lab session at a glance
+
+Inside the launcher, any session that qualifies as co-lab — either its
+`role` is set, or its provenance is `spawned` — gets a neutral `CO-LAB`
+chip in the badge row next to its name. The chip's tooltip surfaces the
+specific role when one is present (`Co-lab session — role: reviewer`)
+and falls back to "Co-lab session (spawned by another session)"
+otherwise. Sessions with `role: "coordinator"` trade the neutral chip
+for a stronger `COORDINATOR` tag in the launcher's accent color, so the
+orchestrator of the fleet is findable in one scan. Plain user-created
+sessions (no role, no spawned provenance) render exactly as before — no
+chip, no tag.
+
+The same metadata shapes the OS window title so Mission Control and
+Alt-Tab stay readable without opening each window: `twapp - co-lab - <name>`
+for spawned sessions without a role, `twapp - co-lab:<role> - <name>` for
+the co-lab role archetypes (`coordinator`, `implementer`, `reviewer`,
+`auditor`, `log-watcher`, `architect`, `qa`, `area-owner`, `designer`),
+and the unchanged `twapp - <name>` for plain user sessions. The formatter
+lives in [`src-tauri/src/gui/title.rs`](src-tauri/src/gui/title.rs) with a
+unit test per branch.
+
 ### Spawning a worker agent
 
 twapp works well as a terminal wrapper for *interactive* sessions, but

--- a/docs/designs/agent-aware-ui.md
+++ b/docs/designs/agent-aware-ui.md
@@ -1,6 +1,9 @@
 # Design: Agent-aware UI — provenance, roles, coordinator dashboard
 
-Status: **draft**
+Status: **draft** — §3.1 (provenance) and §3.2 (role badge) are
+**partially landed** by the co-lab identifier-chrome PR
+(`feat(ui): co-lab window title prefix + coordinator tag in sessions
+list`). See the in-section notes and §3.6 for the shipped shape.
 Author: design pass grounded in one audit of the current Tauri UI; no
 implementation in this PR.
 Scope: a proposed shape for how the twapp UI evolves once the messaging
@@ -205,6 +208,15 @@ users never render it.
 
 ### 3.1 Instance provenance visual
 
+> **Partially landed** (colab-ui-chrome PR): the launcher now renders a
+> neutral `CO-LAB` chip in `launcher-session-meta` when the session has
+> a non-empty `role` **or** `provenance == "spawned"`. The richer
+> 12-px glyph prefix (◦ / ▸) described below is still aspirational —
+> the shipped chip intentionally rides on the existing badge row to
+> keep the scope small. See also §3.2 (COORDINATOR tag) and the new
+> OS-window-title prefix `twapp - co-lab[:<role>] - <name>`
+> centralized in `src-tauri/src/gui/title.rs`.
+
 **Shape:** a 12-px **icon prefix** immediately before the session name,
 both in the launcher list and in the session window's `sidebar-title`:
 
@@ -233,6 +245,15 @@ absent — single-session users migrate silently with an
 `◦` prefix.
 
 ### 3.2 Role badge
+
+> **Partially landed** (colab-ui-chrome PR): the coordinator variant
+> ships as a prominent `COORDINATOR` tag in the same
+> `launcher-session-meta` row, and the OS window title for
+> coordinator sessions becomes `twapp - co-lab:coordinator - <name>`
+> (other co-lab archetypes also get `co-lab:<role>` titles). The
+> kebab-case-token chip set (`[coord] [impl] [rev] ...`) for
+> non-coordinator roles is deferred; the shipped chrome uses a single
+> neutral `CO-LAB` chip plus the tooltip `role: <role>` for now.
 
 **Shape:** a compact right-aligned chip next to the session name,
 inside the same `launcher-session-meta` row as other badges. Short

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -9,6 +9,7 @@ pub mod pty;
 pub mod sessions;
 pub mod shell_env;
 pub mod tickets;
+pub mod title;
 pub mod types;
 
 pub use tickets::{extract_adf_text, truncate_str};
@@ -34,11 +35,22 @@ pub fn run(args: GuiArgs) {
     let pty_state = Arc::new(Mutex::new(PtyState::default()));
     let monitor_state = Arc::new(Mutex::new(MonitorState::default()));
 
-    let title = if args.name == "twapp" {
-        "twapp".to_string()
-    } else {
-        format!("twapp - {}", args.name)
-    };
+    // Pull role + provenance from the session file (if any) so the OS
+    // window title can advertise co-lab sessions at a glance. A missing
+    // or unparseable file silently falls back to the plain title.
+    let (session_role, session_provenance) = args
+        .cwd
+        .as_ref()
+        .and_then(|cwd| {
+            crate::cli::session::read_session(&std::path::PathBuf::from(cwd)).ok()
+        })
+        .map(|s| (s.role, s.provenance))
+        .unwrap_or((None, None));
+    let title = title::format_window_title(
+        &args.name,
+        session_role.as_deref(),
+        session_provenance.as_deref(),
+    );
 
     // Clone cwd for the file watcher thread
     let watcher_cwd = args.cwd.clone();

--- a/src-tauri/src/gui/title.rs
+++ b/src-tauri/src/gui/title.rs
@@ -1,0 +1,144 @@
+/// Co-lab role archetypes — these are the roles we render as
+/// `co-lab:<role>` in the OS window title. Other non-empty role strings
+/// are permitted on `SessionData.role` (the field is free-form), but
+/// they collapse to the plain `co-lab` prefix if provenance is spawned,
+/// and to no prefix at all if provenance is user. The list mirrors the
+/// archetypes called out by the co-lab docs-brand briefing.
+pub const COLAB_ROLE_ARCHETYPES: &[&str] = &[
+    "coordinator",
+    "implementer",
+    "reviewer",
+    "auditor",
+    "log-watcher",
+    "architect",
+    "qa",
+    "area-owner",
+    "designer",
+];
+
+fn is_colab_archetype(role: &str) -> bool {
+    COLAB_ROLE_ARCHETYPES.contains(&role)
+}
+
+/// Compose the OS window title for a twapp instance.
+///
+/// Precedence:
+/// 1. `role` is a known co-lab archetype → `twapp - co-lab:<role> - <name>`
+/// 2. `provenance == "spawned"`         → `twapp - co-lab - <name>`
+/// 3. otherwise                          → unchanged `twapp` / `twapp - <name>`
+///
+/// The unchanged branch is what the app rendered before this function
+/// existed; single-session plain usage must see zero regression.
+pub fn format_window_title(
+    name: &str,
+    role: Option<&str>,
+    provenance: Option<&str>,
+) -> String {
+    let plain = if name == "twapp" {
+        "twapp".to_string()
+    } else {
+        format!("twapp - {}", name)
+    };
+
+    if let Some(r) = role {
+        if is_colab_archetype(r) {
+            return format!("twapp - co-lab:{} - {}", r, name);
+        }
+    }
+    if provenance == Some("spawned") {
+        return format!("twapp - co-lab - {}", name);
+    }
+    plain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_user_session_unchanged() {
+        assert_eq!(
+            format_window_title("bash", None, Some("user")),
+            "twapp - bash"
+        );
+    }
+
+    #[test]
+    fn plain_user_session_no_provenance_unchanged() {
+        // Legacy session files predate the provenance field.
+        assert_eq!(
+            format_window_title("legacy", None, None),
+            "twapp - legacy"
+        );
+    }
+
+    #[test]
+    fn default_instance_name_stays_bare() {
+        // The GUI falls back to `name == "twapp"` when nothing was passed;
+        // that case must still produce just `twapp` with no trailing dash.
+        assert_eq!(format_window_title("twapp", None, None), "twapp");
+    }
+
+    #[test]
+    fn spawned_without_role_gets_colab_prefix() {
+        assert_eq!(
+            format_window_title("my-worker", None, Some("spawned")),
+            "twapp - co-lab - my-worker"
+        );
+    }
+
+    #[test]
+    fn coordinator_role_gets_role_scoped_prefix() {
+        assert_eq!(
+            format_window_title("my-coord", Some("coordinator"), Some("spawned")),
+            "twapp - co-lab:coordinator - my-coord"
+        );
+    }
+
+    #[test]
+    fn reviewer_role_gets_role_scoped_prefix() {
+        assert_eq!(
+            format_window_title("feature-x", Some("reviewer"), Some("spawned")),
+            "twapp - co-lab:reviewer - feature-x"
+        );
+    }
+
+    #[test]
+    fn archetype_role_wins_even_if_provenance_is_user() {
+        // role set takes precedence — a reviewer deliberately launched by
+        // a human should still be identifiable as co-lab chrome.
+        assert_eq!(
+            format_window_title("feature-x", Some("reviewer"), Some("user")),
+            "twapp - co-lab:reviewer - feature-x"
+        );
+    }
+
+    #[test]
+    fn non_archetype_role_with_spawned_falls_through_to_plain_colab() {
+        // Free-form role that isn't in the archetype list: we still want
+        // *some* co-lab signal if the session was spawned, so it collapses
+        // to the plain `co-lab` prefix rather than a role-scoped one.
+        assert_eq!(
+            format_window_title("oddjob", Some("mystery-role"), Some("spawned")),
+            "twapp - co-lab - oddjob"
+        );
+    }
+
+    #[test]
+    fn non_archetype_role_with_user_provenance_stays_plain() {
+        // Free-form non-archetype role + user provenance: no co-lab chrome.
+        // This matches the briefing's strict ordering.
+        assert_eq!(
+            format_window_title("oddjob", Some("mystery-role"), Some("user")),
+            "twapp - oddjob"
+        );
+    }
+
+    #[test]
+    fn all_archetypes_produce_role_scoped_prefix() {
+        for archetype in COLAB_ROLE_ARCHETYPES {
+            let title = format_window_title("x", Some(archetype), None);
+            assert_eq!(title, format!("twapp - co-lab:{} - x", archetype));
+        }
+    }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -3362,9 +3362,28 @@ a.file-link {
   color: var(--text-muted);
 }
 
+/* Coordinator tag — deliberately stronger than the neutral CO-LAB chip so
+   the orchestrating session stands out in a fleet. Shares the palette
+   with `launcher-session-coordinator` (subtle card chrome). */
 .launcher-role-coordinator {
-  background: rgba(80, 120, 220, 0.15);
+  background: rgba(80, 120, 220, 0.18);
   color: var(--accent, #4a7de8);
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+/* Neutral co-lab chip — appears on any session with a role or spawned
+   provenance. Kept intentionally quiet so user sessions remain the
+   visual default; coordinator tag takes over when role=coordinator. */
+.launcher-colab-chip {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: rgba(100, 120, 150, 0.12);
+  color: var(--text-muted);
+  text-transform: uppercase;
 }
 
 .launcher-spinner {

--- a/src/components/SessionLauncher.tsx
+++ b/src/components/SessionLauncher.tsx
@@ -9,6 +9,7 @@ import {
   partitionSessions,
   colabGroupBorderColor,
 } from "../utils/sessionSections";
+import { isColabSession } from "../utils/colab";
 import { buildClaimArgs, buildLaunchArgs } from "../utils/coordinator";
 import type {
   LauncherSession,
@@ -1176,6 +1177,7 @@ function SessionLauncher({
 
   const renderSession = (session: LauncherSession, borderOverride?: string) => {
     const isCoordinator = session.role === "coordinator";
+    const isColab = isColabSession(session);
     // Border precedence: explicit override (co-lab group hue) > session color
     // > transparent. Coordinator within a group gets a thicker visual tier via
     // a class — colab-ui-chrome's chip lives on a separate badge in the meta
@@ -1220,9 +1222,24 @@ function SessionLauncher({
           </div>
           <div className="launcher-session-meta">
             <span className="launcher-imported-badge">{session.provider}</span>
+            {isColab && !isCoordinator && (
+              <span
+                className="launcher-colab-chip"
+                title={
+                  session.role
+                    ? `Co-lab session — role: ${session.role}`
+                    : "Co-lab session (spawned by another session)"
+                }
+              >
+                CO-LAB
+              </span>
+            )}
             {isCoordinator && (
-              <span className="launcher-role-badge launcher-role-coordinator" title="Coordinator for this co-lab group">
-                Coordinator
+              <span
+                className="launcher-role-badge launcher-role-coordinator"
+                title="Coordinator for this co-lab group"
+              >
+                COORDINATOR
               </span>
             )}
             {session.forked_from && (

--- a/src/utils/colab.test.ts
+++ b/src/utils/colab.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { isColabSession, isCoordinatorSession, COLAB_ROLE_ARCHETYPES } from "./colab";
+
+describe("isColabSession", () => {
+  it("plain user session with no role and no provenance is not co-lab", () => {
+    expect(isColabSession({ role: null, provenance: null })).toBe(false);
+  });
+
+  it("explicit user provenance with no role is not co-lab", () => {
+    expect(isColabSession({ role: null, provenance: "user" })).toBe(false);
+  });
+
+  it("spawned provenance with no role is co-lab", () => {
+    expect(isColabSession({ role: null, provenance: "spawned" })).toBe(true);
+  });
+
+  it("any non-empty role qualifies as co-lab even when provenance is user", () => {
+    expect(isColabSession({ role: "reviewer", provenance: "user" })).toBe(true);
+    expect(isColabSession({ role: "mystery-role", provenance: "user" })).toBe(true);
+  });
+
+  it("whitespace-only role is treated as unset", () => {
+    expect(isColabSession({ role: "   ", provenance: null })).toBe(false);
+  });
+
+  it("missing fields behave like null", () => {
+    expect(isColabSession({})).toBe(false);
+  });
+});
+
+describe("isCoordinatorSession", () => {
+  it("role=coordinator is coordinator", () => {
+    expect(isCoordinatorSession({ role: "coordinator" })).toBe(true);
+  });
+
+  it("other archetype roles are not coordinator", () => {
+    for (const role of COLAB_ROLE_ARCHETYPES) {
+      if (role === "coordinator") continue;
+      expect(isCoordinatorSession({ role })).toBe(false);
+    }
+  });
+
+  it("null / missing role is not coordinator", () => {
+    expect(isCoordinatorSession({ role: null })).toBe(false);
+  });
+});

--- a/src/utils/colab.ts
+++ b/src/utils/colab.ts
@@ -1,0 +1,45 @@
+import type { LauncherSession } from "../types";
+
+/**
+ * Co-lab role archetypes — sessions with a role in this list get the
+ * richer `co-lab:<role>` window-title prefix (see `gui::title` in
+ * src-tauri). Mirrored here because the frontend also consults `role`
+ * for chip text and tooltips. Kept as a TypeScript literal-union so
+ * callers can narrow on known archetypes at the call site.
+ */
+export const COLAB_ROLE_ARCHETYPES = [
+  "coordinator",
+  "implementer",
+  "reviewer",
+  "auditor",
+  "log-watcher",
+  "architect",
+  "qa",
+  "area-owner",
+  "designer",
+] as const;
+
+export type ColabRoleArchetype = (typeof COLAB_ROLE_ARCHETYPES)[number];
+
+/**
+ * A session qualifies as co-lab when either:
+ *  - it has a non-empty `role` (any value, not just archetypes), OR
+ *  - it was spawned by another session (`provenance === "spawned"`).
+ *
+ * This matches the window-title formatter in `gui::title` and the
+ * briefing's chip rule ("role set OR provenance=spawned"). Plain
+ * user-created sessions return false — the launcher keeps its clean
+ * single-session look for them.
+ */
+export function isColabSession(session: {
+  role?: string | null;
+  provenance?: string | null;
+}): boolean {
+  if (session.role && session.role.trim().length > 0) return true;
+  if (session.provenance === "spawned") return true;
+  return false;
+}
+
+export function isCoordinatorSession(session: Pick<LauncherSession, "role">): boolean {
+  return session.role === "coordinator";
+}


### PR DESCRIPTION
## Summary

Ships the minimum **co-lab-identifying chrome** in the launcher and OS
window title, per briefing `twapp-colab-ui-chrome.md`. Everything
surfaces metadata already landed by #43 (`role` + `provenance`) and #54
(`colab_group`) — no new backend fields.

## Changes

- **Window title formatter** — new `src-tauri/src/gui/title.rs`
  centralizes `format_window_title(name, role, provenance)`:
  - `role` ∈ co-lab archetypes → `twapp - co-lab:<role> - <name>`
  - `provenance == "spawned"` → `twapp - co-lab - <name>`
  - everything else → unchanged `twapp - <name>` (or bare `twapp`)
  Wired in `gui/mod.rs` — the GUI reads `role` + `provenance` from the
  session file's `.twapp-session.json` at startup.
- **Sessions-list chip** — in `SessionLauncher.tsx`, co-lab-qualifying
  rows (role set OR spawned) now render a neutral `CO-LAB` chip in
  `launcher-session-meta`. Coordinator sessions trade the chip for a
  prominent `COORDINATOR` tag in the launcher accent color. Plain user
  sessions unchanged.
- **Helper** — `src/utils/colab.ts` exposes `isColabSession` and the
  archetype list, mirroring `gui::title::COLAB_ROLE_ARCHETYPES`.
- **Docs** — `agent-aware-ui.md` §3.1 / §3.2 flagged "partially
  landed" with pointers here; README's co-lab section grows a
  "Identifying a co-lab session at a glance" subsection.

## Tests

- `cargo test --lib` → 189/189 passing (10 new in `gui::title::tests`,
  one per branch including the full archetype loop and the two
  non-archetype edge cases).
- `npm test` → 127/127 passing (9 new in `src/utils/colab.test.ts`).
- `npx tsc --noEmit` → clean.

## Test plan

- [ ] `cargo test --lib` green
- [ ] `npm test` green
- [ ] Launch a plain user session (`twapp work --name bash`) → window
      title reads `twapp - bash`; launcher row has no CO-LAB chip.
- [ ] Launch a spawned session with no role (e.g. `--from-file`) →
      window title reads `twapp - co-lab - <name>`; launcher row shows
      a neutral `CO-LAB` chip.
- [ ] Launch a session with `role: "coordinator"` → window title reads
      `twapp - co-lab:coordinator - <name>`; launcher row shows the
      `COORDINATOR` tag instead of the neutral chip.
- [ ] Launch a session with `role: "reviewer"` → window title reads
      `twapp - co-lab:reviewer - <name>`; launcher row shows the
      `CO-LAB` chip with the tooltip `Co-lab session — role: reviewer`.

## Out of scope

- The full coordinator dashboard (§3.3 — separate, larger PR).
- Fleet pane / unread counts / urgent queue / spawn timeline.
- Quick-action context menu.
- Any backend metadata additions — `role`, `provenance`, and
  `colab_group` are already enough.

## Coordinate

Parallel with `twapp-readme-colab` (README co-lab section); this PR's
README chunk lives in a **new** subsection (`### Identifying a co-lab
session at a glance`) right after the launcher-sections subsection, so
there's no overlap with that PR's expected rewrite.

Reviewer: `twapp-reviewer`.