### PR TITLE
feat(ui): coordinator fleet pane (presence-aware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,37 @@ and the unchanged `twapp - <name>` for plain user sessions. The formatter
 lives in [`src-tauri/src/gui/title.rs`](src-tauri/src/gui/title.rs) with a
 unit test per branch.
 
+### Coordinator fleet pane
+
+A session whose `.twapp-session.json` declares `role: "coordinator"`
+renders a **Fleet** panel in its sidebar, above the notes / prompts
+stack. The pane polls the `list_fleet` Tauri command every 5 seconds and
+lists one row per handle with a live `<mailbox>/presence/<handle>.json`:
+
+- Status dot — green fill for `processing`, hollow for `idle`, muted for
+  `dormant` (derived from `last_heartbeat` aged past `5 × poll_interval_sec`
+  per the messaging design's dormancy rule).
+- Handle and role chip, with a provenance glyph (◦ user-created, ▸
+  agent-spawned) drawn from the session's on-disk metadata.
+- Counts: urgent-lane tally (merging `inbox/urgent/<handle>/` and
+  `inbox/urgent/all/`) in red, plus the unread count of
+  `inbox/direct/<handle>/`.
+- Last-heartbeat age as "30s ago" / "4m ago" with the full RFC3339
+  timestamp on hover.
+- Current task line (truncated to ~80 chars) from the presence file's
+  `current_task`.
+
+Rows sort urgent-first, then by unread desc, then by freshest heartbeat.
+Clicking a row raises that handle's twapp window via the same
+`launch_session` focus path the launcher uses. When the coordinator's
+session has a `colab_group`, the pane is scoped to that group; a
+coordinator without a group sees every active handle in the shared
+mailbox. Non-coordinator sessions never render the pane (single-session
+and worker UX are byte-unchanged). The backend lives in
+[`src-tauri/src/gui/fleet.rs`](src-tauri/src/gui/fleet.rs) and the React
+side in [`src/components/FleetPane.tsx`](src/components/FleetPane.tsx),
+both with unit tests.
+
 ### Spawning a worker agent
 
 twapp works well as a terminal wrapper for *interactive* sessions, but

--- a/docs/designs/agent-aware-ui.md
+++ b/docs/designs/agent-aware-ui.md
@@ -283,6 +283,17 @@ heartbeat loop.
 
 ### 3.3 Coordinator dashboard
 
+> **Partially landed** (ui-fleet-pane PR): the Fleet sidebar pane ships
+> read-only, reading `presence/<handle>.json` plus direct-inbox and
+> urgent-lane file counts via the new `list_fleet` Tauri command. Rows
+> are status-dot / handle / role / provenance / unread / urgent /
+> heartbeat-age; row-click raises the target session's window via the
+> existing `launch_session` focus path. Dashboard-mode expansion,
+> inbox/broadcast panes, the spawn timeline, and the quick-action
+> context menu remain separate PRs (§3.3 dashboard-mode, §3.5, §3.7).
+> Scoping: when the coordinator's session declares a `colab_group`, the
+> pane is scoped to that group; otherwise every handle is listed.
+
 Activates when the current session declares `role: coordinator` **and**
 at least one other session in the shared dir has a live
 `presence/<handle>.json`. Below that threshold, nothing changes in the

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -278,6 +278,13 @@ twapp msg presence list --stale
 twapp msg presence get worker-a
 ```
 
+If the coordinator is running inside a twapp window (role `coordinator`
+in `.twapp-session.json`), the same view is surfaced live in the
+sidebar's **Fleet** pane — one row per active handle with status dot,
+unread / urgent counts, and last-heartbeat age, refreshed every 5s.
+Click a row to raise that worker's twapp window. The CLI forms above
+remain the source of truth for scripting and terminals.
+
 Three liveness states the coordinator reasons about:
 
 - **processing / idle** — heartbeat within `5 × poll_interval_sec`. Alive.

--- a/src-tauri/src/gui/fleet.rs
+++ b/src-tauri/src/gui/fleet.rs
@@ -1,0 +1,466 @@
+//! `list_fleet` — coordinator fleet pane backend.
+//!
+//! Aggregates `<mailbox>/presence/<handle>.json`, inbox message counts, and
+//! session-directory metadata into one snapshot per active handle. Consumed by
+//! `src/components/FleetPane.tsx` on a 5s poll.
+//!
+//! Presence dormancy math lives in `cli::msg_presence::is_dormant`; this module
+//! only decorates those records with the per-handle inbox counts and with
+//! launcher-discovered metadata (provenance, colab_group, session directory)
+//! so row-clicks can raise the target window via `launch_session`.
+//!
+//! Scoping: when `colab_group` is `Some`, rows whose session file declares a
+//! different colab_group are excluded. Handles with no discoverable session
+//! file are kept (the presence record is authoritative for a handle's
+//! liveness; session-on-disk is a best-effort decoration).
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::cli::msg::{direct_dir, inbox_dir, resolve_mailbox_dir, urgent_dir};
+use crate::cli::msg_presence::{is_dormant, list_presence, PresenceFile, PresenceStatus};
+use crate::cli::session::{list_sessions, SessionData};
+
+/// One row in the coordinator fleet pane.
+///
+/// The status string is the presence-recorded status when the heartbeat is
+/// fresh, but flips to `"dormant"` when `is_dormant` says so regardless of what
+/// the file says (§2.6 derives dormancy; the file can lag behind the truth).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FleetAgent {
+    pub handle: String,
+    /// `"processing" | "idle" | "dormant"` — derived, not the raw file field.
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub colab_group: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_task: Option<String>,
+    /// RFC3339 timestamp from the presence file (pass-through).
+    pub last_heartbeat: String,
+    /// Age of last heartbeat in seconds relative to the server's now. `None`
+    /// when the stamp was unparseable.
+    pub last_heartbeat_age_sec: Option<i64>,
+    pub poll_interval_sec: u64,
+    pub dormant: bool,
+    /// Count of direct messages sitting in `inbox/direct/<handle>/`. Cursor-
+    /// aware unread math is out of scope for this PR — it's a file count.
+    pub unread_count: u64,
+    /// Count of urgent-lane messages: `inbox/urgent/<handle>/` plus
+    /// `inbox/urgent/all/`. Blocker-priority is folded in (the urgent lane
+    /// already holds both urgent and blocker symlinks per PR-4).
+    pub urgent_count: u64,
+    /// Session working directory, discovered by matching `name == handle`
+    /// among `list_sessions(work_directory)`. `None` when the handle has no
+    /// on-disk session (e.g. a spawned agent that hasn't written session
+    /// metadata yet, or a handle that lives purely in the mailbox).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub directory: Option<String>,
+}
+
+// --- Inbox counting ---------------------------------------------------------
+
+/// Count regular files under `dir`. Missing dir → 0. Subdirectories and dotfiles
+/// are skipped. Not recursive — the split-inbox layout is flat under each
+/// recipient directory (design §2.1).
+pub fn count_files_in(dir: &Path) -> u64 {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    rd.flatten()
+        .filter(|e| {
+            e.file_type().map(|t| t.is_file()).unwrap_or(false)
+                && !e
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with('.')
+        })
+        .count() as u64
+}
+
+/// Count direct-inbox messages for `handle`: `inbox/direct/<handle>/*`.
+pub fn count_direct(inbox: &Path, handle: &str) -> u64 {
+    count_files_in(&direct_dir(inbox).join(handle))
+}
+
+/// Count urgent-lane messages for `handle`: `inbox/urgent/<handle>/*` plus
+/// `inbox/urgent/all/*` (blocker/urgent broadcasts are landed in both per PR-4).
+pub fn count_urgent(inbox: &Path, handle: &str) -> u64 {
+    let urgent = urgent_dir(inbox);
+    count_files_in(&urgent.join(handle)) + count_files_in(&urgent.join("all"))
+}
+
+// --- Handle → session directory index ---------------------------------------
+
+/// Build a `handle → (session_dir, session_metadata)` index from the on-disk
+/// session scan so a fleet row can deep-link to its window. The launcher uses
+/// the same `list_sessions` helper — we reuse it to stay in lockstep with
+/// what the launcher considers a session.
+fn index_sessions_by_name(
+    work_directory: &Path,
+) -> HashMap<String, (PathBuf, SessionData)> {
+    let mut out = HashMap::new();
+    for (data, dir) in list_sessions(work_directory) {
+        out.insert(data.name.clone(), (dir, data));
+    }
+    out
+}
+
+// --- Build the row list -----------------------------------------------------
+
+/// Pure builder: presence records + inbox counter + session index + clock →
+/// FleetAgent rows. Split out so tests can feed mocked inputs without a Tauri
+/// State<'_, GuiArgs>.
+pub fn build_fleet_rows<F>(
+    presence: Vec<PresenceFile>,
+    mut count_inbox_for: F,
+    session_index: &HashMap<String, (PathBuf, SessionData)>,
+    colab_group_filter: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Vec<FleetAgent>
+where
+    F: FnMut(&str) -> (u64, u64),
+{
+    let mut rows: Vec<FleetAgent> = presence
+        .into_iter()
+        .filter_map(|p| {
+            let (directory, metadata) = match session_index.get(&p.handle) {
+                Some((dir, data)) => (Some(dir.to_string_lossy().to_string()), Some(data)),
+                None => (None, None),
+            };
+
+            // Scope filter: when a colab_group is requested, skip handles
+            // whose discoverable session declares a different group. Handles
+            // with no session (unknown group) are passed through — the
+            // presence record itself carries no colab_group field today, so
+            // filtering them out would mean a group=X coordinator loses
+            // visibility on any handle that hadn't written session metadata
+            // yet, which is the common case during spawn.
+            if let Some(want) = colab_group_filter {
+                if let Some(meta) = metadata {
+                    if let Some(have) = meta.colab_group.as_deref() {
+                        if have != want {
+                            return None;
+                        }
+                    }
+                }
+            }
+
+            let dormant = is_dormant(&p, now);
+            let status = if dormant {
+                "dormant".to_string()
+            } else {
+                match p.status {
+                    PresenceStatus::Processing => "processing".to_string(),
+                    PresenceStatus::Idle => "idle".to_string(),
+                    PresenceStatus::Dormant => "dormant".to_string(),
+                }
+            };
+
+            let last_heartbeat_age_sec =
+                chrono::DateTime::parse_from_rfc3339(&p.last_heartbeat)
+                    .ok()
+                    .map(|hb| (now - hb.with_timezone(&chrono::Utc)).num_seconds());
+
+            let (unread_count, urgent_count) = count_inbox_for(&p.handle);
+
+            let role = metadata.and_then(|m| m.role.clone());
+            let provenance = metadata.and_then(|m| m.provenance.clone());
+            let colab_group = metadata.and_then(|m| m.colab_group.clone());
+
+            Some(FleetAgent {
+                handle: p.handle,
+                status,
+                role,
+                provenance,
+                colab_group,
+                current_task: p.current_task,
+                last_heartbeat: p.last_heartbeat,
+                last_heartbeat_age_sec,
+                poll_interval_sec: p.poll_interval_sec,
+                dormant,
+                unread_count,
+                urgent_count,
+                directory,
+            })
+        })
+        .collect();
+
+    // Sort: urgent-first, then by unread desc, then by heartbeat age asc
+    // (freshest processing agents above stale ones). Matches §3.3:
+    // "urgent-first, then by-unread-count, then by-last-heartbeat".
+    rows.sort_by(|a, b| {
+        b.urgent_count
+            .cmp(&a.urgent_count)
+            .then(b.unread_count.cmp(&a.unread_count))
+            .then_with(|| match (a.last_heartbeat_age_sec, b.last_heartbeat_age_sec) {
+                (Some(x), Some(y)) => x.cmp(&y),
+                (Some(_), None) => std::cmp::Ordering::Less,
+                (None, Some(_)) => std::cmp::Ordering::Greater,
+                (None, None) => std::cmp::Ordering::Equal,
+            })
+            .then_with(|| a.handle.cmp(&b.handle))
+    });
+
+    rows
+}
+
+// --- Tauri command ----------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListFleetArgs {
+    /// Scope rows to this colab_group. When omitted, returns every handle.
+    pub colab_group: Option<String>,
+}
+
+#[tauri::command]
+pub fn list_fleet(args: ListFleetArgs) -> Result<Vec<FleetAgent>, String> {
+    let mailbox = resolve_mailbox_dir()?;
+    let inbox = inbox_dir()?;
+    let presence = list_presence(&mailbox);
+
+    // Session index is best-effort: if the global config can't load (e.g.
+    // brand-new install) we just have no directory decoration — the pane still
+    // renders from presence alone.
+    let session_index = match crate::cli::config::GlobalConfig::load() {
+        Ok(cfg) => index_sessions_by_name(&cfg.work_directory),
+        Err(_) => HashMap::new(),
+    };
+
+    let rows = build_fleet_rows(
+        presence,
+        |handle| (count_direct(&inbox, handle), count_urgent(&inbox, handle)),
+        &session_index,
+        args.colab_group.as_deref(),
+        chrono::Utc::now(),
+    );
+
+    Ok(rows)
+}
+
+// --- Tests ------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::msg_presence::{write_presence, DEFAULT_POLL_INTERVAL_SEC};
+    use crate::cli::session::AgentProvider;
+
+    fn rfc(secs_ago: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs_ago))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    }
+
+    fn presence_record(handle: &str, secs_ago: i64, status: PresenceStatus) -> PresenceFile {
+        PresenceFile {
+            handle: handle.to_string(),
+            status,
+            last_heartbeat: rfc(secs_ago),
+            current_task: Some(format!("working on {}", handle)),
+            inbox_cursor: None,
+            poll_interval_sec: DEFAULT_POLL_INTERVAL_SEC,
+            claims: Vec::new(),
+        }
+    }
+
+    fn session_data(name: &str, role: Option<&str>, group: Option<&str>) -> SessionData {
+        SessionData {
+            session_id: format!("id-{}", name),
+            name: name.to_string(),
+            color: String::new(),
+            ticket_key: None,
+            claude_cwd: String::new(),
+            created: String::new(),
+            last_resumed: None,
+            provider: Some(AgentProvider::Claude),
+            codex_session_id: None,
+            codex_cwd: None,
+            forked_from: None,
+            imported: None,
+            imported_from: None,
+            use_chrome: None,
+            override_terminal_theme: None,
+            role: role.map(String::from),
+            provenance: Some("spawned".to_string()),
+            colab_group: group.map(String::from),
+        }
+    }
+
+    #[test]
+    fn build_rows_passes_through_presence_and_inbox_counts() {
+        let now = chrono::Utc::now();
+        let presence = vec![presence_record("alpha", 5, PresenceStatus::Processing)];
+        let mut index = HashMap::new();
+        index.insert(
+            "alpha".to_string(),
+            (
+                PathBuf::from("/tmp/alpha"),
+                session_data("alpha", Some("implementer"), Some("grp-1")),
+            ),
+        );
+        let rows = build_fleet_rows(
+            presence,
+            |h| {
+                assert_eq!(h, "alpha");
+                (3, 1)
+            },
+            &index,
+            None,
+            now,
+        );
+        assert_eq!(rows.len(), 1);
+        let r = &rows[0];
+        assert_eq!(r.handle, "alpha");
+        assert_eq!(r.status, "processing");
+        assert_eq!(r.role.as_deref(), Some("implementer"));
+        assert_eq!(r.provenance.as_deref(), Some("spawned"));
+        assert_eq!(r.colab_group.as_deref(), Some("grp-1"));
+        assert_eq!(r.unread_count, 3);
+        assert_eq!(r.urgent_count, 1);
+        assert_eq!(r.directory.as_deref(), Some("/tmp/alpha"));
+        assert!(!r.dormant);
+        assert!(r.last_heartbeat_age_sec.unwrap() >= 4);
+    }
+
+    #[test]
+    fn build_rows_marks_dormant_when_heartbeat_stale() {
+        let now = chrono::Utc::now();
+        // interval default 90 → threshold 450s. 500s ago is dormant.
+        let presence = vec![presence_record("stale", 500, PresenceStatus::Processing)];
+        let rows = build_fleet_rows(presence, |_| (0, 0), &HashMap::new(), None, now);
+        assert_eq!(rows.len(), 1);
+        assert!(rows[0].dormant, "500s old with 90s interval should be dormant");
+        assert_eq!(rows[0].status, "dormant", "derived status flips regardless of file value");
+    }
+
+    #[test]
+    fn build_rows_filters_by_colab_group_when_set() {
+        let now = chrono::Utc::now();
+        let presence = vec![
+            presence_record("alpha", 10, PresenceStatus::Processing),
+            presence_record("beta", 10, PresenceStatus::Processing),
+            presence_record("ghost", 10, PresenceStatus::Processing),
+        ];
+        let mut index = HashMap::new();
+        index.insert(
+            "alpha".to_string(),
+            (PathBuf::from("/a"), session_data("alpha", None, Some("grp-a"))),
+        );
+        index.insert(
+            "beta".to_string(),
+            (PathBuf::from("/b"), session_data("beta", None, Some("grp-b"))),
+        );
+        // `ghost` has no session file → passes through the filter (see comment
+        // in build_fleet_rows for the reasoning).
+        let rows = build_fleet_rows(
+            presence,
+            |_| (0, 0),
+            &index,
+            Some("grp-a"),
+            now,
+        );
+        let handles: Vec<_> = rows.iter().map(|r| r.handle.as_str()).collect();
+        assert_eq!(
+            handles,
+            vec!["alpha", "ghost"],
+            "grp-a keeps alpha + unknown-group ghost, drops grp-b beta"
+        );
+    }
+
+    #[test]
+    fn build_rows_sorts_urgent_then_unread_then_freshness() {
+        let now = chrono::Utc::now();
+        let presence = vec![
+            presence_record("quiet-fresh", 5, PresenceStatus::Idle),
+            presence_record("loud-stale", 120, PresenceStatus::Processing),
+            presence_record("urgent-oldest", 180, PresenceStatus::Processing),
+        ];
+        let counts: HashMap<&str, (u64, u64)> = [
+            ("quiet-fresh", (0u64, 0u64)),
+            ("loud-stale", (5, 0)),
+            ("urgent-oldest", (0, 1)),
+        ]
+        .into_iter()
+        .collect();
+        let rows = build_fleet_rows(
+            presence,
+            |h| *counts.get(h).unwrap(),
+            &HashMap::new(),
+            None,
+            now,
+        );
+        let handles: Vec<_> = rows.iter().map(|r| r.handle.as_str()).collect();
+        assert_eq!(
+            handles,
+            vec!["urgent-oldest", "loud-stale", "quiet-fresh"],
+            "urgent wins, then unread, then freshness"
+        );
+    }
+
+    #[test]
+    fn count_files_in_counts_only_regular_files() {
+        let root = std::env::temp_dir()
+            .join(format!("twapp-fleet-count-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("a.md"), "x").unwrap();
+        std::fs::write(root.join("b.md"), "y").unwrap();
+        std::fs::write(root.join(".hidden"), "z").unwrap();
+        std::fs::create_dir_all(root.join("subdir")).unwrap();
+        assert_eq!(count_files_in(&root), 2);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn count_urgent_sums_handle_dir_and_all_dir() {
+        let root = std::env::temp_dir()
+            .join(format!("twapp-fleet-urgent-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(root.join("urgent/alpha")).unwrap();
+        std::fs::create_dir_all(root.join("urgent/all")).unwrap();
+        std::fs::write(root.join("urgent/alpha/m1.md"), "x").unwrap();
+        std::fs::write(root.join("urgent/alpha/m2.md"), "x").unwrap();
+        std::fs::write(root.join("urgent/all/b1.md"), "x").unwrap();
+
+        assert_eq!(count_urgent(&root, "alpha"), 3);
+        assert_eq!(count_urgent(&root, "beta"), 1, "beta only sees urgent/all");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn end_to_end_with_real_presence_dir() {
+        // Spin up a real mailbox and verify that write_presence → list_presence
+        // → build_fleet_rows produces the expected shape (no filesystem mocks
+        // between the presence writer and the fleet builder).
+        let mailbox = std::env::temp_dir()
+            .join(format!("twapp-fleet-e2e-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&mailbox).unwrap();
+
+        let file = PresenceFile {
+            handle: "worker-a".to_string(),
+            status: PresenceStatus::Processing,
+            last_heartbeat: rfc(10),
+            current_task: Some("rebasing".to_string()),
+            inbox_cursor: None,
+            poll_interval_sec: 60,
+            claims: vec!["channel:reviewers".to_string()],
+        };
+        write_presence(&mailbox, &file).unwrap();
+
+        let rows = build_fleet_rows(
+            list_presence(&mailbox),
+            |_| (0, 0),
+            &HashMap::new(),
+            None,
+            chrono::Utc::now(),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].handle, "worker-a");
+        assert_eq!(rows[0].current_task.as_deref(), Some("rebasing"));
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+}

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
 pub mod coordinator;
 pub mod files;
+pub mod fleet;
 pub mod monitor;
 pub mod msg;
 pub mod notes;
@@ -127,6 +128,7 @@ pub fn run(args: GuiArgs) {
             files::reveal_in_finder,
             msg::send_message,
             msg::fetch_messages,
+            fleet::list_fleet,
             coordinator::launch_coordinator,
             coordinator::claim_coordinator,
             coordinator::list_claimable_sessions,

--- a/src/App.css
+++ b/src/App.css
@@ -4790,3 +4790,207 @@ a.file-link {
   color: var(--text-primary);
   flex: 1;
 }
+
+/* Coordinator fleet pane (sidebar) */
+.fleet-panel {
+  border-top: 1px solid var(--border-color);
+  border-bottom: 1px solid var(--border-color);
+  padding: 8px 12px 6px;
+  background: var(--bg-primary);
+}
+
+.fleet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.fleet-header h2 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.fleet-title {
+  font-weight: 600;
+}
+
+.fleet-summary {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 6px;
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.fleet-summary-urgent {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.fleet-body {
+  margin-top: 6px;
+}
+
+.fleet-empty {
+  padding: 8px 0 2px;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.fleet-error {
+  padding: 6px 8px;
+  background: rgba(220, 38, 38, 0.10);
+  border: 1px solid rgba(220, 38, 38, 0.45);
+  color: #b91c1c;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.fleet-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.fleet-row {
+  padding: 5px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.fleet-row-clickable {
+  cursor: pointer;
+}
+
+.fleet-row-clickable:hover {
+  border-color: var(--text-muted);
+  background: var(--bg-primary);
+}
+
+.fleet-row-dormant {
+  opacity: 0.65;
+}
+
+.fleet-row-urgent {
+  border-color: rgba(220, 38, 38, 0.55);
+  background: rgba(220, 38, 38, 0.05);
+}
+
+.fleet-row-top {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: nowrap;
+}
+
+.fleet-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: inline-block;
+}
+
+.fleet-dot-processing {
+  background: #16a34a;
+}
+
+.fleet-dot-idle {
+  background: transparent;
+  border: 1.5px solid #64748b;
+}
+
+.fleet-dot-dormant {
+  background: var(--text-muted);
+  opacity: 0.6;
+}
+
+.fleet-handle {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  flex-shrink: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fleet-role-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: lowercase;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.fleet-provenance {
+  font-size: 11px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.fleet-counts {
+  display: inline-flex;
+  gap: 3px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.fleet-count-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  min-width: 18px;
+  justify-content: center;
+}
+
+.fleet-count-chip.fleet-unread {
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.fleet-age {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.fleet-task {
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,7 @@ import type { EditingPromptState } from "./components/PromptSections";
 import SessionLauncher from "./components/SessionLauncher";
 import MessageComposer from "./components/MessageComposer";
 import UrgentInbox from "./components/UrgentInbox";
+import FleetPane from "./components/FleetPane";
 
 
 const SESSION_COLORS = [
@@ -62,6 +63,11 @@ function App() {
   const [ticketExpanded, setTicketExpanded] = useState(false);
   const [ticketSectionExpanded, setTicketSectionExpanded] = useState(false);
   const [appConfig, setAppConfig] = useState<AppConfig | null>(null);
+  // Role + colab_group are not in AppConfig — they live in the session file and
+  // the fleet pane gates on them. Loaded alongside get_app_config at boot and
+  // refreshed after session-field edits that touch these values.
+  const [sessionRole, setSessionRole] = useState<string | null>(null);
+  const [sessionColabGroup, setSessionColabGroup] = useState<string | null>(null);
 
   // Ticket linking state
   const [linkTicketKey, setLinkTicketKey] = useState("");
@@ -563,6 +569,16 @@ function App() {
       if (config.name && config.name !== "twapp") {
         setTabs((prev) => prev.map((t) => t.id === "main" ? { ...t, name: config.name } : t));
       }
+
+      // Role + colab_group drive the coordinator fleet pane. Silent on failure —
+      // a missing/unparseable session file just means "no fleet pane here".
+      invoke<Record<string, unknown> | null>("get_session_info").then((data) => {
+        if (!data) return;
+        const role = typeof data.role === "string" ? data.role : null;
+        const group = typeof data.colab_group === "string" ? data.colab_group : null;
+        setSessionRole(role);
+        setSessionColabGroup(group);
+      }).catch(() => {});
 
       // Launcher mode — don't spawn shell or initialize terminal peripherals
       if (!config.command && !config.session_id) {
@@ -2373,6 +2389,12 @@ function App() {
             </div>
           </div>
         )}
+
+        {/* Coordinator fleet pane — renders only when role === "coordinator". */}
+        <FleetPane
+          isCoordinator={sessionRole === "coordinator"}
+          colabGroup={sessionColabGroup}
+        />
 
         {/* Urgent messages panel — renders only when session has a handle. */}
         <UrgentInbox selfHandle={appConfig?.name && appConfig.name !== "twapp" ? appConfig.name : null} />

--- a/src/components/FleetPane.test.ts
+++ b/src/components/FleetPane.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatAge,
+  summarize,
+  statusDotClass,
+  truncateTask,
+  type FleetAgent,
+} from "./FleetPane";
+
+const agent = (o: Partial<FleetAgent> & { handle: string }): FleetAgent => ({
+  status: "processing",
+  last_heartbeat: "2026-04-21T12:00:00Z",
+  last_heartbeat_age_sec: 5,
+  poll_interval_sec: 90,
+  dormant: false,
+  unread_count: 0,
+  urgent_count: 0,
+  ...o,
+});
+
+describe("formatAge", () => {
+  it("formats seconds / minutes / hours / days", () => {
+    expect(formatAge(5)).toBe("5s ago");
+    expect(formatAge(65)).toBe("1m ago");
+    expect(formatAge(3600)).toBe("1h ago");
+    expect(formatAge(86400 * 2)).toBe("2d ago");
+  });
+
+  it("clamps negative and null", () => {
+    expect(formatAge(-10)).toBe("0s ago");
+    expect(formatAge(null)).toBe("—");
+    expect(formatAge(undefined)).toBe("—");
+    expect(formatAge(Number.NaN)).toBe("—");
+  });
+});
+
+describe("summarize", () => {
+  it("counts total / active / dormant / urgent", () => {
+    const s = summarize([
+      agent({ handle: "a" }),
+      agent({ handle: "b", dormant: true }),
+      agent({ handle: "c", urgent_count: 2 }),
+      agent({ handle: "d", dormant: true, urgent_count: 1 }),
+    ]);
+    expect(s).toEqual({ total: 4, active: 2, dormant: 2, urgent: 2 });
+  });
+
+  it("returns zeroes for empty fleet", () => {
+    expect(summarize([])).toEqual({ total: 0, active: 0, dormant: 0, urgent: 0 });
+  });
+});
+
+describe("statusDotClass", () => {
+  it("routes by derived status", () => {
+    expect(statusDotClass(agent({ handle: "a", status: "processing" }))).toContain("fleet-dot-processing");
+    expect(statusDotClass(agent({ handle: "a", status: "idle" }))).toContain("fleet-dot-idle");
+    expect(statusDotClass(agent({ handle: "a", status: "dormant" }))).toContain("fleet-dot-dormant");
+  });
+
+  it("dormant overrides a stale processing status", () => {
+    // The Rust builder already does this flip, but guard the UI against a
+    // hand-crafted response that left status=processing with dormant=true.
+    expect(
+      statusDotClass(agent({ handle: "a", status: "processing", dormant: true })),
+    ).toContain("fleet-dot-dormant");
+  });
+});
+
+describe("truncateTask", () => {
+  it("returns trimmed string when under the cap", () => {
+    expect(truncateTask("  rebasing onto main  ")).toBe("rebasing onto main");
+  });
+
+  it("appends ellipsis when over the cap", () => {
+    const long = "x".repeat(100);
+    const out = truncateTask(long, 20);
+    expect(out).toHaveLength(20);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("handles null / empty", () => {
+    expect(truncateTask(null)).toBe("");
+    expect(truncateTask(undefined)).toBe("");
+    expect(truncateTask("   ")).toBe("");
+  });
+});

--- a/src/components/FleetPane.tsx
+++ b/src/components/FleetPane.tsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export type FleetAgent = {
+  handle: string;
+  status: string;
+  role?: string | null;
+  provenance?: string | null;
+  colab_group?: string | null;
+  current_task?: string | null;
+  last_heartbeat: string;
+  last_heartbeat_age_sec?: number | null;
+  poll_interval_sec: number;
+  dormant: boolean;
+  unread_count: number;
+  urgent_count: number;
+  directory?: string | null;
+};
+
+type FleetPaneProps = {
+  /** True when the current session has role === "coordinator" — pane is hidden otherwise. */
+  isCoordinator: boolean;
+  /** If non-null, scope the fleet to this colab_group. */
+  colabGroup?: string | null;
+  /** Injected in tests; defaults to the Tauri invoke bridge. */
+  fetcher?: (args: { colabGroup?: string | null }) => Promise<FleetAgent[]>;
+  /** Called when the user clicks a row. Defaults to the Tauri launch_session bridge. */
+  opener?: (agent: FleetAgent) => Promise<void>;
+  /** Poll interval while visible. 5s per briefing. */
+  pollMs?: number;
+};
+
+const tauriFetcher = (args: { colabGroup?: string | null }): Promise<FleetAgent[]> =>
+  invoke<FleetAgent[]>("list_fleet", { args: { colabGroup: args.colabGroup ?? null } });
+
+const tauriOpener = async (agent: FleetAgent): Promise<void> => {
+  if (!agent.directory) return;
+  await invoke("launch_session", { sessionId: "", directory: agent.directory });
+};
+
+/** Format heartbeat age. `null` / unknown → "—". Caps at days. */
+export function formatAge(ageSec: number | null | undefined): string {
+  if (ageSec === null || ageSec === undefined || Number.isNaN(ageSec)) return "—";
+  const s = Math.max(0, Math.floor(ageSec));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+/** Summary counts used by the collapsed header. */
+export function summarize(agents: FleetAgent[]): {
+  total: number;
+  active: number;
+  dormant: number;
+  urgent: number;
+} {
+  const total = agents.length;
+  let dormant = 0;
+  let urgent = 0;
+  for (const a of agents) {
+    if (a.dormant) dormant += 1;
+    if (a.urgent_count > 0) urgent += 1;
+  }
+  return { total, active: total - dormant, dormant, urgent };
+}
+
+/** Pick a status-dot CSS class from the agent's derived status. */
+export function statusDotClass(a: FleetAgent): string {
+  if (a.dormant) return "fleet-dot fleet-dot-dormant";
+  switch (a.status) {
+    case "processing":
+      return "fleet-dot fleet-dot-processing";
+    case "idle":
+      return "fleet-dot fleet-dot-idle";
+    default:
+      return "fleet-dot fleet-dot-dormant";
+  }
+}
+
+/** Truncate a current_task line for dense rows. Never hard-breaks a token mid-run. */
+export function truncateTask(task: string | null | undefined, max = 80): string {
+  if (!task) return "";
+  const trimmed = task.trim();
+  if (trimmed.length <= max) return trimmed;
+  return trimmed.slice(0, max - 1) + "…";
+}
+
+/** Coordinator fleet pane — collapsible sidebar section that lists every
+ *  handle with a live `presence/<handle>.json`. Polls `list_fleet` every 5s
+ *  while expanded; hidden entirely for non-coordinators so single-session
+ *  users and regular workers see no new chrome. */
+export default function FleetPane({
+  isCoordinator,
+  colabGroup = null,
+  fetcher = tauriFetcher,
+  opener = tauriOpener,
+  pollMs = 5_000,
+}: FleetPaneProps) {
+  const [agents, setAgents] = useState<FleetAgent[]>([]);
+  const [expanded, setExpanded] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  const fetchSeqRef = useRef(0);
+
+  const doFetch = useCallback(async () => {
+    const seq = ++fetchSeqRef.current;
+    try {
+      const result = await fetcher({ colabGroup });
+      if (seq !== fetchSeqRef.current) return;
+      setAgents(result || []);
+      setError(null);
+      setLoaded(true);
+    } catch (e) {
+      if (seq !== fetchSeqRef.current) return;
+      setError(String(e));
+      setLoaded(true);
+    }
+  }, [fetcher, colabGroup]);
+
+  useEffect(() => {
+    if (!isCoordinator) return;
+    doFetch();
+    const h = window.setInterval(doFetch, pollMs);
+    return () => window.clearInterval(h);
+  }, [isCoordinator, doFetch, pollMs]);
+
+  const summary = useMemo(() => summarize(agents), [agents]);
+
+  if (!isCoordinator) return null;
+
+  const handleRowClick = async (a: FleetAgent) => {
+    if (!a.directory) return;
+    try {
+      await opener(a);
+    } catch (e) {
+      setError(`Failed to open ${a.handle}: ${e}`);
+    }
+  };
+
+  return (
+    <div className="fleet-panel">
+      <div
+        className="fleet-header"
+        onClick={() => setExpanded((v) => !v)}
+        role="button"
+        aria-expanded={expanded}
+      >
+        <h2>
+          <span className={`prompt-chevron ${expanded ? "expanded" : ""}`}>&#9654;</span>
+          <span className="fleet-title">Fleet</span>
+          {loaded && (
+            <span className="fleet-summary">
+              <span className="fleet-summary-active" title="processing + idle">
+                {summary.active} active
+              </span>
+              {summary.dormant > 0 && (
+                <span className="fleet-summary-dormant" title="dormant">
+                  · {summary.dormant} dormant
+                </span>
+              )}
+              {summary.urgent > 0 && (
+                <span className="fleet-summary-urgent" title="agents with urgent mail">
+                  · {summary.urgent} urgent
+                </span>
+              )}
+            </span>
+          )}
+        </h2>
+        <button
+          className="section-refresh-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            doFetch();
+          }}
+          title="Refresh fleet"
+        >
+          &#8635;
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="fleet-body">
+          {error && <div className="fleet-error">{error}</div>}
+          {!error && loaded && agents.length === 0 && (
+            <div className="fleet-empty">No workers online.</div>
+          )}
+          {!error && agents.length > 0 && (
+            <ul className="fleet-list" role="list">
+              {agents.map((a) => (
+                <li
+                  key={a.handle}
+                  className={`fleet-row${a.dormant ? " fleet-row-dormant" : ""}${
+                    a.urgent_count > 0 ? " fleet-row-urgent" : ""
+                  }${a.directory ? " fleet-row-clickable" : ""}`}
+                  onClick={() => handleRowClick(a)}
+                  role={a.directory ? "button" : undefined}
+                  title={
+                    a.directory
+                      ? `Open ${a.handle}'s window`
+                      : `${a.handle} — no on-disk session yet`
+                  }
+                >
+                  <div className="fleet-row-top">
+                    <span className={statusDotClass(a)} aria-hidden="true" />
+                    <span className="fleet-handle">{a.handle}</span>
+                    {a.role && (
+                      <span className="fleet-role-chip" title={`role: ${a.role}`}>
+                        {a.role}
+                      </span>
+                    )}
+                    {a.provenance === "spawned" && (
+                      <span
+                        className="fleet-provenance"
+                        title="spawned by another session"
+                        aria-label="spawned"
+                      >
+                        &#9656;
+                      </span>
+                    )}
+                    {a.provenance === "user" && (
+                      <span
+                        className="fleet-provenance"
+                        title="user-created"
+                        aria-label="user-created"
+                      >
+                        &#9702;
+                      </span>
+                    )}
+                    <span className="fleet-counts">
+                      {a.urgent_count > 0 && (
+                        <span
+                          className="priority-chip priority-urgent fleet-count-chip"
+                          title={`${a.urgent_count} urgent`}
+                        >
+                          {a.urgent_count}!
+                        </span>
+                      )}
+                      {a.unread_count > 0 && (
+                        <span className="fleet-count-chip fleet-unread" title={`${a.unread_count} unread`}>
+                          {a.unread_count}
+                        </span>
+                      )}
+                    </span>
+                    <span className="fleet-age" title={a.last_heartbeat}>
+                      {formatAge(a.last_heartbeat_age_sec)}
+                    </span>
+                  </div>
+                  {a.current_task && (
+                    <div className="fleet-task">{truncateTask(a.current_task)}</div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- New sidebar **Fleet** pane that activates when the session declares `role: "coordinator"`. Lists every handle with a live `<mailbox>/presence/<handle>.json`, with status dot, role/provenance chips, unread + urgent counts, heartbeat age, and truncated `current_task`. Polls `list_fleet` every 5s; row-click raises the target twapp window via the existing `launch_session` focus path.
- New `list_fleet` Tauri command in `src-tauri/src/gui/fleet.rs` that reads presence files, counts `inbox/direct/<handle>/` + `inbox/urgent/<handle>/` + `inbox/urgent/all/`, decorates each row with the launcher's session-on-disk metadata, and (optionally) scopes to a `colab_group`.
- Implements design §3.3 (read-only fleet pane item from the roadmap in §5 item 3). Dashboard-mode expansion, inbox/broadcast panes, spawn timeline, and quick-action context menu remain separate wave-3 PRs per the design doc.

## What lands

- `src-tauri/src/gui/fleet.rs` — `list_fleet` command + pure `build_fleet_rows` builder + `count_files_in` / `count_direct` / `count_urgent` helpers. 7 unit tests, no new deps.
- `src/components/FleetPane.tsx` — collapsible sidebar panel with status dots, role chips, provenance glyphs, urgent/unread chips, heartbeat age, and clickable rows. Hidden for non-coordinators.
- `src/components/FleetPane.test.ts` — 9 vitest tests for the pure helpers (age formatter, summarizer, dot routing, task truncation).
- `src/App.tsx` — loads `role` + `colab_group` from `get_session_info` at boot and renders `FleetPane` above `UrgentInbox`.
- `src/App.css` — fleet pane styles (dots, chips, row states, dormant opacity).
- Docs: `docs/designs/agent-aware-ui.md` §3.3 marked partially landed; `README.md` gains a "Coordinator fleet pane" subsection; `skills/agent-coordinator/SKILL.md` notes the UI pane alongside `twapp msg presence list`.

## Out of scope (per briefing + §3.3 notes)

- Dashboard-mode toggle that collapses the terminal.
- Inbox / Broadcast panes inside the dashboard.
- Spawn / offboard timeline.
- Quick-action context menu (open window / stop agent / send urgent / …).
- Cross-group view.

## Test plan

- [x] `cargo test --lib` — 239/239 pass (7 new fleet tests + unchanged suite).
- [x] `cargo clippy --lib` — no new warnings attributable to this change.
- [x] `npx vitest run` — 136/136 pass (9 new FleetPane tests + unchanged suite).
- [x] `npm run build` (tsc + vite) — clean.
- [ ] Manual smoke: coordinator with live workers → rows render sorted urgent-first; a dormant worker collapses to muted dot; row-click raises the worker's window. (Deferred: no active coordinator fleet to point this build at; the test suites cover the shape.)

## Dependency note

Messaging PR-5 (`feat(msg): presence / heartbeat`, #61) is the prerequisite and has merged. Automating heartbeats inside the `/loop` skill is a separate follow-up per the PR-5 offboard notes — until that lands, presence files are only present when an agent manually runs `twapp msg presence heartbeat`, so the pane legitimately shows "No workers online" in most repos today.