### PR TITLE
feat(msg): directory split + read cursors — design PR-3

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,15 +548,17 @@ filesystem mailbox is a simple way to let them leave each other messages
 without leaving twapp.
 
 `twapp msg` is a thin wrapper over that convention: it drops
-fenced-frontmatter markdown files into a shared `inbox/` directory and
-reads them back. See
+fenced-frontmatter markdown files into a shared mailbox and reads them
+back. See
 [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) for
-the full model. Today's CLI covers **PR-1** (scaffolding) and **PR-4**
-(priority lane) of that design — `send`, `broadcast`, and `fetch`
-against the current flat `inbox/` layout, plus urgent-lane symlinks
-under `inbox/urgent/<recipient>/` for time-sensitive traffic.
-Threading, directory split, cursors, presence, channels, and archive
-rotation all land in later PRs.
+the full model. Today's CLI covers **PR-1** (scaffolding), **PR-2**
+(threading), **PR-3** (directory split + read cursors), **PR-4**
+(priority lane), and **PR-7** (archive rotation) of that design. Sends
+land under a per-recipient layout (`inbox/broadcast/`,
+`inbox/direct/<handle>/`, `inbox/channel/<name>/`); every send also
+drops a grace-period symlink at the flat `inbox/<filename>.md` path so
+un-upgraded readers doing `ls inbox/` keep working. Presence and
+first-class channel subscriptions still land in later PRs.
 
 #### Configure the mailbox
 
@@ -570,7 +572,22 @@ export TWAPP_MAILBOX_DIR="$HOME/collab/mailbox"
 export TWAPP_SHARED_DIR="$HOME/collab"
 ```
 
-Messages land in `<mailbox>/inbox/<YYYYMMDDTHHMMSSZ>-<id6>.md`.
+Messages land under the per-recipient split layout (design §2.1):
+
+```
+<mailbox>/inbox/
+  broadcast/<ts>-<id6>.md          # to: [all]
+  direct/<handle>/<ts>-<id6>.md    # to: [<handle>]
+  channel/<name>/<ts>-<id6>.md     # to: [channel:<name>]
+  urgent/<handle-or-all>/…         # priority lane (PR-4)
+  <ts>-<id6>.md                    # grace-period symlink → canonical
+```
+
+A send always writes one canonical file and leaves symlinks for every
+additional recipient, every direct `cc:`, and the legacy flat path.
+`twapp msg migrate` (below) moves any pre-PR-3 flat files into the new
+slots; `migrate --drop-legacy` closes the grace period by removing the
+flat symlinks once every participant is on the new layout.
 
 #### Send, broadcast, fetch
 
@@ -662,8 +679,61 @@ urgents a muted one. Single-session users with no handle see no panel.
 `from:` / `to:` / `re:` layout so inboxes don't need to be migrated
 wholesale — messages missing a frontmatter `id`, `thread`, or `priority`
 get synthetic defaults (routine priority, no thread, id derived from the
-filename). This keeps day-one upgrades unbreaking; directory split and
-layout migration live in later PRs.
+filename). `fetch` also scans both the new split subdirs and anything
+left flat under `inbox/*.md`, deduped by canonical path.
+
+#### Read cursors & ack (PR-3)
+
+Each handle's reads and acks are appended to
+`<mailbox>/cursors/<handle>.jsonl`, one JSON object per line:
+
+```jsonl
+{"ts":"20260420T202957Z","msg_id":"01JS4M7Q8W","action":"read"}
+{"ts":"20260420T203102Z","msg_id":"01JS4M7Q8W","action":"ack","note":"scope accepted"}
+```
+
+- `read` — "I consumed this message" (past `ls`-and-skim).
+- `ack` — "I commit to acting on it." Archiving is neither.
+
+The cursor `ts` is the *message's* frontmatter ts (compact
+`YYYYMMDDTHHMMSSZ`), so it can be passed directly as a `--since` value.
+
+```bash
+# Read the queue AND advance the cursor in one go.
+twapp msg fetch --for reviewer --mark-read
+
+# Default --since picks up strictly after the last `read` entry, so a
+# second call with no flag returns only what arrived since.
+twapp msg fetch --for reviewer
+
+# Explicit --since is still inclusive — pass a known ts to re-surface.
+twapp msg fetch --for reviewer --since 20260420T120000Z
+
+# Commit to action on a specific message.
+twapp msg ack 01JS4M7Q8W --note "rebasing now"
+```
+
+`--mark-read` is opt-in; a plain `fetch` never advances the cursor.
+
+#### Migrating the inbox layout
+
+`twapp msg migrate` rewrites the mailbox from the pre-PR-3 flat layout
+into the split layout. It parses each `inbox/*.md` regular file (fenced
+or bare), moves it under `broadcast/`, `direct/<handle>/`, or
+`channel/<name>/` based on its `to:` field, and leaves a symlink at the
+original flat path so grace-period readers keep working. Idempotent —
+re-running finds nothing to move.
+
+```bash
+# Plan only — prints the moves without touching anything.
+twapp msg migrate --dry-run
+
+# Real run. Leaves grace-period symlinks at inbox/*.md.
+twapp msg migrate
+
+# Once every participant is on the new layout, close the grace period.
+twapp msg migrate --drop-legacy
+```
 
 ### Lane claims — coordinating N workers on a shared queue
 

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -171,8 +171,15 @@ A plain-directory mailbox is the coordination bus. No database, no service — j
 ### Directory shape
 
 ```
-<shared-dir>/mailbox/inbox/
-<shared-dir>/mailbox/archive/
+<shared-dir>/mailbox/
+  inbox/
+    broadcast/<ts>-<id6>.md             # to: [all]
+    direct/<handle>/<ts>-<id6>.md       # to: [<handle>]
+    channel/<name>/<ts>-<id6>.md        # to: [channel:<name>]
+    urgent/<handle-or-all>/…            # priority lane (PR-4)
+    <ts>-<id6>.md                       # grace-period symlink → canonical
+  cursors/<handle>.jsonl                # read + ack log (PR-3, §2.7)
+  archive/<YYYY-MM-DD>/…                # rotated daily (PR-7)
 ```
 
 Pick `<shared-dir>` once at the start of a multi-agent session and put the path in every briefing.
@@ -180,10 +187,12 @@ Pick `<shared-dir>` once at the start of a multi-agent session and put the path 
 ### Filename convention
 
 ```
-YYYYMMDDTHHMMSSZ-<from-handle>-to-<to-handle>.md
+<ts>-<id6>.md                           # where <ts> is YYYYMMDDTHHMMSSZ
 ```
 
-Use `to-all.md` for broadcasts. UTC timestamps keep the directory listing sortable; handles in the name make the inbox greppable and auditable.
+The recipient lives in the subdirectory, not the filename — `direct/<handle>/…` or `broadcast/…`. UTC timestamps keep each slot sortable.
+
+Legacy flat files (`YYYYMMDDTHHMMSSZ-<from>-to-<to>.md`) still parse, and `twapp msg migrate` walks them into the split layout. After running `twapp msg migrate --drop-legacy`, the flat-path compatibility symlinks are gone and every reader must use the split layout or the CLI.
 
 ### Reading
 
@@ -194,10 +203,45 @@ Workers poll `inbox/` every 90-120 seconds from their `/loop`. The coordinator p
 After a worker reads a message addressed to it (or to `all`), it moves the file to `archive/`:
 
 ```
-mv <shared-dir>/mailbox/inbox/<msg>.md <shared-dir>/mailbox/archive/
+# Canonical file lives under the split layout — archive from there.
+mv <shared-dir>/mailbox/inbox/direct/<me>/<msg>.md <shared-dir>/mailbox/archive/
 ```
 
 Messages addressed to *other* agents stay in `inbox/` — never archive on someone else's behalf. The coordinator sweeps stragglers periodically (agents that offboarded without tidying).
+
+### Read cursors (PR-3)
+
+Each handle's reads and acks are appended to `<shared-dir>/mailbox/cursors/<handle>.jsonl` — one JSON object per line, per design §2.7:
+
+```jsonl
+{"ts":"<msg-fm-ts>","msg_id":"<id>","action":"read"}
+{"ts":"<msg-fm-ts>","msg_id":"<id>","action":"ack","note":"optional free text"}
+```
+
+Semantics:
+
+- `read` — "I consumed this message" (past ls-and-skim).
+- `ack` — "I commit to acting on the ask." Archiving is neither.
+- The entry's `ts` is the **message's** fenced-frontmatter ts (compact `YYYYMMDDTHHMMSSZ`), not wall-clock action time — so it's a drop-in `--since` value.
+
+CLI:
+
+```bash
+# Poll + advance the cursor in one go. Without --mark-read, the cursor
+# never advances — a plain fetch is a peek, not a commit.
+twapp msg fetch --for <me> --mark-read
+
+# Default --since (no explicit value) is the max-read ts + strict `>`,
+# so the next fetch returns only what arrived since the last mark-read.
+twapp msg fetch --for <me>
+
+# Explicit --since is still inclusive (≥). Pass a known ts / cursor to
+# re-surface its message (e.g. after a crash).
+twapp msg fetch --for <me> --since 20260420T120000Z
+
+# Commit to action on a specific message; stored alongside the read log.
+twapp msg ack <msg-id> --note "rebasing now"
+```
 
 ### Archive maintenance
 

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -6,6 +6,8 @@ pub mod monitor;
 pub mod msg;
 pub mod msg_archive;
 pub mod msg_claim;
+pub mod msg_cursors;
+pub mod msg_migrate;
 pub mod notes;
 pub mod permissions;
 pub mod prompts;
@@ -529,6 +531,11 @@ pub fn run(cmd: Commands) -> i32 {
                 }
             },
             MsgCommands::Thread { thread_id, format } => msg::cmd_thread(thread_id, format),
+            MsgCommands::Ack { msg_id, from, note } => msg_cursors::cmd_ack(msg_id, from, note),
+            MsgCommands::Migrate {
+                dry_run,
+                drop_legacy,
+            } => msg_migrate::cmd_migrate(dry_run, drop_legacy),
         },
         Commands::Models { command } => match command {
             ModelsCommands::List { provider, format } => models::cmd_list(provider, format),

--- a/src-tauri/src/cli/msg.rs
+++ b/src-tauri/src/cli/msg.rs
@@ -173,13 +173,15 @@ pub enum MsgCommands {
         note: Option<String>,
     },
     /// List messages from the mailbox inbox
-    #[command(after_help = "Examples:\n  twapp msg fetch --for reviewer\n  twapp msg fetch --priority urgent\n  twapp msg fetch --since 20260420T180000Z --limit 10\n  twapp msg fetch --for reviewer --format json")]
+    #[command(after_help = "Examples:\n  twapp msg fetch --for reviewer\n  twapp msg fetch --priority urgent\n  twapp msg fetch --since 20260420T180000Z --limit 10\n  twapp msg fetch --for reviewer --mark-read\n  twapp msg fetch --for reviewer --format json")]
     Fetch {
         /// Handle to filter for. Returns direct messages + broadcasts + cc.
         /// Defaults to the current .twapp-session.json name. Omit to list everything.
         #[arg(long = "for")]
         for_handle: Option<String>,
         /// Return only messages at or after this cursor (ts or filename prefix).
+        /// When omitted, defaults to strictly-after the handle's last `read`
+        /// cursor entry (PR-3, design §2.7).
         #[arg(long)]
         since: Option<String>,
         /// Filter by priority.
@@ -191,7 +193,9 @@ pub enum MsgCommands {
         /// Filter to messages addressed to a specific channel.
         #[arg(long)]
         channel: Option<String>,
-        /// Reserved for PR-3 (cursors). No-op in PR-1.
+        /// Append `action:"read"` cursor entries for each returned message
+        /// into `<mailbox>/cursors/<for>.jsonl`. No-op without --for / a
+        /// session handle to attribute the reads to.
         #[arg(long = "mark-read")]
         mark_read: bool,
         /// Cap the number of messages returned (oldest first).
@@ -203,6 +207,41 @@ pub enum MsgCommands {
         /// Skip session-name lookup for `--for`; list everything.
         #[arg(long)]
         all: bool,
+    },
+    /// Append an `action:"ack"` cursor entry committing the handle to act on
+    /// a message (design §2.7). Use after a `fetch --mark-read` when the
+    /// worker has decided the message's ask is accepted.
+    #[command(after_help = "Examples:\n  twapp msg ack 01JS4M7Q8W\n  twapp msg ack 01JS4M7Q8W --note \"scope accepted, rebasing\"")]
+    Ack {
+        /// Message id to ack.
+        msg_id: String,
+        /// Handle performing the ack. Defaults to the current .twapp-session.json name.
+        #[arg(long)]
+        from: Option<String>,
+        /// Optional free-text note; stored alongside the cursor entry.
+        #[arg(long)]
+        note: Option<String>,
+    },
+    /// One-shot directory-layout migration (design §2.1 + §2.10, PR-3).
+    ///
+    /// Moves every flat `<mailbox>/inbox/*.md` into its canonical slot under
+    /// `broadcast/`, `direct/<handle>/`, or `channel/<name>/` based on the
+    /// file's `to:` field, drops multi-recipient symlinks, and leaves a
+    /// legacy symlink at the original flat path during the grace period.
+    /// Idempotent — re-running finds nothing to move.
+    ///
+    /// `--drop-legacy` closes the grace period: removes every symlink
+    /// directly under `inbox/` (legacy shims for both new writes and
+    /// previously-migrated files).
+    #[command(after_help = "Examples:\n  twapp msg migrate --dry-run\n  twapp msg migrate\n  twapp msg migrate --drop-legacy")]
+    Migrate {
+        /// Report what would change without touching anything.
+        #[arg(long)]
+        dry_run: bool,
+        /// Additionally remove legacy `inbox/*.md` symlinks (the grace-period
+        /// compatibility shim). Safe to re-run; no-op if nothing is left.
+        #[arg(long = "drop-legacy")]
+        drop_legacy: bool,
     },
     /// Archive maintenance: rotate flat messages into `<YYYY-MM-DD>/`, purge
     /// old days, or list counts per day.
@@ -253,6 +292,107 @@ pub fn inbox_dir() -> Result<PathBuf, String> {
 
 pub fn urgent_dir(inbox: &Path) -> PathBuf {
     inbox.join("urgent")
+}
+
+pub fn broadcast_dir(inbox: &Path) -> PathBuf {
+    inbox.join("broadcast")
+}
+
+pub fn direct_dir(inbox: &Path) -> PathBuf {
+    inbox.join("direct")
+}
+
+pub fn channel_dir(inbox: &Path) -> PathBuf {
+    inbox.join("channel")
+}
+
+/// Canonical path where a message addressed to `recipient` should land under
+/// the split layout (design §2.1):
+///
+/// - `"all"` → `inbox/broadcast/<filename>`
+/// - `"channel:<name>"` → `inbox/channel/<name>/<filename>`
+/// - any other (non-empty) handle → `inbox/direct/<handle>/<filename>`
+///
+/// Empty or malformed recipients (trailing `channel:` with no name) yield
+/// None so callers can skip them.
+pub fn recipient_path(inbox: &Path, recipient: &str, filename: &str) -> Option<PathBuf> {
+    let r = recipient.trim();
+    if r.is_empty() {
+        return None;
+    }
+    if r == "all" {
+        return Some(broadcast_dir(inbox).join(filename));
+    }
+    if let Some(ch) = r.strip_prefix("channel:") {
+        let ch = ch.trim();
+        if ch.is_empty() {
+            return None;
+        }
+        return Some(channel_dir(inbox).join(ch).join(filename));
+    }
+    Some(direct_dir(inbox).join(r).join(filename))
+}
+
+/// Build a relative path from `base` to `target`, assuming both share a
+/// common absolute-or-relative prefix (all callers in this module are rooted
+/// under the inbox). Returns `None` only if the two paths have fundamentally
+/// incompatible prefixes (one absolute, one relative with no overlap).
+fn make_relative(target: &Path, base: &Path) -> Option<PathBuf> {
+    use std::path::Component;
+    let t_comps: Vec<Component> = target.components().collect();
+    let b_comps: Vec<Component> = base.components().collect();
+    let mut common = 0usize;
+    while common < t_comps.len()
+        && common < b_comps.len()
+        && t_comps[common] == b_comps[common]
+    {
+        common += 1;
+    }
+    if common == 0 && target.is_absolute() != base.is_absolute() {
+        return None;
+    }
+    let up = b_comps.len() - common;
+    let mut rel = PathBuf::new();
+    for _ in 0..up {
+        rel.push("..");
+    }
+    for comp in &t_comps[common..] {
+        rel.push(comp.as_os_str());
+    }
+    Some(rel)
+}
+
+/// Create a symlink at `link_path` whose target resolves to `canonical`,
+/// expressed relative to `link_path`'s parent. Idempotent — leaves an
+/// existing file/symlink alone. Logs rather than errors on failure, matching
+/// the rest of the messaging layer's "best-effort symlink" convention.
+pub fn symlink_to_canonical(link_path: &Path, canonical: &Path) {
+    if link_path.exists() || link_path.is_symlink() {
+        return;
+    }
+    let Some(parent) = link_path.parent() else {
+        return;
+    };
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        log::debug!("create {} failed: {}", parent.display(), e);
+        return;
+    }
+    let Some(rel) = make_relative(canonical, parent) else {
+        log::debug!(
+            "could not relativize {} against {}",
+            canonical.display(),
+            parent.display()
+        );
+        return;
+    };
+    if let Err(e) = std::os::unix::fs::symlink(&rel, link_path) {
+        log::debug!(
+            "symlink {} -> {}: {}",
+            link_path.display(),
+            rel.display(),
+            e
+        );
+    }
 }
 
 // --- ID / timestamp generation ---------------------------------------------
@@ -402,7 +542,20 @@ pub struct SentMessage {
     pub fm: Frontmatter,
 }
 
-/// Compose + write a message to `<inbox>/<ts>-<id6>.md`.
+/// Compose + write a message under the split layout (design §2.1, PR-3):
+///
+/// - Canonical file lands under the first recipient's slot —
+///   `inbox/broadcast/<filename>`, `inbox/direct/<handle>/<filename>`,
+///   or `inbox/channel/<name>/<filename>`.
+/// - Additional `to:` recipients and every direct `cc:` get a relative
+///   symlink to the canonical file, so a reader scanning only its own
+///   `direct/<self>/` slot still finds multi-recipient traffic.
+/// - A legacy symlink at `inbox/<filename>` points back to the canonical
+///   file for the grace-period shim, so old readers doing `ls inbox/` still
+///   see everything. `twapp msg migrate --drop-legacy` closes the period.
+/// - Urgent / blocker messages additionally hardlink-via-symlink into
+///   `inbox/urgent/<recipient>/` (PR-4 behavior, retargeted at the canonical
+///   under the new layout).
 pub fn write_message(inbox: &Path, args: SendArgs) -> Result<SentMessage, String> {
     if args.to.is_empty() {
         return Err("At least one recipient is required.".to_string());
@@ -416,7 +569,6 @@ pub fn write_message(inbox: &Path, args: SendArgs) -> Result<SentMessage, String
     let ts = current_ts();
     let id6 = id.chars().take(6).collect::<String>();
     let filename = format!("{}-{}.md", ts, id6);
-    let path = inbox.join(&filename);
 
     let fm = Frontmatter {
         id,
@@ -436,20 +588,64 @@ pub fn write_message(inbox: &Path, args: SendArgs) -> Result<SentMessage, String
     content.push_str(body);
     content.push('\n');
 
-    std::fs::write(&path, content).map_err(|e| format!("write {}: {}", path.display(), e))?;
+    // Canonical path = first routable recipient's slot. An all-empty /
+    // malformed recipient list was rejected above, but `recipient_path`
+    // still returns None for individual garbage entries — skip those.
+    let canonical = fm
+        .to
+        .iter()
+        .find_map(|r| recipient_path(inbox, r, &filename))
+        .ok_or_else(|| "No routable recipient (empty handle / bad channel name).".to_string())?;
+    if let Some(parent) = canonical.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+    }
+    std::fs::write(&canonical, &content)
+        .map_err(|e| format!("write {}: {}", canonical.display(), e))?;
 
-    // Priority lane (design §2.5, PR-4): urgent + blocker also get a symlink
-    // under inbox/urgent/<recipient>/<filename> so readers can scan the small
-    // urgent lane without listing the whole inbox. Routine messages are not
-    // linked. Channel recipients are out of scope for PR-4.
-    if matches!(fm.priority, MsgPriority::Urgent | MsgPriority::Blocker) {
-        create_urgent_symlinks(inbox, &filename, &fm.to);
+    // Secondary symlinks: every other `to:` slot that isn't already the
+    // canonical. Multi-recipient direct traffic therefore lands once on
+    // disk and is reachable from each recipient's own direct/<self>/ dir.
+    for recipient in &fm.to {
+        if let Some(p) = recipient_path(inbox, recipient, &filename) {
+            if p != canonical {
+                symlink_to_canonical(&p, &canonical);
+            }
+        }
     }
 
-    Ok(SentMessage { path, fm })
+    // CC recipients are "visible to recipient" (design §2.2) — give each
+    // one a direct/<cc>/ symlink so scoped scans pick them up. Channel and
+    // `all` cc's don't make sense; skip them.
+    for cc in &fm.cc {
+        let c = cc.trim();
+        if c.is_empty() || c == "all" || c.starts_with("channel:") {
+            continue;
+        }
+        let p = direct_dir(inbox).join(c).join(&filename);
+        if p != canonical {
+            symlink_to_canonical(&p, &canonical);
+        }
+    }
+
+    // Legacy symlink at `inbox/<filename>` so `ls inbox/` still lists every
+    // message for un-upgraded readers. PR-3 keeps this on by default;
+    // `twapp msg migrate --drop-legacy` closes the grace period.
+    let legacy = inbox.join(&filename);
+    symlink_to_canonical(&legacy, &canonical);
+
+    // Priority lane (design §2.5, PR-4): urgent + blocker also get a symlink
+    // under inbox/urgent/<recipient>/<filename>. The target is the canonical
+    // file under the new layout (direct/<first>/... or broadcast/...), so
+    // every recipient's urgent link resolves to a single real file.
+    if matches!(fm.priority, MsgPriority::Urgent | MsgPriority::Blocker) {
+        create_urgent_symlinks(inbox, &canonical, &filename, &fm.to);
+    }
+
+    Ok(SentMessage { path: canonical, fm })
 }
 
-fn create_urgent_symlinks(inbox: &Path, filename: &str, to: &[String]) {
+fn create_urgent_symlinks(inbox: &Path, canonical: &Path, filename: &str, to: &[String]) {
     let urgent_root = urgent_dir(inbox);
     for recipient in to {
         // Channel lane lives in PR-6; skip for now.
@@ -460,45 +656,77 @@ fn create_urgent_symlinks(inbox: &Path, filename: &str, to: &[String]) {
         if trimmed.is_empty() {
             continue;
         }
-        let recipient_dir = urgent_root.join(trimmed);
-        if let Err(e) = std::fs::create_dir_all(&recipient_dir) {
-            log::debug!(
-                "create urgent dir {} failed: {}",
-                recipient_dir.display(),
-                e
-            );
-            continue;
-        }
-        let link_path = recipient_dir.join(filename);
-        // Symlinks are idempotent — if one already exists at this path, leave
-        // it alone rather than failing (e.g. two writers racing to the same
-        // id6, which is astronomically unlikely but cheap to tolerate).
-        if link_path.exists() || link_path.is_symlink() {
-            continue;
-        }
-        // Relative target so moving the mailbox tree doesn't break the link.
-        let target = PathBuf::from("../..").join(filename);
-        if let Err(e) = std::os::unix::fs::symlink(&target, &link_path) {
-            log::debug!(
-                "symlink {} -> {} failed: {}",
-                link_path.display(),
-                target.display(),
-                e
-            );
-        }
+        let link_path = urgent_root.join(trimmed).join(filename);
+        symlink_to_canonical(&link_path, canonical);
     }
 }
 
 // --- Reading / parsing -----------------------------------------------------
 
+/// Scan every `.md` in the mailbox inbox under both the split layout
+/// (`broadcast/`, `direct/<handle>/`, `channel/<name>/`) and the flat legacy
+/// layout, deduped by canonical path. Messages are returned sorted by
+/// `(ts, id)` ascending.
+///
+/// The dedup step is what lets legacy symlinks at `inbox/<filename>` and
+/// per-recipient multi-write symlinks coexist with the canonical file
+/// without double-counting.
 pub fn list_messages(inbox: &Path) -> Vec<ParsedMessage> {
     let mut out = Vec::new();
-    let Ok(entries) = std::fs::read_dir(inbox) else {
-        return out;
+    let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
+
+    // New-shape scans.
+    scan_flat_dir_into(&broadcast_dir(inbox), &mut out, &mut seen);
+    scan_subdirs_into(&direct_dir(inbox), &mut out, &mut seen);
+    scan_subdirs_into(&channel_dir(inbox), &mut out, &mut seen);
+
+    // Legacy flat fallback — files directly under inbox/*.md that aren't
+    // already reachable via the new layout (dedup by canonical path).
+    if let Ok(entries) = std::fs::read_dir(inbox) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let meta = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if meta.file_type().is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !name.ends_with(".md") {
+                continue;
+            }
+            let canon = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if !seen.insert(canon) {
+                continue;
+            }
+            if let Some(msg) = parse_message_file(&path) {
+                out.push(msg);
+            }
+        }
+    }
+
+    out.sort_by(|a, b| a.fm.ts.cmp(&b.fm.ts).then_with(|| a.fm.id.cmp(&b.fm.id)));
+    out
+}
+
+fn scan_flat_dir_into(
+    dir: &Path,
+    out: &mut Vec<ParsedMessage>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
     };
     for entry in entries.flatten() {
         let path = entry.path();
-        if !path.is_file() {
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_dir() {
             continue;
         }
         let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
@@ -507,12 +735,30 @@ pub fn list_messages(inbox: &Path) -> Vec<ParsedMessage> {
         if !name.ends_with(".md") {
             continue;
         }
+        let canon = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+        if !seen.insert(canon) {
+            continue;
+        }
         if let Some(msg) = parse_message_file(&path) {
             out.push(msg);
         }
     }
-    out.sort_by(|a, b| a.fm.ts.cmp(&b.fm.ts).then_with(|| a.fm.id.cmp(&b.fm.id)));
-    out
+}
+
+fn scan_subdirs_into(
+    root: &Path,
+    out: &mut Vec<ParsedMessage>,
+    seen: &mut std::collections::HashSet<PathBuf>,
+) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            scan_flat_dir_into(&path, out, seen);
+        }
+    }
 }
 
 /// Scan the urgent-priority lane for a given recipient (or all lanes when
@@ -1079,18 +1325,19 @@ pub fn cmd_fetch(
     priority: Option<MsgPriority>,
     thread: Option<String>,
     channel: Option<String>,
-    _mark_read: bool,
+    mark_read: bool,
     limit: Option<usize>,
     format: FetchFormat,
     all: bool,
 ) -> i32 {
-    let inbox = match inbox_dir() {
+    let mailbox = match resolve_mailbox_dir() {
         Ok(p) => p,
         Err(e) => {
             eprintln!("Error: {}", e);
             return 1;
         }
     };
+    let inbox = mailbox.join("inbox");
 
     let effective_for = if all {
         None
@@ -1110,15 +1357,53 @@ pub fn cmd_fetch(
             })
     };
 
-    let msgs = select_messages(
+    // Resolve --since. Explicit value → use as-is (inclusive, legacy
+    // behavior). Omitted + we know whose reads to default to → use the
+    // handle's last-read cursor position (strictly-after, so we don't
+    // re-return what was already marked read). Omitted + no handle → no
+    // filter.
+    let (since_val, since_exclusive) = match since {
+        Some(s) => (Some(s), false),
+        None => match effective_for.as_deref() {
+            Some(h) => match super::msg_cursors::last_read_ts(&mailbox, h) {
+                Some(ts) => (Some(ts), true),
+                None => (None, false),
+            },
+            None => (None, false),
+        },
+    };
+
+    let mut msgs = select_messages(
         &inbox,
         effective_for.as_deref(),
-        since.as_deref(),
+        since_val.as_deref(),
         priority,
         thread.as_deref(),
         channel.as_deref(),
-        limit,
+        None,
     );
+    if since_exclusive {
+        if let Some(ts) = &since_val {
+            msgs.retain(|m| m.fm.ts.as_str() > ts.as_str());
+        }
+    }
+    if let Some(n) = limit {
+        msgs.truncate(n);
+    }
+
+    // Append read cursors for everything returned, attributed to
+    // `effective_for`. A --mark-read without a handle is silently skipped.
+    if mark_read {
+        if let Some(h) = effective_for.as_deref() {
+            let entries: Vec<super::msg_cursors::CursorEntry> = msgs
+                .iter()
+                .map(|m| super::msg_cursors::CursorEntry::new_read(&m.fm.ts, &m.fm.id))
+                .collect();
+            if let Err(e) = super::msg_cursors::append_entries(&mailbox, h, &entries) {
+                eprintln!("warn: cursor append failed: {}", e);
+            }
+        }
+    }
 
     match format {
         FetchFormat::Json => match serde_json::to_string_pretty(&msgs) {
@@ -2276,8 +2561,425 @@ new\n";
         assert!(thread[1].fm.ts <= thread[2].fm.ts);
     }
 
+    // ---- PR-3: directory split + read cursors ---------------------------
+
     #[test]
-    fn thread_returns_empty_on_unknown_id_without_crash() {
+    fn send_direct_writes_canonical_in_direct_subdir_plus_legacy_symlink() {
+        let g = MailboxGuard::new();
+        let sent = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "hi");
+        let filename = sent.path.file_name().unwrap().to_str().unwrap().to_string();
+
+        // Canonical lives in direct/<recipient>/ and is a regular file.
+        let canonical = g.inbox().join("direct").join("reviewer").join(&filename);
+        assert_eq!(sent.path, canonical);
+        assert!(canonical.is_file());
+        assert!(!canonical.is_symlink());
+
+        // Legacy shim symlink at inbox/<filename> resolves to canonical.
+        let legacy = g.inbox().join(&filename);
+        assert!(legacy.is_symlink(), "expected legacy symlink at {}", legacy.display());
+        assert_eq!(
+            std::fs::canonicalize(&legacy).unwrap(),
+            std::fs::canonicalize(&canonical).unwrap(),
+        );
+    }
+
+    #[test]
+    fn broadcast_writes_canonical_in_broadcast_subdir() {
+        let g = MailboxGuard::new();
+        let sent = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["all".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "standup".to_string(),
+            },
+        )
+        .unwrap();
+        let filename = sent.path.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(sent.path, g.inbox().join("broadcast").join(&filename));
+        assert!(sent.path.is_file());
+        // Legacy symlink also lands.
+        assert!(g.inbox().join(&filename).is_symlink());
+    }
+
+    #[test]
+    fn channel_send_writes_canonical_in_channel_subdir() {
+        let g = MailboxGuard::new();
+        let sent = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["channel:reviewers-standby".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "any reviewer free?".to_string(),
+            },
+        )
+        .unwrap();
+        let filename = sent.path.file_name().unwrap().to_str().unwrap().to_string();
+        assert_eq!(
+            sent.path,
+            g.inbox()
+                .join("channel")
+                .join("reviewers-standby")
+                .join(&filename)
+        );
+        assert!(sent.path.is_file());
+    }
+
+    #[test]
+    fn multi_recipient_direct_lands_one_entry_per_recipient_all_resolving_to_canonical() {
+        let g = MailboxGuard::new();
+        let sent = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string(), "qa".to_string(), "coordinator".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "multi".to_string(),
+            },
+        )
+        .unwrap();
+        let filename = sent.path.file_name().unwrap().to_str().unwrap().to_string();
+        // Canonical = first recipient.
+        assert_eq!(sent.path, g.inbox().join("direct/reviewer").join(&filename));
+        // Every recipient has an entry reachable via direct/<self>/.
+        for recipient in ["reviewer", "qa", "coordinator"] {
+            let p = g.inbox().join("direct").join(recipient).join(&filename);
+            assert!(p.exists(), "missing entry for {} at {}", recipient, p.display());
+            let resolved = std::fs::canonicalize(&p).unwrap();
+            assert_eq!(resolved, std::fs::canonicalize(&sent.path).unwrap());
+        }
+    }
+
+    #[test]
+    fn cc_recipient_gets_direct_symlink() {
+        let g = MailboxGuard::new();
+        let sent = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: vec!["coordinator".to_string(), "qa".to_string()],
+                body: "see PR".to_string(),
+            },
+        )
+        .unwrap();
+        let filename = sent.path.file_name().unwrap().to_str().unwrap().to_string();
+        for cc in ["coordinator", "qa"] {
+            let p = g.inbox().join("direct").join(cc).join(&filename);
+            assert!(p.is_symlink(), "expected cc symlink for {} at {}", cc, p.display());
+            let resolved = std::fs::canonicalize(&p).unwrap();
+            assert_eq!(resolved, std::fs::canonicalize(&sent.path).unwrap());
+        }
+    }
+
+    #[test]
+    fn list_messages_sees_split_layout_and_flat_legacy_without_duplicates() {
+        let g = MailboxGuard::new();
+        // Three new-shape sends (broadcast, direct, channel).
+        let sent_bcast = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["all".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "b".to_string(),
+            },
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let sent_dir = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "d".to_string(),
+            },
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let sent_ch = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["channel:reviewers-standby".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "c".to_string(),
+            },
+        )
+        .unwrap();
+        // A raw flat-legacy file that predates PR-3 (no symlink, real file).
+        let bare = "from: qa\nto: reviewer\nre: legacy\n\nold body\n";
+        let legacy_path = g.inbox().join("20260418T000000Z-qa-to-reviewer.md");
+        write_raw(&legacy_path, bare);
+
+        let msgs = list_messages(&g.inbox());
+        // Exactly 4 (dedup: each new-shape send has a legacy symlink shim
+        // that must not double-count).
+        assert_eq!(msgs.len(), 4, "ids: {:?}", msgs.iter().map(|m| &m.fm.id).collect::<Vec<_>>());
+        let ids: Vec<String> = msgs.iter().map(|m| m.fm.id.clone()).collect();
+        for expected in [&sent_bcast.fm.id, &sent_dir.fm.id, &sent_ch.fm.id] {
+            assert!(ids.contains(expected), "missing {}", expected);
+        }
+        assert!(msgs.iter().any(|m| m.legacy && m.body.trim() == "old body"));
+    }
+
+    #[test]
+    fn fetch_since_on_legacy_flat_message_filters_correctly() {
+        // --since still narrows based on ts, including when the mailbox only
+        // contains flat-layout legacy files.
+        let g = MailboxGuard::new();
+        let older = "---\n\
+id: AAAA000000000000000000AAAA\n\
+from: a\n\
+to: [reviewer]\n\
+priority: routine\n\
+ts: 20260419T000000Z\n\
+---\n\n\
+old\n";
+        let newer = "---\n\
+id: BBBB000000000000000000BBBB\n\
+from: a\n\
+to: [reviewer]\n\
+priority: routine\n\
+ts: 20260420T120000Z\n\
+---\n\n\
+new\n";
+        write_raw(&g.inbox().join("20260419T000000Z-AAAAAA.md"), older);
+        write_raw(&g.inbox().join("20260420T120000Z-BBBBBB.md"), newer);
+
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            Some("20260420T000000Z"),
+            None,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].fm.ts, "20260420T120000Z");
+    }
+
+    #[test]
+    fn legacy_symlink_is_not_double_counted_even_when_dangling() {
+        // If the canonical file is deleted mid-flight, the legacy symlink
+        // still lists but parses to None — list_messages must not crash
+        // and must not return a stale ParsedMessage.
+        let g = MailboxGuard::new();
+        let sent = send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "drop me");
+        std::fs::remove_file(&sent.path).unwrap();
+
+        let msgs = list_messages(&g.inbox());
+        assert!(msgs.is_empty(), "got {:?}", msgs.iter().map(|m| &m.fm.id).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn multi_recipient_send_does_not_duplicate_in_list() {
+        let g = MailboxGuard::new();
+        write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string(), "qa".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "one".to_string(),
+            },
+        )
+        .unwrap();
+        let msgs = list_messages(&g.inbox());
+        assert_eq!(msgs.len(), 1, "multi-recipient should dedupe to one");
+    }
+
+    #[test]
+    fn fetch_mark_read_appends_cursor_read_entries_for_each_returned_message() {
+        let g = MailboxGuard::new();
+        // Three direct messages to reviewer.
+        for i in 0..3 {
+            write_message(
+                &g.inbox(),
+                SendArgs {
+                    to: vec!["reviewer".to_string()],
+                    from: "implementer-a".to_string(),
+                    priority: MsgPriority::Routine,
+                    subject: Some(format!("m{}", i)),
+                    thread: None,
+                    in_reply_to: None,
+                    cc: Vec::new(),
+                    body: format!("body-{}", i),
+                },
+            )
+            .unwrap();
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+        }
+        // Call cmd_fetch through the real CLI entry point so --mark-read
+        // wires through end-to-end.
+        let code = cmd_fetch(
+            Some("reviewer".to_string()),
+            None,
+            None,
+            None,
+            None,
+            true,
+            None,
+            FetchFormat::Json,
+            false,
+        );
+        assert_eq!(code, 0);
+
+        let entries = crate::cli::msg_cursors::read_entries(&g.root, "reviewer");
+        assert_eq!(entries.len(), 3, "got: {:?}", entries);
+        assert!(entries.iter().all(|e| e.action == "read"));
+        // All three ts values are present.
+        let ts_set: std::collections::HashSet<_> =
+            entries.iter().map(|e| e.ts.clone()).collect();
+        assert_eq!(ts_set.len(), 3);
+    }
+
+    #[test]
+    fn fetch_default_since_picks_up_where_last_read_left_off() {
+        let g = MailboxGuard::new();
+        // One "old" message — mark it read manually so the cursor advances.
+        let old = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: Some("old".to_string()),
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "old".to_string(),
+            },
+        )
+        .unwrap();
+        crate::cli::msg_cursors::append_entries(
+            &g.root,
+            "reviewer",
+            &[crate::cli::msg_cursors::CursorEntry::new_read(
+                &old.fm.ts,
+                &old.fm.id,
+            )],
+        )
+        .unwrap();
+
+        // A new message that arrived later.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let fresh = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "implementer-a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: Some("fresh".to_string()),
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "fresh".to_string(),
+            },
+        )
+        .unwrap();
+
+        // Default --since (no explicit value) must skip `old` and return `fresh`.
+        let since_val: Option<String> =
+            crate::cli::msg_cursors::last_read_ts(&g.root, "reviewer");
+        let since_exclusive = true;
+        assert_eq!(since_val.as_deref(), Some(old.fm.ts.as_str()));
+        let mut msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer"),
+            since_val.as_deref(),
+            None,
+            None,
+            None,
+            None,
+        );
+        if since_exclusive {
+            if let Some(ts) = &since_val {
+                msgs.retain(|m| m.fm.ts.as_str() > ts.as_str());
+            }
+        }
+        assert_eq!(msgs.len(), 1, "default --since should skip already-read");
+        assert_eq!(msgs[0].fm.id, fresh.fm.id);
+    }
+
+    #[test]
+    fn explicit_since_stays_inclusive_and_does_not_consume_cursor() {
+        // When the user passes --since X explicitly, it's inclusive (≥) so
+        // passing a known cursor ts re-surfaces that message. The fetch
+        // also must NOT advance the handle's cursor (--mark-read is
+        // opt-in).
+        let g = MailboxGuard::new();
+        let sent = write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "a".to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "x".to_string(),
+            },
+        )
+        .unwrap();
+
+        let code = cmd_fetch(
+            Some("reviewer".to_string()),
+            Some(sent.fm.ts.clone()),
+            None,
+            None,
+            None,
+            false, // no --mark-read
+            None,
+            FetchFormat::Json,
+            false,
+        );
+        assert_eq!(code, 0);
+        // Cursor file should not exist yet.
+        let cursor = crate::cli::msg_cursors::cursor_file(&g.root, "reviewer");
+        assert!(!cursor.exists(), "cursor file unexpectedly created");
+    }
+
+    #[test]
+    fn thread_returns_empty_on_unknown_id_without_crash_pr3() {
         let g = MailboxGuard::new();
         send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "hi");
         let thread = list_thread(&g.inbox(), "NOSUCHTHREADID");

--- a/src-tauri/src/cli/msg_claim.rs
+++ b/src-tauri/src/cli/msg_claim.rs
@@ -1009,9 +1009,14 @@ mod tests {
         );
         assert_eq!(exit, 0);
 
-        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
-        assert_eq!(entries.len(), 1, "expected 1 broadcast");
-        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        // The broadcast lands in inbox/broadcast/<filename>.md under the
+        // PR-3 split layout, with a grace-period symlink at inbox/<filename>.
+        let bcast_entries: Vec<_> = std::fs::read_dir(g.inbox().join("broadcast"))
+            .unwrap()
+            .flatten()
+            .collect();
+        assert_eq!(bcast_entries.len(), 1, "expected 1 broadcast");
+        let parsed = parse_message_file(&bcast_entries[0].path()).unwrap();
         assert_eq!(parsed.fm.from, "reviewer-a");
         assert_eq!(parsed.fm.to, vec!["all"]);
         assert_eq!(
@@ -1033,11 +1038,15 @@ mod tests {
             Some("shipped".to_string()),
         );
         assert_eq!(exit, 0);
-        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
-        // The cmd_release path emits exactly one broadcast; claims done
-        // via try_claim skip the broadcast.
-        assert_eq!(entries.len(), 1, "expected 1 broadcast");
-        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        // PR-3 split layout: broadcasts live under inbox/broadcast/.
+        // cmd_release emits exactly one broadcast; claims done via
+        // try_claim skip the broadcast.
+        let bcast_entries: Vec<_> = std::fs::read_dir(g.inbox().join("broadcast"))
+            .unwrap()
+            .flatten()
+            .collect();
+        assert_eq!(bcast_entries.len(), 1, "expected 1 broadcast");
+        let parsed = parse_message_file(&bcast_entries[0].path()).unwrap();
         assert_eq!(parsed.fm.subject.as_deref(), Some("release lane PR-91"));
         assert!(parsed.body.contains("released PR-91"));
     }
@@ -1069,9 +1078,12 @@ mod tests {
             FetchFormat::Pretty,
         );
         assert_eq!(exit, 0);
-        let entries: Vec<_> = std::fs::read_dir(g.inbox()).unwrap().flatten().collect();
-        assert_eq!(entries.len(), 1);
-        let parsed = parse_message_file(&entries[0].path()).unwrap();
+        let bcast_entries: Vec<_> = std::fs::read_dir(g.inbox().join("broadcast"))
+            .unwrap()
+            .flatten()
+            .collect();
+        assert_eq!(bcast_entries.len(), 1);
+        let parsed = parse_message_file(&bcast_entries[0].path()).unwrap();
         assert_eq!(parsed.fm.subject.as_deref(), Some("reclaim lane lane-z"));
         assert!(parsed.body.contains("reclaimed lane-z from stale owner ghost"));
     }

--- a/src-tauri/src/cli/msg_cursors.rs
+++ b/src-tauri/src/cli/msg_cursors.rs
@@ -1,0 +1,372 @@
+//! `<mailbox>/cursors/<handle>.jsonl` — append-only per-handle read/ack log.
+//!
+//! PR-3 of the design in `docs/designs/agent-messaging.md` (§2.7). One line per
+//! action, either `"read"` (the worker consumed the message past ls-and-skim)
+//! or `"ack"` (the worker commits to acting on it). Archiving is neither.
+//!
+//! The entry's `ts` is the *message's* fenced-frontmatter `ts` (compact
+//! `YYYYMMDDTHHMMSSZ`) — not wall-clock action time. That lets `msg fetch`
+//! use it directly as a `--since` comparator when defaulting to the last
+//! read position.
+
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use super::msg::resolve_mailbox_dir;
+
+/// Path to the cursors directory inside a mailbox.
+pub fn cursors_dir(mailbox: &Path) -> PathBuf {
+    mailbox.join("cursors")
+}
+
+/// Path to a handle's cursor log file.
+pub fn cursor_file(mailbox: &Path, handle: &str) -> PathBuf {
+    cursors_dir(mailbox).join(format!("{}.jsonl", handle))
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CursorEntry {
+    /// Message's fm.ts (compact `YYYYMMDDTHHMMSSZ`).
+    pub ts: String,
+    pub msg_id: String,
+    /// `"read"` or `"ack"`.
+    pub action: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+impl CursorEntry {
+    pub fn new_read(msg_ts: &str, msg_id: &str) -> Self {
+        Self {
+            ts: msg_ts.to_string(),
+            msg_id: msg_id.to_string(),
+            action: "read".to_string(),
+            note: None,
+        }
+    }
+
+    pub fn new_ack(msg_ts: &str, msg_id: &str, note: Option<String>) -> Self {
+        Self {
+            ts: msg_ts.to_string(),
+            msg_id: msg_id.to_string(),
+            action: "ack".to_string(),
+            note,
+        }
+    }
+}
+
+/// Append cursor entries for a handle. Creates `cursors/` if missing. No-op
+/// when `entries` is empty.
+pub fn append_entries(
+    mailbox: &Path,
+    handle: &str,
+    entries: &[CursorEntry],
+) -> Result<(), String> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+    let dir = cursors_dir(mailbox);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| format!("create cursors dir {}: {}", dir.display(), e))?;
+    let file = cursor_file(mailbox, handle);
+    let mut f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&file)
+        .map_err(|e| format!("open {}: {}", file.display(), e))?;
+    for entry in entries {
+        let line = serde_json::to_string(entry)
+            .map_err(|e| format!("serialize cursor entry: {}", e))?;
+        writeln!(f, "{}", line)
+            .map_err(|e| format!("append {}: {}", file.display(), e))?;
+    }
+    Ok(())
+}
+
+/// Read all cursor entries for a handle in file order (oldest first).
+/// Missing file → empty vec.
+pub fn read_entries(mailbox: &Path, handle: &str) -> Vec<CursorEntry> {
+    let file = cursor_file(mailbox, handle);
+    let Ok(content) = std::fs::read_to_string(&file) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Ok(entry) = serde_json::from_str::<CursorEntry>(line) {
+            out.push(entry);
+        }
+    }
+    out
+}
+
+/// Return the highest message-ts that this handle has a `read` cursor for,
+/// or None if the log is empty / missing.
+pub fn last_read_ts(mailbox: &Path, handle: &str) -> Option<String> {
+    let entries = read_entries(mailbox, handle);
+    entries
+        .into_iter()
+        .filter(|e| e.action == "read")
+        .map(|e| e.ts)
+        .filter(|ts| !ts.is_empty())
+        .max()
+}
+
+/// `twapp msg ack <msg-id> [--note <s>]` entry point.
+pub fn cmd_ack(msg_id: String, from: Option<String>, note: Option<String>) -> i32 {
+    let mailbox = match resolve_mailbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let handle = match super::msg::resolve_from(from.as_deref()) {
+        Ok(h) => h,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let inbox = mailbox.join("inbox");
+    let fm = match super::msg::find_by_id(&inbox, &msg_id) {
+        Some(fm) => fm,
+        None => {
+            eprintln!(
+                "Error: msg id {} not found in {}",
+                msg_id,
+                inbox.display()
+            );
+            return 1;
+        }
+    };
+    let entry = CursorEntry::new_ack(&fm.ts, &fm.id, note.clone());
+    if let Err(e) = append_entries(&mailbox, &handle, &[entry]) {
+        eprintln!("Error: {}", e);
+        return 1;
+    }
+    match note {
+        Some(n) => println!("Acked {} ({}) for {} — {}", fm.id, fm.ts, handle, n),
+        None => println!("Acked {} ({}) for {}", fm.id, fm.ts, handle),
+    }
+    0
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    struct Guard {
+        root: PathBuf,
+        prev_mailbox: Option<String>,
+        prev_shared: Option<String>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl Guard {
+        fn new() -> Self {
+            let _guard = env_lock();
+            let root = std::env::temp_dir().join(format!(
+                "twapp-cursor-test-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(&root).unwrap();
+            let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
+            let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
+            std::env::set_var("TWAPP_MAILBOX_DIR", &root);
+            std::env::remove_var("TWAPP_SHARED_DIR");
+            Guard {
+                root,
+                prev_mailbox,
+                prev_shared,
+                _guard,
+            }
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            match &self.prev_mailbox {
+                Some(v) => std::env::set_var("TWAPP_MAILBOX_DIR", v),
+                None => std::env::remove_var("TWAPP_MAILBOX_DIR"),
+            }
+            match &self.prev_shared {
+                Some(v) => std::env::set_var("TWAPP_SHARED_DIR", v),
+                None => std::env::remove_var("TWAPP_SHARED_DIR"),
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    #[test]
+    fn append_creates_dir_and_file() {
+        let g = Guard::new();
+        append_entries(
+            &g.root,
+            "worker-a",
+            &[CursorEntry::new_read("20260420T120000Z", "AAAA")],
+        )
+        .unwrap();
+        let file = cursor_file(&g.root, "worker-a");
+        assert!(file.exists());
+        let content = std::fs::read_to_string(&file).unwrap();
+        assert!(content.contains("\"ts\":\"20260420T120000Z\""));
+        assert!(content.contains("\"msg_id\":\"AAAA\""));
+        assert!(content.contains("\"action\":\"read\""));
+    }
+
+    #[test]
+    fn append_is_append_only() {
+        let g = Guard::new();
+        append_entries(
+            &g.root,
+            "worker-a",
+            &[CursorEntry::new_read("20260420T120000Z", "A")],
+        )
+        .unwrap();
+        append_entries(
+            &g.root,
+            "worker-a",
+            &[CursorEntry::new_ack(
+                "20260420T120000Z",
+                "A",
+                Some("scope accepted".to_string()),
+            )],
+        )
+        .unwrap();
+
+        let entries = read_entries(&g.root, "worker-a");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].action, "read");
+        assert_eq!(entries[1].action, "ack");
+        assert_eq!(entries[1].note.as_deref(), Some("scope accepted"));
+    }
+
+    #[test]
+    fn ack_serialization_has_note_only_when_present() {
+        let with_note = serde_json::to_string(&CursorEntry::new_ack(
+            "20260420T120000Z",
+            "A",
+            Some("ok".to_string()),
+        ))
+        .unwrap();
+        assert!(with_note.contains("\"note\":\"ok\""));
+
+        let without_note =
+            serde_json::to_string(&CursorEntry::new_ack("20260420T120000Z", "A", None)).unwrap();
+        assert!(
+            !without_note.contains("note"),
+            "expected no note field: {}",
+            without_note
+        );
+    }
+
+    #[test]
+    fn last_read_ts_picks_max() {
+        let g = Guard::new();
+        append_entries(
+            &g.root,
+            "worker-a",
+            &[
+                CursorEntry::new_read("20260420T120000Z", "A"),
+                CursorEntry::new_read("20260420T110000Z", "B"),
+                CursorEntry::new_ack("20260420T130000Z", "A", None),
+            ],
+        )
+        .unwrap();
+        // Max across only `read` entries — ack's 13:00 is ignored.
+        assert_eq!(
+            last_read_ts(&g.root, "worker-a"),
+            Some("20260420T120000Z".to_string())
+        );
+    }
+
+    #[test]
+    fn last_read_ts_empty_log_returns_none() {
+        let g = Guard::new();
+        assert_eq!(last_read_ts(&g.root, "nobody"), None);
+    }
+
+    #[test]
+    fn cmd_ack_writes_ack_entry_for_existing_message() {
+        use super::super::msg::{write_message, MsgPriority, SendArgs};
+        let g = Guard::new();
+        std::fs::create_dir_all(g.root.join("inbox")).unwrap();
+        let sent = write_message(
+            &g.root.join("inbox"),
+            SendArgs {
+                to: vec!["reviewer".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Routine,
+                subject: Some("scope".to_string()),
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "please ack".to_string(),
+            },
+        )
+        .unwrap();
+
+        let code = cmd_ack(
+            sent.fm.id.clone(),
+            Some("reviewer".to_string()),
+            Some("will do".to_string()),
+        );
+        assert_eq!(code, 0);
+
+        let entries = read_entries(&g.root, "reviewer");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].action, "ack");
+        assert_eq!(entries[0].msg_id, sent.fm.id);
+        assert_eq!(entries[0].ts, sent.fm.ts);
+        assert_eq!(entries[0].note.as_deref(), Some("will do"));
+    }
+
+    #[test]
+    fn cmd_ack_rejects_missing_message_with_nonzero_exit() {
+        let g = Guard::new();
+        std::fs::create_dir_all(g.root.join("inbox")).unwrap();
+        let code = cmd_ack(
+            "NOSUCHIDXXXXXXXX".to_string(),
+            Some("reviewer".to_string()),
+            None,
+        );
+        assert_ne!(code, 0);
+        let entries = read_entries(&g.root, "reviewer");
+        assert!(entries.is_empty(), "no cursor entry when msg unknown");
+    }
+
+    #[test]
+    fn read_entries_tolerates_blank_lines_and_garbage() {
+        let g = Guard::new();
+        let file = cursor_file(&g.root, "worker-a");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::write(
+            &file,
+            "\n\
+             {\"ts\":\"20260420T120000Z\",\"msg_id\":\"A\",\"action\":\"read\"}\n\
+             not json at all\n\
+             \n\
+             {\"ts\":\"20260420T130000Z\",\"msg_id\":\"B\",\"action\":\"ack\"}\n",
+        )
+        .unwrap();
+        let entries = read_entries(&g.root, "worker-a");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].msg_id, "A");
+        assert_eq!(entries[1].msg_id, "B");
+    }
+}

--- a/src-tauri/src/cli/msg_migrate.rs
+++ b/src-tauri/src/cli/msg_migrate.rs
@@ -1,0 +1,500 @@
+//! `twapp msg migrate` — one-shot inbox-layout migration (design §2.1 + §2.10,
+//! PR-3). Moves each legacy flat `<mailbox>/inbox/*.md` into the split layout
+//! (`broadcast/`, `direct/<handle>/`, `channel/<name>/`) based on the file's
+//! `to:` field and leaves a legacy symlink at the original flat path so
+//! old readers keep working during the grace period.
+//!
+//! Idempotent: after the first successful run, every flat `inbox/*.md` is
+//! a legacy symlink (or is gone entirely with `--drop-legacy`), so re-runs
+//! find nothing to move.
+
+use std::path::{Path, PathBuf};
+
+use super::msg::{
+    direct_dir, inbox_dir, parse_message_file, recipient_path, symlink_to_canonical,
+};
+
+/// One planned/executed file move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MigrateMove {
+    pub from: PathBuf,
+    pub to: PathBuf,
+    pub extra_links: Vec<PathBuf>,
+    pub recipients: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MigrateReport {
+    pub moves: Vec<MigrateMove>,
+    pub dropped_legacy: Vec<PathBuf>,
+    pub skipped_unknown_to: Vec<PathBuf>,
+}
+
+/// Plan and (unless `dry_run`) execute a migration from the flat inbox
+/// layout into the split layout. If `drop_legacy` is true, *also* delete
+/// every legacy symlink directly under `inbox/`.
+pub fn migrate(
+    inbox: &Path,
+    dry_run: bool,
+    drop_legacy: bool,
+) -> Result<MigrateReport, String> {
+    let mut report = MigrateReport::default();
+    let Ok(entries) = std::fs::read_dir(inbox) else {
+        return Ok(report);
+    };
+
+    // Collect up front: std::fs::rename during the walk can confuse some
+    // readdir impls on macOS.
+    let mut files: Vec<(PathBuf, bool)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let meta = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        if meta.file_type().is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.ends_with(".md") {
+            continue;
+        }
+        let is_symlink = meta.file_type().is_symlink();
+        files.push((path, is_symlink));
+    }
+
+    for (path, is_symlink) in files {
+        if is_symlink {
+            if drop_legacy {
+                if !dry_run {
+                    if let Err(e) = std::fs::remove_file(&path) {
+                        return Err(format!("remove {}: {}", path.display(), e));
+                    }
+                }
+                report.dropped_legacy.push(path);
+            }
+            continue;
+        }
+
+        let Some(name) = path.file_name().and_then(|n| n.to_str()).map(str::to_string)
+        else {
+            continue;
+        };
+
+        // Parse frontmatter to recover the `to:` list. Bare legacy files get
+        // their headers extracted by the same parser.
+        let Some(msg) = parse_message_file(&path) else {
+            report.skipped_unknown_to.push(path);
+            continue;
+        };
+        if msg.fm.to.is_empty() {
+            report.skipped_unknown_to.push(path);
+            continue;
+        }
+
+        // Pick canonical target = first recipient whose slot maps cleanly.
+        let Some(canonical) =
+            msg.fm.to.iter().find_map(|r| recipient_path(inbox, r, &name))
+        else {
+            report.skipped_unknown_to.push(path);
+            continue;
+        };
+
+        // Build secondary-link list: every other `to:` slot + every direct
+        // `cc:` recipient.
+        let mut extra = Vec::new();
+        let push_once = |v: &mut Vec<PathBuf>, p: PathBuf| {
+            if p != canonical && !v.contains(&p) {
+                v.push(p);
+            }
+        };
+        for r in &msg.fm.to {
+            if let Some(p) = recipient_path(inbox, r, &name) {
+                push_once(&mut extra, p);
+            }
+        }
+        for cc in &msg.fm.cc {
+            let c = cc.trim();
+            if c.is_empty() || c == "all" || c.starts_with("channel:") {
+                continue;
+            }
+            let p = direct_dir(inbox).join(c).join(&name);
+            push_once(&mut extra, p);
+        }
+
+        if !dry_run {
+            if let Some(parent) = canonical.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("create {}: {}", parent.display(), e))?;
+            }
+            std::fs::rename(&path, &canonical).map_err(|e| {
+                format!(
+                    "rename {} -> {}: {}",
+                    path.display(),
+                    canonical.display(),
+                    e
+                )
+            })?;
+            for link in &extra {
+                symlink_to_canonical(link, &canonical);
+            }
+            // Only lay down a grace-period symlink when we're NOT simultaneously
+            // dropping legacy symlinks. `migrate --drop-legacy` is the
+            // "close the period" move; creating a new shim at the same
+            // moment would defeat it.
+            if !drop_legacy {
+                symlink_to_canonical(&path, &canonical);
+            }
+        }
+
+        report.moves.push(MigrateMove {
+            from: path,
+            to: canonical,
+            extra_links: extra,
+            recipients: msg.fm.to.clone(),
+        });
+    }
+
+    Ok(report)
+}
+
+pub fn cmd_migrate(dry_run: bool, drop_legacy: bool) -> i32 {
+    let inbox = match inbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let report = match migrate(&inbox, dry_run, drop_legacy) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+
+    let noun = if dry_run { "would move" } else { "moved" };
+    let dropped_noun = if dry_run { "would drop" } else { "dropped" };
+
+    if report.moves.is_empty()
+        && report.dropped_legacy.is_empty()
+        && report.skipped_unknown_to.is_empty()
+    {
+        println!("No legacy files to migrate in {}.", inbox.display());
+        return 0;
+    }
+
+    for m in &report.moves {
+        println!(
+            "{}: {} -> {}",
+            noun,
+            m.from.display(),
+            m.to.display()
+        );
+        for link in &m.extra_links {
+            println!("    +link {}", link.display());
+        }
+    }
+    for d in &report.dropped_legacy {
+        println!("{}: {}", dropped_noun, d.display());
+    }
+    for s in &report.skipped_unknown_to {
+        println!("skipped (no routable `to:` field): {}", s.display());
+    }
+
+    0
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+
+    struct Guard {
+        root: PathBuf,
+        prev_mailbox: Option<String>,
+        prev_shared: Option<String>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl Guard {
+        fn new() -> Self {
+            let _guard = env_lock();
+            let root = std::env::temp_dir().join(format!(
+                "twapp-migrate-test-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(root.join("inbox")).unwrap();
+            let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
+            let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
+            std::env::set_var("TWAPP_MAILBOX_DIR", &root);
+            std::env::remove_var("TWAPP_SHARED_DIR");
+            Guard {
+                root,
+                prev_mailbox,
+                prev_shared,
+                _guard,
+            }
+        }
+        fn inbox(&self) -> PathBuf {
+            self.root.join("inbox")
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            match &self.prev_mailbox {
+                Some(v) => std::env::set_var("TWAPP_MAILBOX_DIR", v),
+                None => std::env::remove_var("TWAPP_MAILBOX_DIR"),
+            }
+            match &self.prev_shared {
+                Some(v) => std::env::set_var("TWAPP_SHARED_DIR", v),
+                None => std::env::remove_var("TWAPP_SHARED_DIR"),
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn write_raw(path: &Path, content: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn write_fenced(
+        inbox: &Path,
+        filename: &str,
+        to: &[&str],
+        cc: &[&str],
+        ts: &str,
+    ) -> PathBuf {
+        let cc_line = if cc.is_empty() {
+            String::new()
+        } else {
+            format!("cc: [{}]\n", cc.join(", "))
+        };
+        let content = format!(
+            "---\n\
+             id: MIGRATE{:0>13}\n\
+             from: coordinator\n\
+             to: [{}]\n\
+             {}priority: routine\n\
+             ts: {}\n\
+             ---\n\n\
+             body for {}\n",
+            filename,
+            to.join(", "),
+            cc_line,
+            ts,
+            filename,
+        );
+        let path = inbox.join(filename);
+        write_raw(&path, &content);
+        path
+    }
+
+    #[test]
+    fn migrate_moves_flat_direct_to_direct_subdir_and_leaves_legacy_symlink() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        let flat = write_fenced(
+            &inbox,
+            "20260419T120000Z-AAAAAA.md",
+            &["reviewer"],
+            &[],
+            "20260419T120000Z",
+        );
+
+        let report = migrate(&inbox, false, false).unwrap();
+        assert_eq!(report.moves.len(), 1, "one move expected");
+        let m = &report.moves[0];
+        assert_eq!(m.from, flat);
+        assert_eq!(m.to, inbox.join("direct/reviewer/20260419T120000Z-AAAAAA.md"));
+
+        assert!(m.to.is_file());
+        // Legacy shim at the original path now points at the canonical.
+        assert!(flat.is_symlink());
+        let resolved = std::fs::canonicalize(&flat).unwrap();
+        let canon = std::fs::canonicalize(&m.to).unwrap();
+        assert_eq!(resolved, canon);
+    }
+
+    #[test]
+    fn migrate_broadcast_and_channel() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        write_fenced(
+            &inbox,
+            "20260419T120000Z-BROADCST.md",
+            &["all"],
+            &[],
+            "20260419T120000Z",
+        );
+        write_fenced(
+            &inbox,
+            "20260419T120005Z-CHANNEL.md",
+            &["channel:reviewers-standby"],
+            &[],
+            "20260419T120005Z",
+        );
+
+        let report = migrate(&inbox, false, false).unwrap();
+        assert_eq!(report.moves.len(), 2);
+        assert!(inbox.join("broadcast/20260419T120000Z-BROADCST.md").is_file());
+        assert!(
+            inbox
+                .join("channel/reviewers-standby/20260419T120005Z-CHANNEL.md")
+                .is_file()
+        );
+    }
+
+    #[test]
+    fn migrate_multi_recipient_creates_extra_symlinks() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        write_fenced(
+            &inbox,
+            "20260419T120010Z-MULTI.md",
+            &["reviewer", "qa", "coordinator"],
+            &["planner"],
+            "20260419T120010Z",
+        );
+
+        let report = migrate(&inbox, false, false).unwrap();
+        assert_eq!(report.moves.len(), 1);
+        let m = &report.moves[0];
+        // Canonical under first recipient.
+        assert_eq!(
+            m.to,
+            inbox.join("direct/reviewer/20260419T120010Z-MULTI.md")
+        );
+        // Extra symlinks for the other `to:` entries AND the cc.
+        let expected_extras: Vec<PathBuf> = [
+            "direct/qa/20260419T120010Z-MULTI.md",
+            "direct/coordinator/20260419T120010Z-MULTI.md",
+            "direct/planner/20260419T120010Z-MULTI.md",
+        ]
+        .into_iter()
+        .map(|p| inbox.join(p))
+        .collect();
+        for p in &expected_extras {
+            assert!(
+                p.is_symlink(),
+                "expected secondary symlink at {}",
+                p.display()
+            );
+            let resolved = std::fs::canonicalize(p).unwrap();
+            assert_eq!(resolved, std::fs::canonicalize(&m.to).unwrap());
+        }
+    }
+
+    #[test]
+    fn migrate_is_idempotent() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        write_fenced(
+            &inbox,
+            "20260419T120020Z-IDEM.md",
+            &["reviewer"],
+            &[],
+            "20260419T120020Z",
+        );
+        let r1 = migrate(&inbox, false, false).unwrap();
+        assert_eq!(r1.moves.len(), 1);
+        let r2 = migrate(&inbox, false, false).unwrap();
+        assert!(r2.moves.is_empty(), "second run should be a no-op");
+        // Legacy symlink still in place after second run.
+        assert!(inbox.join("20260419T120020Z-IDEM.md").is_symlink());
+    }
+
+    #[test]
+    fn migrate_drop_legacy_removes_flat_symlinks() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        let flat = write_fenced(
+            &inbox,
+            "20260419T120030Z-DROP.md",
+            &["reviewer"],
+            &[],
+            "20260419T120030Z",
+        );
+        let _ = migrate(&inbox, false, false).unwrap();
+        assert!(flat.is_symlink());
+
+        let r = migrate(&inbox, false, true).unwrap();
+        assert!(r.moves.is_empty());
+        assert_eq!(r.dropped_legacy.len(), 1);
+        assert!(!flat.exists() && !flat.is_symlink());
+        // Canonical file is still there.
+        assert!(inbox
+            .join("direct/reviewer/20260419T120030Z-DROP.md")
+            .is_file());
+    }
+
+    #[test]
+    fn migrate_dry_run_makes_no_changes() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        let flat = write_fenced(
+            &inbox,
+            "20260419T120040Z-DRY.md",
+            &["reviewer"],
+            &[],
+            "20260419T120040Z",
+        );
+        let r = migrate(&inbox, true, false).unwrap();
+        assert_eq!(r.moves.len(), 1, "plan should include the file");
+        assert!(flat.is_file(), "flat file still present");
+        assert!(
+            !inbox
+                .join("direct/reviewer/20260419T120040Z-DRY.md")
+                .exists(),
+            "no canonical created under dry-run"
+        );
+    }
+
+    #[test]
+    fn migrate_skips_file_without_to_field() {
+        let g = Guard::new();
+        let inbox = g.inbox();
+        let path = inbox.join("20260419T120050Z-empty.md");
+        // No `to:` — neither fenced nor bare headers provide it.
+        write_raw(&path, "just a body, no headers at all\n");
+        let r = migrate(&inbox, false, false).unwrap();
+        assert!(r.moves.is_empty());
+        assert_eq!(r.skipped_unknown_to.len(), 1);
+        assert!(path.is_file(), "file untouched when can't be routed");
+    }
+
+    #[test]
+    fn migrate_bare_legacy_file_routes_by_header_to() {
+        // Old-shape bare files (no fenced frontmatter) also have to: be
+        // respected so a full-history migration lands everything correctly.
+        let g = Guard::new();
+        let inbox = g.inbox();
+        let path = inbox.join("20260419T120100Z-qa-to-worker-a.md");
+        let content = "from: qa\nto: worker-a\nre: ping\n\nbody\n";
+        write_raw(&path, content);
+
+        let r = migrate(&inbox, false, false).unwrap();
+        assert_eq!(r.moves.len(), 1);
+        assert_eq!(
+            r.moves[0].to,
+            inbox.join("direct/worker-a/20260419T120100Z-qa-to-worker-a.md")
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements **PR-3** of [`docs/designs/agent-messaging.md`](../blob/main/docs/designs/agent-messaging.md) (§2.1, §2.7, §2.9, §2.10): per-recipient directory split for `inbox/`, append-only read/ack cursors per handle, and a one-shot `migrate` to move any pre-PR-3 flat files into the new layout. Backwards-compatible via a grace-period symlink shim and dedup-on-read.

- **Directory split** — `inbox/broadcast/`, `inbox/direct/<handle>/`, `inbox/channel/<name>/`. Multi-recipient sends land canonical + per-recipient symlinks; direct `cc:` also gets a `direct/<cc>/` symlink so cc'd workers find it by scoped scan.
- **Legacy shim** — every send also writes `inbox/<filename>.md` as a symlink back to the canonical file during the grace period, so un-upgraded readers doing `ls inbox/` continue to work (design §2.10).
- **Cursors + ack** — `<mailbox>/cursors/<handle>.jsonl` append-only. `fetch --mark-read` records a `read` per returned message; `msg ack <id>` records an `ack`. Default `--since` for a fetch with a handle is strictly-after the last `read` — a worker can \`fetch --mark-read\` in a loop and only see new traffic.
- **Migrate** — \`twapp msg migrate [--dry-run] [--drop-legacy]\` moves every regular `inbox/*.md` into its canonical slot, laying down grace-period symlinks at the old flat path. Idempotent. `--drop-legacy` closes the period.
- **Urgent lane** (PR-4) retargeted at the canonical under the new layout; broken-symlink and multi-recipient tests still pass.

## Test plan
- [x] Subdir-based send creates canonical file + legacy symlink
- [x] Multi-recipient direct creates one file/symlink per recipient
- [x] \`fetch\` sees messages in new shape
- [x] \`fetch\` also sees legacy-flat messages during grace period
- [x] \`fetch --since <cursor>\` narrows correctly (including against legacy flat)
- [x] \`fetch --mark-read\` appends the right cursor entries
- [x] \`ack\` appends \`action:\"ack\"\` (with and without \`--note\`)
- [x] \`migrate\` moves flat files by \`to:\` field; idempotent re-run is a no-op
- [x] \`migrate --drop-legacy\` removes grace-period symlinks
- [x] Default \`fetch --since\` resumes strictly-after last read cursor
- [x] Full suite: \`cargo test --lib\` — 212 passed, 0 failed

## Out of scope
Presence/heartbeat (PR-5), channel subscription model (PR-6). Archive rotation shape (PR-7) is left alone.