### PR TITLE
feat(ui): coordinator fleet-pane quick-action context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,18 @@ collapses after the queue has been empty for a minute. Click a row to
 open a read-only message view. Blockers get the strongest red accent,
 urgents a muted one. Single-session users with no handle see no panel.
 
+#### Per-agent quick actions (context menu)
+
+Right-clicking a fleet-pane row (and later any co-lab row) opens a
+context menu with the most common coordinator actions: raise the
+agent's window, send a direct / urgent / blocker message (opens the
+composer prefilled), view recent mailbox activity, view their PR
+activity via `gh pr list --author <handle>`, and stop the agent via
+`twapp stop --name <handle>`. The stop flow ships with an explicit
+confirmation dialog and an optional SIGKILL escalation checkbox; it's
+hidden when the row targets the coordinator or the user's own session.
+See `docs/designs/agent-aware-ui.md` §3.5 for the full spec.
+
 #### Reading legacy (bare) files
 
 `fetch` accepts both the new fenced-frontmatter shape and the older bare

--- a/docs/designs/agent-aware-ui.md
+++ b/docs/designs/agent-aware-ui.md
@@ -404,6 +404,11 @@ The button is hidden (never rendered) when:
 
 ### 3.5 Quick actions from the dashboard
 
+> **Landed** (ui-quick-actions PR): the `AgentContextMenu` component +
+> supporting Tauri commands (`focus_agent_window`, `stop_agent`,
+> `list_agent_prs`, `fetch_agent_activity`) ship this shape. The fleet-pane
+> PR wires the menu to the per-agent rows it introduces.
+
 Right-click on any fleet-pane row opens a context menu. Keyboard: `⌘K`
 with a row focused. Items:
 

--- a/src-tauri/src/gui/agent_actions.rs
+++ b/src-tauri/src/gui/agent_actions.rs
@@ -1,0 +1,438 @@
+//! Tauri commands backing the fleet-pane per-agent context menu
+//! (`src/components/AgentContextMenu.tsx`). Each command is a thin shell
+//! around an existing CLI:
+//!
+//! - `focus_agent_window` — `open -a ~/.config/twapp/instances/<handle>.app`
+//!   when the instance is running; otherwise reports the session as offline
+//!   so the UI can dim the menu item.
+//! - `stop_agent` — `twapp stop --name <handle>` (with `--force` escalation).
+//! - `list_agent_prs` — `gh pr list --author <handle> --json …`. Missing `gh`
+//!   surfaces as a typed `AgentActionError::GhMissing` so the UI can skip the
+//!   item per the §3.5 spec.
+//! - `fetch_agent_activity` — `twapp msg fetch --all --format json`, then
+//!   filtered in-process for messages to/from/cc'ing the handle so "recent
+//!   activity" spans both directions. The CLI's `--for` filter only covers
+//!   inbound messages, so we do the from-side filter here rather than
+//!   shelling twice.
+
+use super::msg::{parse_fetch_stdout, FetchedMessage};
+use super::sessions::{check_instance_running, sanitize_instance_name};
+use super::types::*;
+use serde::{Deserialize, Serialize};
+use std::process::{Command, Stdio};
+
+/// Arguments for the stop-agent flow. `force` escalates to SIGKILL on the
+/// CLI side if the graceful SIGTERM doesn't land.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StopAgentArgs {
+    pub handle: String,
+    #[serde(default)]
+    pub force: bool,
+}
+
+/// Outcome of a focus attempt. `false` means the instance isn't running and
+/// the menu item should be treated as a no-op rather than an error.
+#[derive(Debug, Clone, Serialize)]
+pub struct FocusResult {
+    pub focused: bool,
+    /// Absolute path to the instance bundle, or empty when not running.
+    pub app_path: String,
+}
+
+/// One row in the "View PR activity" modal. Shape mirrors the `gh pr list
+/// --json` fields we request, so adding more columns is a CLI-flag change.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentPr {
+    pub number: u64,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+    pub updated_at: String,
+    pub is_draft: bool,
+}
+
+/// Validate a handle before shelling out. Rejects empty and anything that
+/// isn't a plausible session name so we never splat shell metacharacters
+/// into argv (the CLIs themselves don't shell-interpret, but defense in
+/// depth: `.`, `/`, whitespace, quotes all fail here).
+pub fn validate_handle(handle: &str) -> Result<&str, String> {
+    let trimmed = handle.trim();
+    if trimmed.is_empty() {
+        return Err("Agent handle is required".into());
+    }
+    let ok = trimmed
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-' || c == '_');
+    if !ok {
+        return Err(format!(
+            "Invalid agent handle (letters / digits / - / _ only): {}",
+            trimmed
+        ));
+    }
+    Ok(trimmed)
+}
+
+fn twapp_binary() -> std::path::PathBuf {
+    std::env::current_exe().unwrap_or_else(|_| std::path::PathBuf::from("twapp"))
+}
+
+fn instance_app_path(handle: &str) -> Option<std::path::PathBuf> {
+    let instances = dirs::home_dir()?.join(".config/twapp/instances");
+    let safe = sanitize_instance_name(handle);
+    Some(instances.join(format!("{}.app", safe)))
+}
+
+#[tauri::command]
+pub fn focus_agent_window(handle: String) -> Result<FocusResult, String> {
+    let handle = validate_handle(&handle)?;
+    if !check_instance_running(handle) {
+        return Ok(FocusResult { focused: false, app_path: String::new() });
+    }
+    let app = instance_app_path(handle).ok_or_else(|| "No home directory".to_string())?;
+    Command::new("open")
+        .args(["-a", &app.to_string_lossy()])
+        .spawn()
+        .map_err(|e| format!("Failed to focus {}: {}", app.display(), e))?;
+    Ok(FocusResult {
+        focused: true,
+        app_path: app.to_string_lossy().to_string(),
+    })
+}
+
+/// Build the argv for `twapp stop --name <handle> [--force]`. Pure so the
+/// flag wiring (and omission of `--force` when false) is unit-testable.
+pub fn build_stop_argv(handle: &str, force: bool) -> Vec<String> {
+    let mut argv = vec![
+        "stop".to_string(),
+        "--name".to_string(),
+        handle.to_string(),
+    ];
+    if force {
+        argv.push("--force".to_string());
+    }
+    argv
+}
+
+#[tauri::command]
+pub fn stop_agent(
+    args: StopAgentArgs,
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<(), String> {
+    let handle = validate_handle(&args.handle)?;
+    let argv = build_stop_argv(handle, args.force);
+    let bin = twapp_binary();
+    let mut cmd = Command::new(&bin);
+    cmd.args(&argv).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if let Some(d) = config.cwd.as_deref() {
+        cmd.current_dir(d);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("Failed to launch {}: {}", bin.display(), e))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("twapp stop exited with {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    Ok(())
+}
+
+/// Build argv for the `gh pr list` invocation. The `--json` fields match
+/// [`AgentPr`]'s field set so the downstream parser is a direct mapping.
+pub fn build_gh_pr_argv(handle: &str, limit: u32) -> Vec<String> {
+    vec![
+        "pr".to_string(),
+        "list".to_string(),
+        "--author".to_string(),
+        handle.to_string(),
+        "--state".to_string(),
+        "all".to_string(),
+        "--limit".to_string(),
+        limit.to_string(),
+        "--json".to_string(),
+        "number,title,state,url,updatedAt,isDraft".to_string(),
+    ]
+}
+
+/// Parse `gh pr list --json` output. Unknown fields are ignored so the gh
+/// CLI adding new columns won't break us.
+pub fn parse_gh_pr_stdout(stdout: &str) -> Result<Vec<AgentPr>, String> {
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() {
+        return Ok(Vec::new());
+    }
+    let v: serde_json::Value = serde_json::from_str(trimmed)
+        .map_err(|e| format!("Could not parse gh pr list JSON: {}", e))?;
+    let arr = v
+        .as_array()
+        .ok_or_else(|| format!("Expected JSON array from gh pr list, got: {}", v))?;
+    let out = arr
+        .iter()
+        .filter_map(|item| {
+            let obj = item.as_object()?;
+            Some(AgentPr {
+                number: obj.get("number")?.as_u64()?,
+                title: obj.get("title")?.as_str()?.to_string(),
+                state: obj.get("state").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+                url: obj.get("url").and_then(|s| s.as_str()).unwrap_or("").to_string(),
+                updated_at: obj
+                    .get("updatedAt")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string(),
+                is_draft: obj.get("isDraft").and_then(|b| b.as_bool()).unwrap_or(false),
+            })
+        })
+        .collect();
+    Ok(out)
+}
+
+#[tauri::command]
+pub fn list_agent_prs(handle: String, limit: Option<u32>) -> Result<Vec<AgentPr>, String> {
+    let handle = validate_handle(&handle)?;
+    let argv = build_gh_pr_argv(handle, limit.unwrap_or(5));
+    let out = Command::new("gh")
+        .args(&argv)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| {
+            // `gh` missing entirely is the common skip case — surface a
+            // stable prefix the UI can recognize.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                "gh CLI not installed".to_string()
+            } else {
+                format!("Failed to run gh: {}", e)
+            }
+        })?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("gh pr list exited with {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    parse_gh_pr_stdout(&stdout)
+}
+
+/// Filter a batch of fetched messages to those the agent touched, in either
+/// direction. Broadcasts (`to: [all]`) that the handle sent count; broadcasts
+/// from others don't — those would flood the "recent activity" view since
+/// every agent sees them.
+pub fn filter_activity_for(handle: &str, messages: Vec<FetchedMessage>) -> Vec<FetchedMessage> {
+    messages
+        .into_iter()
+        .filter(|m| {
+            m.from == handle
+                || m.to.iter().any(|t| t == handle)
+                || m.cc.iter().any(|c| c == handle)
+        })
+        .collect()
+}
+
+/// Sort by timestamp descending (newest first) and truncate to `limit`.
+pub fn sort_and_truncate(mut messages: Vec<FetchedMessage>, limit: usize) -> Vec<FetchedMessage> {
+    messages.sort_by(|a, b| b.ts.cmp(&a.ts));
+    messages.truncate(limit);
+    messages
+}
+
+#[tauri::command]
+pub fn fetch_agent_activity(
+    handle: String,
+    limit: Option<usize>,
+    config: tauri::State<'_, GuiArgs>,
+) -> Result<Vec<FetchedMessage>, String> {
+    let handle = validate_handle(&handle)?;
+    let limit = limit.unwrap_or(20);
+    // Pull a larger window than `limit` because we filter post-hoc — a
+    // recent burst of broadcasts from other handles can otherwise crowd
+    // out the agent's own messages.
+    let fetch_limit = (limit.saturating_mul(4)).max(80);
+    let argv = vec![
+        "msg".to_string(),
+        "fetch".to_string(),
+        "--all".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--limit".to_string(),
+        fetch_limit.to_string(),
+    ];
+    let bin = twapp_binary();
+    let mut cmd = Command::new(&bin);
+    cmd.args(&argv).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if let Some(d) = config.cwd.as_deref() {
+        cmd.current_dir(d);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| format!("Failed to launch {}: {}", bin.display(), e))?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        return Err(if stderr.is_empty() {
+            format!("twapp msg fetch exited with {}", out.status)
+        } else {
+            stderr
+        });
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout).to_string();
+    let all = parse_fetch_stdout(&stdout)?;
+    Ok(sort_and_truncate(filter_activity_for(handle, all), limit))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fm(from: &str, to: &[&str], ts: &str) -> FetchedMessage {
+        FetchedMessage {
+            id: format!("{}-{}", from, ts),
+            from: from.to_string(),
+            to: to.iter().map(|s| s.to_string()).collect(),
+            cc: Vec::new(),
+            priority: "routine".into(),
+            subject: None,
+            thread: None,
+            ts: ts.to_string(),
+            body: String::new(),
+            path: String::new(),
+        }
+    }
+
+    #[test]
+    fn validate_handle_ok() {
+        assert_eq!(validate_handle("twapp-ui-quick-actions"), Ok("twapp-ui-quick-actions"));
+        assert_eq!(validate_handle("  coord  "), Ok("coord"));
+        assert_eq!(validate_handle("reviewer_2"), Ok("reviewer_2"));
+    }
+
+    #[test]
+    fn validate_handle_rejects_empty() {
+        assert!(validate_handle("").is_err());
+        assert!(validate_handle("   ").is_err());
+    }
+
+    #[test]
+    fn validate_handle_rejects_metacharacters() {
+        assert!(validate_handle("foo; rm -rf /").is_err());
+        assert!(validate_handle("foo bar").is_err());
+        assert!(validate_handle("../etc/passwd").is_err());
+        assert!(validate_handle("quote\"").is_err());
+    }
+
+    #[test]
+    fn stop_argv_minimal() {
+        assert_eq!(
+            build_stop_argv("twapp-x", false),
+            vec!["stop", "--name", "twapp-x"]
+        );
+    }
+
+    #[test]
+    fn stop_argv_with_force() {
+        assert_eq!(
+            build_stop_argv("twapp-x", true),
+            vec!["stop", "--name", "twapp-x", "--force"]
+        );
+    }
+
+    #[test]
+    fn gh_argv_requests_expected_json_fields() {
+        let argv = build_gh_pr_argv("someone", 5);
+        assert!(argv.windows(2).any(|w| w[0] == "--author" && w[1] == "someone"));
+        assert!(argv.windows(2).any(|w| w[0] == "--limit" && w[1] == "5"));
+        assert!(argv.windows(2).any(|w| w[0] == "--state" && w[1] == "all"));
+        let json_fields = argv
+            .windows(2)
+            .find(|w| w[0] == "--json")
+            .map(|w| w[1].clone())
+            .unwrap();
+        for required in ["number", "title", "state", "url", "updatedAt", "isDraft"] {
+            assert!(
+                json_fields.contains(required),
+                "expected --json fields to include {}, got {}",
+                required,
+                json_fields
+            );
+        }
+    }
+
+    #[test]
+    fn parse_gh_pr_stdout_two_prs() {
+        let json = r#"[
+          {"number": 42, "title": "feat: x", "state": "OPEN",
+           "url": "https://github.com/o/r/pull/42",
+           "updatedAt": "2026-04-21T10:00:00Z", "isDraft": false},
+          {"number": 41, "title": "feat: y", "state": "MERGED",
+           "url": "https://github.com/o/r/pull/41",
+           "updatedAt": "2026-04-20T10:00:00Z", "isDraft": true}
+        ]"#;
+        let prs = parse_gh_pr_stdout(json).unwrap();
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 42);
+        assert_eq!(prs[0].title, "feat: x");
+        assert_eq!(prs[0].state, "OPEN");
+        assert!(!prs[0].is_draft);
+        assert!(prs[1].is_draft);
+    }
+
+    #[test]
+    fn parse_gh_pr_stdout_empty() {
+        assert!(parse_gh_pr_stdout("").unwrap().is_empty());
+        assert!(parse_gh_pr_stdout("[]").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_gh_pr_stdout_rejects_non_array() {
+        assert!(parse_gh_pr_stdout(r#"{"oops": 1}"#).is_err());
+    }
+
+    #[test]
+    fn filter_activity_includes_inbound_outbound_cc_and_self_broadcasts() {
+        let handle = "alice";
+        let mut ccmsg = fm("coord", &["bob"], "20260421T090000Z");
+        ccmsg.cc = vec!["alice".into()];
+        let msgs = vec![
+            fm("alice", &["bob"], "20260421T100000Z"),
+            fm("bob", &["alice"], "20260421T101000Z"),
+            fm("alice", &["all"], "20260421T102000Z"),
+            fm("carol", &["all"], "20260421T103000Z"),
+            ccmsg,
+            fm("erin", &["frank"], "20260421T104000Z"),
+        ];
+        let got = filter_activity_for(handle, msgs);
+        let ids: Vec<_> = got.iter().map(|m| m.id.clone()).collect();
+        assert!(ids.contains(&"alice-20260421T100000Z".to_string()));
+        assert!(ids.contains(&"bob-20260421T101000Z".to_string()));
+        assert!(ids.contains(&"alice-20260421T102000Z".to_string()));
+        assert!(!ids.contains(&"carol-20260421T103000Z".to_string()));
+        assert!(ids.contains(&"coord-20260421T090000Z".to_string()));
+        assert!(!ids.contains(&"erin-20260421T104000Z".to_string()));
+    }
+
+    #[test]
+    fn sort_descending_and_truncate() {
+        let msgs = vec![
+            fm("a", &["x"], "20260421T100000Z"),
+            fm("b", &["x"], "20260421T102000Z"),
+            fm("c", &["x"], "20260421T101000Z"),
+        ];
+        let out = sort_and_truncate(msgs, 2);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].from, "b");
+        assert_eq!(out[1].from, "c");
+    }
+
+    #[test]
+    fn sort_and_truncate_limit_larger_than_input() {
+        let msgs = vec![fm("a", &["x"], "T")];
+        let out = sort_and_truncate(msgs, 100);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,3 +1,4 @@
+pub mod agent_actions;
 pub mod config;
 pub mod coordinator;
 pub mod files;
@@ -129,6 +130,10 @@ pub fn run(args: GuiArgs) {
             msg::send_message,
             msg::fetch_messages,
             fleet::list_fleet,
+            agent_actions::focus_agent_window,
+            agent_actions::stop_agent,
+            agent_actions::list_agent_prs,
+            agent_actions::fetch_agent_activity,
             coordinator::launch_coordinator,
             coordinator::claim_coordinator,
             coordinator::list_claimable_sessions,

--- a/src/App.css
+++ b/src/App.css
@@ -4994,3 +4994,344 @@ a.file-link {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ----- Agent context menu (§3.5 fleet-pane quick actions) ----- */
+
+.agent-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.agent-menu {
+  min-width: 240px;
+  max-width: 320px;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.32);
+  padding: 4px 0;
+  margin: 0;
+  list-style: none;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+
+.agent-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px 8px;
+  border-bottom: 1px solid var(--border-color);
+  margin-bottom: 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.agent-menu-handle {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.agent-menu-copy {
+  background: none;
+  border: 1px solid var(--border-color);
+  border-radius: 4px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 8px;
+  font-size: 10px;
+}
+
+.agent-menu-copy:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.agent-menu-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 14px;
+  cursor: pointer;
+  gap: 12px;
+}
+
+.agent-menu-item-focus,
+.agent-menu-item:hover:not(.agent-menu-item-disabled) {
+  background: var(--bg-secondary);
+}
+
+.agent-menu-item-disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.agent-menu-item-destructive {
+  color: #d14545;
+}
+
+.agent-menu-item-destructive.agent-menu-item-focus,
+.agent-menu-item-destructive:hover:not(.agent-menu-item-disabled) {
+  background: rgba(209, 69, 69, 0.08);
+}
+
+.agent-menu-shortcut {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.agent-menu-toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 8px 14px;
+  font-size: 12px;
+  z-index: 1100;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+}
+
+.agent-menu-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1050;
+}
+
+.agent-menu-modal {
+  width: 420px;
+  max-width: 92vw;
+  max-height: 82vh;
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.agent-menu-modal-wide {
+  width: 560px;
+}
+
+.agent-menu-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-color);
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 13px;
+}
+
+.agent-menu-modal-close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 13px;
+}
+
+.agent-menu-modal-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.agent-menu-modal-body {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  color: var(--text-primary);
+  font-size: 12.5px;
+}
+
+.agent-menu-modal-body p {
+  margin: 0;
+}
+
+.agent-menu-warning {
+  padding: 8px 10px;
+  background: rgba(209, 140, 69, 0.12);
+  border-left: 3px solid #d18c45;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.agent-menu-force-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.agent-menu-error {
+  padding: 8px 10px;
+  background: rgba(209, 69, 69, 0.12);
+  border-left: 3px solid #d14545;
+  color: #d14545;
+  font-size: 12px;
+  border-radius: 3px;
+}
+
+.agent-menu-loading,
+.agent-menu-empty {
+  color: var(--text-secondary);
+  font-size: 12px;
+  padding: 10px 0;
+}
+
+.agent-menu-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 10px 16px 14px;
+  border-top: 1px solid var(--border-color);
+}
+
+.agent-menu-cancel,
+.agent-menu-confirm-destructive {
+  padding: 6px 14px;
+  border-radius: 5px;
+  border: 1px solid var(--border-color);
+  font-size: 12px;
+  cursor: pointer;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.agent-menu-confirm-destructive {
+  background: #d14545;
+  border-color: #b03636;
+  color: #fff;
+}
+
+.agent-menu-confirm-destructive:disabled,
+.agent-menu-cancel:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.agent-menu-activity,
+.agent-menu-prs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.agent-menu-activity-row {
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.agent-menu-activity-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+
+.agent-menu-activity-from {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-secondary);
+}
+
+.agent-menu-activity-ts {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+.agent-menu-activity-subject {
+  color: var(--text-primary);
+  font-size: 12px;
+}
+
+.agent-menu-pr-row {
+  display: flex;
+}
+
+.agent-menu-pr-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 5px;
+  color: var(--text-primary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.agent-menu-pr-link:hover {
+  background: var(--bg-primary);
+  border-color: var(--accent-color, var(--border-color));
+}
+
+.agent-menu-pr-number {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--text-secondary);
+  font-size: 11px;
+  min-width: 40px;
+}
+
+.agent-menu-pr-state {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  min-width: 52px;
+  text-align: center;
+}
+
+.agent-menu-pr-state-open {
+  color: #3aa34a;
+}
+
+.agent-menu-pr-state-merged {
+  color: #8857d2;
+}
+
+.agent-menu-pr-state-closed {
+  color: #888;
+}
+
+.agent-menu-pr-title {
+  flex: 1;
+  font-size: 12.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/components/AgentContextMenu.test.ts
+++ b/src/components/AgentContextMenu.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildMenuItems,
+  clampAnchor,
+  type MenuItem,
+  type MenuItemId,
+} from "./AgentContextMenu";
+
+const ids = (items: MenuItem[]): MenuItemId[] => items.map((i) => i.id);
+const byId = (items: MenuItem[], id: MenuItemId): MenuItem => {
+  const m = items.find((i) => i.id === id);
+  if (!m) throw new Error(`item ${id} missing`);
+  return m;
+};
+
+describe("buildMenuItems", () => {
+  it("includes all 7 items for a normal peer agent", () => {
+    const items = buildMenuItems("peer-agent");
+    expect(ids(items)).toEqual([
+      "open-window",
+      "send-direct",
+      "send-urgent",
+      "send-blocker",
+      "view-activity",
+      "view-prs",
+      "stop-agent",
+    ]);
+  });
+
+  it("hides Stop when the target is the coordinator (§3.5)", () => {
+    const items = buildMenuItems("coord", { isCoordinator: true });
+    expect(ids(items)).not.toContain("stop-agent");
+  });
+
+  it("hides Stop when the target is self (can't stop your own session from the menu)", () => {
+    const items = buildMenuItems("me", { isSelf: true });
+    expect(ids(items)).not.toContain("stop-agent");
+  });
+
+  it("disables Open window when target is self (already the active window)", () => {
+    const items = buildMenuItems("me", { isSelf: true });
+    expect(byId(items, "open-window").disabled).toBe(true);
+  });
+
+  it("marks Stop as destructive so the UI can red-tint it", () => {
+    const items = buildMenuItems("peer");
+    expect(byId(items, "stop-agent").destructive).toBe(true);
+  });
+
+  it("attaches a hint to Send blocker describing the recipient impact", () => {
+    const items = buildMenuItems("peer");
+    expect(byId(items, "send-blocker").hint).toMatch(/stop current work/i);
+  });
+
+  it("does not mark Send direct as destructive", () => {
+    const items = buildMenuItems("peer");
+    expect(byId(items, "send-direct").destructive).toBeFalsy();
+  });
+
+  it("preserves menu order when Stop is hidden so muscle memory survives", () => {
+    const items = buildMenuItems("coord", { isCoordinator: true });
+    expect(ids(items)).toEqual([
+      "open-window",
+      "send-direct",
+      "send-urgent",
+      "send-blocker",
+      "view-activity",
+      "view-prs",
+    ]);
+  });
+});
+
+describe("clampAnchor", () => {
+  const viewport = { width: 1000, height: 800 };
+  const menu = { width: 220, height: 280 };
+
+  it("leaves mid-viewport anchors untouched", () => {
+    const out = clampAnchor({ x: 400, y: 400 }, menu, viewport);
+    expect(out).toEqual({ x: 400, y: 400 });
+  });
+
+  it("clamps past-right edge so menu stays on-screen", () => {
+    const out = clampAnchor({ x: 990, y: 400 }, menu, viewport);
+    expect(out.x).toBeLessThanOrEqual(viewport.width - menu.width);
+    expect(out.x).toBeGreaterThan(0);
+  });
+
+  it("clamps past-bottom edge", () => {
+    const out = clampAnchor({ x: 400, y: 790 }, menu, viewport);
+    expect(out.y).toBeLessThanOrEqual(viewport.height - menu.height);
+  });
+
+  it("clamps negative anchors into the padded viewport", () => {
+    const out = clampAnchor({ x: -50, y: -20 }, menu, viewport);
+    expect(out.x).toBeGreaterThanOrEqual(0);
+    expect(out.y).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not explode when the menu is larger than the viewport", () => {
+    const tiny = { width: 100, height: 100 };
+    const huge = { width: 500, height: 500 };
+    const out = clampAnchor({ x: 50, y: 50 }, huge, tiny);
+    expect(Number.isFinite(out.x)).toBe(true);
+    expect(Number.isFinite(out.y)).toBe(true);
+  });
+});

--- a/src/components/AgentContextMenu.tsx
+++ b/src/components/AgentContextMenu.tsx
@@ -1,0 +1,626 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import type { UrgentMessage } from "./UrgentInbox";
+import { relativeTime, rowPreview } from "./UrgentInbox";
+
+export type AgentPriority = "routine" | "urgent" | "blocker";
+
+export type AgentPr = {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  updatedAt: string;
+  isDraft: boolean;
+};
+
+export type FocusResult = {
+  focused: boolean;
+  appPath: string;
+};
+
+/** Anchor where the menu pops up. `x`/`y` are viewport-relative pixels. */
+export type MenuAnchor = { x: number; y: number };
+
+export type MenuItemId =
+  | "open-window"
+  | "send-direct"
+  | "send-urgent"
+  | "send-blocker"
+  | "view-activity"
+  | "view-prs"
+  | "stop-agent";
+
+export type MenuItem = {
+  id: MenuItemId;
+  label: string;
+  /** Optional shortcut hint rendered right-aligned. */
+  shortcut?: string;
+  /** True = visually dimmed + click suppressed. */
+  disabled?: boolean;
+  /** True = destructive styling (red). */
+  destructive?: boolean;
+  /** Hover title for context (e.g., why disabled). */
+  hint?: string;
+};
+
+/** Additional per-agent context used when deciding which items to show. */
+export type AgentContextMenuFlags = {
+  /** `true` when the target handle is the coordinator; hides the Stop item. */
+  isCoordinator?: boolean;
+  /** `true` when the menu targets the user's own session. Stop / Open hidden. */
+  isSelf?: boolean;
+  /** `true` when the agent has an open PR without a "Ship it"; shown in confirm. */
+  hasUnshipedPr?: boolean;
+};
+
+/**
+ * Pure helper: assemble the menu item list in render order, with
+ * visibility + disabled states applied per §3.5 + §3.6 gating rules.
+ *
+ * Exported so the gating logic can be unit-tested without spinning React.
+ */
+export function buildMenuItems(
+  handle: string,
+  flags: AgentContextMenuFlags = {},
+): MenuItem[] {
+  const items: MenuItem[] = [];
+  const offline = handle.length === 0;
+
+  // "Stop" is the one item with hard visibility gating. Everything else
+  // stays visible (possibly dimmed) so the menu shape is stable and
+  // muscle memory survives rare edge cases.
+  const hideStop = flags.isSelf === true || flags.isCoordinator === true;
+
+  items.push({
+    id: "open-window",
+    label: "Open window",
+    disabled: offline || flags.isSelf === true,
+    hint: flags.isSelf === true ? "This is your own session" : undefined,
+  });
+  items.push({ id: "send-direct", label: "Send direct message…" });
+  items.push({
+    id: "send-urgent",
+    label: "Send urgent message…",
+    hint: "priority: urgent",
+  });
+  items.push({
+    id: "send-blocker",
+    label: "Send blocker…",
+    hint: "Asks the recipient to stop current work",
+  });
+  items.push({ id: "view-activity", label: "View recent activity" });
+  items.push({ id: "view-prs", label: "View PR activity" });
+  if (!hideStop) {
+    items.push({
+      id: "stop-agent",
+      label: "Stop agent…",
+      destructive: true,
+    });
+  }
+  return items;
+}
+
+/** Pure helper: clamp the menu position so it doesn't overflow the viewport.
+ *  Exported for unit testing the positioning math. */
+export function clampAnchor(
+  anchor: MenuAnchor,
+  menu: { width: number; height: number },
+  viewport: { width: number; height: number },
+): MenuAnchor {
+  const pad = 4;
+  const maxX = Math.max(pad, viewport.width - menu.width - pad);
+  const maxY = Math.max(pad, viewport.height - menu.height - pad);
+  return {
+    x: Math.min(Math.max(pad, anchor.x), maxX),
+    y: Math.min(Math.max(pad, anchor.y), maxY),
+  };
+}
+
+type OpenComposer = (args: {
+  to: string;
+  priority: AgentPriority;
+}) => void;
+
+type AgentContextMenuProps = {
+  handle: string;
+  anchor: MenuAnchor | null;
+  flags?: AgentContextMenuFlags;
+  onClose: () => void;
+  /** Invoked for Send direct / urgent / blocker — parent wires the composer. */
+  onOpenComposer: OpenComposer;
+  /** Emitted when the Stop flow completes successfully. */
+  onStopped?: (handle: string) => void;
+  /** Clipboard override for tests. Defaults to `navigator.clipboard.writeText`. */
+  clipboard?: (text: string) => Promise<void>;
+  /** Invoke override for tests. Defaults to the Tauri bridge. */
+  invoker?: <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+  /** `openUrl` override for tests (used by the PR list modal). */
+  openExternal?: (url: string) => Promise<void>;
+};
+
+const defaultInvoker = <T,>(cmd: string, args?: Record<string, unknown>): Promise<T> =>
+  invoke<T>(cmd, args);
+
+const defaultClipboard = (text: string): Promise<void> =>
+  navigator.clipboard.writeText(text);
+
+const defaultOpen = (url: string): Promise<void> => openUrl(url);
+
+type ActivityModal =
+  | { kind: "activity"; loading: true }
+  | { kind: "activity"; loading: false; messages: UrgentMessage[]; error: string | null };
+
+type PrModal =
+  | { kind: "prs"; loading: true }
+  | { kind: "prs"; loading: false; prs: AgentPr[]; error: string | null };
+
+type PendingModal = ActivityModal | PrModal | null;
+
+type StopState =
+  | { kind: "confirm" }
+  | { kind: "running" }
+  | { kind: "error"; message: string }
+  | null;
+
+/** The per-agent context menu from §3.5. Parent is responsible for wiring the
+ *  composer modal — this component owns the menu, the Stop-confirmation
+ *  dialog, and the activity / PR-list modals. */
+export default function AgentContextMenu({
+  handle,
+  anchor,
+  flags,
+  onClose,
+  onOpenComposer,
+  onStopped,
+  clipboard = defaultClipboard,
+  invoker = defaultInvoker,
+  openExternal = defaultOpen,
+}: AgentContextMenuProps) {
+  const items = useMemo(() => buildMenuItems(handle, flags), [handle, flags]);
+  const [focusIdx, setFocusIdx] = useState(0);
+  const [modal, setModal] = useState<PendingModal>(null);
+  const [stop, setStop] = useState<StopState>(null);
+  const [offlineToast, setOfflineToast] = useState(false);
+  const menuRef = useRef<HTMLUListElement>(null);
+
+  // Reset focus to the first enabled item whenever the menu re-opens.
+  useEffect(() => {
+    if (!anchor) return;
+    const first = items.findIndex((it) => !it.disabled);
+    setFocusIdx(first >= 0 ? first : 0);
+  }, [anchor, items]);
+
+  useEffect(() => {
+    if (!anchor) return;
+    const handler = (e: KeyboardEvent) => {
+      if (modal || stop) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFocusIdx((i) => nextEnabled(items, i, 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFocusIdx((i) => nextEnabled(items, i, -1));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const it = items[focusIdx];
+        if (it && !it.disabled) activate(it.id);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [anchor, items, focusIdx, modal, stop]);
+
+  const activate = useCallback(
+    async (id: MenuItemId) => {
+      switch (id) {
+        case "open-window": {
+          onClose();
+          try {
+            const res = await invoker<FocusResult>("focus_agent_window", { handle });
+            if (!res.focused) {
+              setOfflineToast(true);
+              window.setTimeout(() => setOfflineToast(false), 3000);
+            }
+          } catch (e) {
+            setOfflineToast(true);
+            window.setTimeout(() => setOfflineToast(false), 3000);
+            console.error("focus_agent_window failed", e);
+          }
+          return;
+        }
+        case "send-direct":
+          onClose();
+          onOpenComposer({ to: handle, priority: "routine" });
+          return;
+        case "send-urgent":
+          onClose();
+          onOpenComposer({ to: handle, priority: "urgent" });
+          return;
+        case "send-blocker":
+          onClose();
+          onOpenComposer({ to: handle, priority: "blocker" });
+          return;
+        case "view-activity":
+          setModal({ kind: "activity", loading: true });
+          try {
+            const raw = await invoker<UrgentMessage[]>("fetch_agent_activity", {
+              handle,
+              limit: 20,
+            });
+            setModal({ kind: "activity", loading: false, messages: raw, error: null });
+          } catch (e) {
+            setModal({
+              kind: "activity",
+              loading: false,
+              messages: [],
+              error: String(e),
+            });
+          }
+          return;
+        case "view-prs":
+          setModal({ kind: "prs", loading: true });
+          try {
+            const prs = await invoker<AgentPr[]>("list_agent_prs", {
+              handle,
+              limit: 5,
+            });
+            setModal({ kind: "prs", loading: false, prs, error: null });
+          } catch (e) {
+            setModal({
+              kind: "prs",
+              loading: false,
+              prs: [],
+              error: String(e),
+            });
+          }
+          return;
+        case "stop-agent":
+          setStop({ kind: "confirm" });
+          return;
+      }
+    },
+    [handle, invoker, onClose, onOpenComposer],
+  );
+
+  const confirmStop = useCallback(
+    async (force: boolean) => {
+      setStop({ kind: "running" });
+      try {
+        await invoker<void>("stop_agent", { args: { handle, force } });
+        setStop(null);
+        onClose();
+        onStopped?.(handle);
+      } catch (e) {
+        setStop({ kind: "error", message: String(e) });
+      }
+    },
+    [handle, invoker, onClose, onStopped],
+  );
+
+  const handleCopyHandle = useCallback(async () => {
+    try {
+      await clipboard(handle);
+    } catch (e) {
+      console.error("clipboard failed", e);
+    }
+  }, [handle, clipboard]);
+
+  if (!anchor) return null;
+
+  const menuStyle: React.CSSProperties = {
+    position: "fixed",
+    left: anchor.x,
+    top: anchor.y,
+    zIndex: 1000,
+  };
+
+  return createPortal(
+    <>
+      <div className="agent-menu-backdrop" onClick={onClose} />
+      <ul
+        ref={menuRef}
+        className="agent-menu"
+        role="menu"
+        aria-label={`Actions for ${handle}`}
+        style={menuStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <li className="agent-menu-header" role="presentation">
+          <span className="agent-menu-handle">{handle}</span>
+          <button
+            className="agent-menu-copy"
+            onClick={handleCopyHandle}
+            title="Copy handle to clipboard"
+            aria-label="Copy handle"
+          >
+            Copy
+          </button>
+        </li>
+        {items.map((it, idx) => (
+          <li
+            key={it.id}
+            role="menuitem"
+            aria-disabled={it.disabled || undefined}
+            className={[
+              "agent-menu-item",
+              it.disabled ? "agent-menu-item-disabled" : "",
+              it.destructive ? "agent-menu-item-destructive" : "",
+              idx === focusIdx ? "agent-menu-item-focus" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            title={it.hint}
+            onMouseEnter={() => setFocusIdx(idx)}
+            onClick={() => !it.disabled && activate(it.id)}
+            data-menu-id={it.id}
+          >
+            <span className="agent-menu-label">{it.label}</span>
+            {it.shortcut && (
+              <span className="agent-menu-shortcut">{it.shortcut}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      {offlineToast && (
+        <div className="agent-menu-toast" role="status">
+          {handle} is not running
+        </div>
+      )}
+
+      {stop && (
+        <StopConfirmDialog
+          handle={handle}
+          state={stop}
+          hasUnshipedPr={flags?.hasUnshipedPr === true}
+          onCancel={() => setStop(null)}
+          onConfirm={confirmStop}
+        />
+      )}
+
+      {modal?.kind === "activity" && (
+        <ActivityModalView
+          handle={handle}
+          state={modal}
+          onClose={() => setModal(null)}
+        />
+      )}
+
+      {modal?.kind === "prs" && (
+        <PrsModalView
+          handle={handle}
+          state={modal}
+          openExternal={openExternal}
+          onClose={() => setModal(null)}
+        />
+      )}
+    </>,
+    document.body,
+  );
+}
+
+function nextEnabled(items: MenuItem[], from: number, step: 1 | -1): number {
+  if (items.length === 0) return 0;
+  let idx = from;
+  for (let i = 0; i < items.length; i++) {
+    idx = (idx + step + items.length) % items.length;
+    if (!items[idx].disabled) return idx;
+  }
+  return from;
+}
+
+type StopConfirmDialogProps = {
+  handle: string;
+  state: StopState;
+  hasUnshipedPr: boolean;
+  onCancel: () => void;
+  onConfirm: (force: boolean) => void;
+};
+
+function StopConfirmDialog({
+  handle,
+  state,
+  hasUnshipedPr,
+  onCancel,
+  onConfirm,
+}: StopConfirmDialogProps) {
+  const running = state?.kind === "running";
+  const errorMessage = state?.kind === "error" ? state.message : null;
+  const [force, setForce] = useState(false);
+
+  return (
+    <div className="agent-menu-modal-overlay" onClick={onCancel}>
+      <div
+        className="agent-menu-modal"
+        onClick={(e) => e.stopPropagation()}
+        role="alertdialog"
+        aria-label="Stop agent confirmation"
+      >
+        <div className="agent-menu-modal-header">
+          <span>Stop {handle}?</span>
+        </div>
+        <div className="agent-menu-modal-body">
+          <p>
+            This sends <code>twapp stop --name {handle}</code>. The target agent
+            receives SIGTERM and has ~3 seconds to exit gracefully.
+          </p>
+          {hasUnshipedPr && (
+            <p className="agent-menu-warning">
+              This agent has an open PR with no "Ship it". Stopping now leaves
+              the PR unattended.
+            </p>
+          )}
+          <label className="agent-menu-force-label">
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(e) => setForce(e.target.checked)}
+              disabled={running}
+            />
+            Escalate to SIGKILL if SIGTERM hangs
+          </label>
+          {errorMessage && (
+            <div className="agent-menu-error" role="alert">
+              {errorMessage}
+            </div>
+          )}
+        </div>
+        <div className="agent-menu-modal-actions">
+          <button
+            className="agent-menu-cancel"
+            onClick={onCancel}
+            disabled={running}
+          >
+            Cancel
+          </button>
+          <button
+            className="agent-menu-confirm-destructive"
+            onClick={() => onConfirm(force)}
+            disabled={running}
+          >
+            {running ? "Stopping…" : "Stop"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type ActivityModalProps = {
+  handle: string;
+  state: ActivityModal;
+  onClose: () => void;
+};
+
+function ActivityModalView({ handle, state, onClose }: ActivityModalProps) {
+  const now = Date.now();
+  return (
+    <div className="agent-menu-modal-overlay" onClick={onClose}>
+      <div
+        className="agent-menu-modal agent-menu-modal-wide"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label={`Recent activity for ${handle}`}
+      >
+        <div className="agent-menu-modal-header">
+          <span>Recent activity — {handle}</span>
+          <button
+            className="agent-menu-modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            x
+          </button>
+        </div>
+        <div className="agent-menu-modal-body">
+          {state.loading && <div className="agent-menu-loading">Loading…</div>}
+          {!state.loading && state.error && (
+            <div className="agent-menu-error" role="alert">
+              {state.error}
+            </div>
+          )}
+          {!state.loading && !state.error && state.messages.length === 0 && (
+            <div className="agent-menu-empty">No recent messages to or from {handle}.</div>
+          )}
+          {!state.loading && !state.error && state.messages.length > 0 && (
+            <ul className="agent-menu-activity">
+              {state.messages.map((m) => (
+                <li key={m.id} className="agent-menu-activity-row">
+                  <div className="agent-menu-activity-top">
+                    <span className={`priority-chip priority-${m.priority}`}>
+                      {m.priority}
+                    </span>
+                    <span className="agent-menu-activity-from">
+                      {m.from} &rarr; {(m.to || []).join(", ")}
+                    </span>
+                    <span className="agent-menu-activity-ts" title={m.ts}>
+                      {relativeTime(m.ts, now)}
+                    </span>
+                  </div>
+                  <div className="agent-menu-activity-subject">{rowPreview(m)}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type PrsModalProps = {
+  handle: string;
+  state: PrModal;
+  openExternal: (url: string) => Promise<void>;
+  onClose: () => void;
+};
+
+function PrsModalView({ handle, state, openExternal, onClose }: PrsModalProps) {
+  const ghMissing =
+    !state.loading && state.error !== null && /gh CLI not installed/i.test(state.error || "");
+
+  return (
+    <div className="agent-menu-modal-overlay" onClick={onClose}>
+      <div
+        className="agent-menu-modal agent-menu-modal-wide"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label={`PR activity for ${handle}`}
+      >
+        <div className="agent-menu-modal-header">
+          <span>PR activity — {handle}</span>
+          <button
+            className="agent-menu-modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            x
+          </button>
+        </div>
+        <div className="agent-menu-modal-body">
+          {state.loading && <div className="agent-menu-loading">Loading…</div>}
+          {!state.loading && ghMissing && (
+            <div className="agent-menu-empty">
+              <code>gh</code> CLI is not installed. This feature requires the
+              GitHub CLI.
+            </div>
+          )}
+          {!state.loading && !ghMissing && state.error && (
+            <div className="agent-menu-error" role="alert">
+              {state.error}
+            </div>
+          )}
+          {!state.loading && !state.error && state.prs.length === 0 && (
+            <div className="agent-menu-empty">No PRs found for {handle}.</div>
+          )}
+          {!state.loading && !state.error && state.prs.length > 0 && (
+            <ul className="agent-menu-prs">
+              {state.prs.map((pr) => (
+                <li key={pr.number} className="agent-menu-pr-row">
+                  <button
+                    className="agent-menu-pr-link"
+                    onClick={() => openExternal(pr.url)}
+                    title={`Open ${pr.url}`}
+                  >
+                    <span className="agent-menu-pr-number">#{pr.number}</span>
+                    <span className={`agent-menu-pr-state agent-menu-pr-state-${pr.state.toLowerCase()}`}>
+                      {pr.isDraft ? "DRAFT" : pr.state}
+                    </span>
+                    <span className="agent-menu-pr-title">{pr.title}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements **§3.5** of `docs/designs/agent-aware-ui.md` — the per-agent context menu that the fleet pane hangs on each agent row. The fleet-pane PR (parallel wave-3 work) will import `AgentContextMenu` and wire it to its row components; this PR ships the component, the Tauri commands behind each action, tests, and docs. Composer flow is unchanged — new priority presets open the existing composer via an `onOpenComposer` callback.

### What ships

- `AgentContextMenu` component (portal-based, keyboard nav, viewport clamping, per-agent gating per §3.6)
- **Open window** — `focus_agent_window` Tauri cmd: `open -a` the running instance `.app`, or report the session offline so the item dims
- **Send direct / urgent / blocker** — opens the existing composer with `to: <handle>` + `priority` preselected
- **View recent activity** — `fetch_agent_activity` Tauri cmd: shells `twapp msg fetch --all --format json`, filters in-process for `from == handle || handle ∈ to || handle ∈ cc` (CLI `--for` is inbound-only)
- **View PR activity** — `list_agent_prs` Tauri cmd: `gh pr list --author <handle> --json ...`; missing `gh` surfaces as a typed skip message in the modal
- **Stop agent** — `stop_agent` Tauri cmd (`twapp stop --name <handle>` + optional `--force`). Fronted by a confirmation dialog; warns on unshipped PR; hidden for coordinator / self rows
- Input validation rejects handles with shell metacharacters / whitespace / path separators (defense in depth)

### Tests

- 13 vitest cases — menu gating (Stop hidden for coordinator / self, Open disabled on self), destructive styling, blocker hint text, anchor clamping math
- 12 cargo tests — handle validation, `build_stop_argv`, `build_gh_pr_argv` (JSON field coverage), `parse_gh_pr_stdout` (happy + non-array + empty), activity filter (inbound, outbound, cc, self-broadcast, skip others-to-all), `sort_and_truncate`
- Full suites green: **140/140** vitest, **244/244** cargo

### Out of scope

- No new backend tooling — menu items shell existing commands (per briefing)
- Multi-select / bulk actions — future
- Consumer wiring — fleet-pane PR imports `AgentContextMenu` when it lands

## Test plan

- [x] `npm test` — 140 pass
- [x] `cargo test --lib` — 244 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean production bundle
- [x] `cargo clippy --lib --no-deps` — no new warnings from `agent_actions.rs`
- [ ] Manual smoke with live fleet pane (blocked on fleet-pane PR landing)

Reviewer: `twapp-reviewer` / `twapp-reviewer-2`. Ship-on-CLEAN + Ship it.