### PR TITLE
feat(ui): coordinator spawn/teardown timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,31 @@ and worker UX are byte-unchanged). The backend lives in
 side in [`src/components/FleetPane.tsx`](src/components/FleetPane.tsx),
 both with unit tests.
 
+### Spawn / teardown timeline
+
+Directly below the fleet pane, coordinator sessions see a **Timeline**
+panel that lists spawn, claim, reclaim, release, offboard, and dead
+events for the co-lab, newest-first. Polls the `list_timeline_events`
+Tauri command every 30 seconds and defaults to the last 7 days; a
+*Load more* button extends the window 7 days further back per click.
+A free-text filter narrows rows to handles matching a substring.
+
+Events are aggregated from:
+
+- **Spawn** — `SessionData.created` for each `.twapp-session.json`
+  under the global work directory (scoped by `colab_group` when set).
+- **Claim / reclaim / release** — `<mailbox>/claims/<lane-id>/owner.json`
+  and `released.json`, plus the `.released-<ts>/` archived dirs from
+  repeat claims. Structural records from the lane-claim primitive
+  (§1.4 of [`worker-coordination.md`](docs/designs/worker-coordination.md)).
+- **Offboard** — `to: [all]` broadcasts whose subject or body contains
+  "offboard" (case-insensitive).
+- **Dead** — presence handles whose `last_heartbeat` is older than
+  `15 × poll_interval_sec` (3× the dormant threshold).
+
+Backend: [`src-tauri/src/gui/timeline.rs`](src-tauri/src/gui/timeline.rs).
+Frontend: [`src/components/TimelinePane.tsx`](src/components/TimelinePane.tsx).
+
 ### Spawning a worker agent
 
 twapp works well as a terminal wrapper for *interactive* sessions, but

--- a/docs/designs/agent-aware-ui.md
+++ b/docs/designs/agent-aware-ui.md
@@ -288,11 +288,21 @@ heartbeat loop.
 > urgent-lane file counts via the new `list_fleet` Tauri command. Rows
 > are status-dot / handle / role / provenance / unread / urgent /
 > heartbeat-age; row-click raises the target session's window via the
-> existing `launch_session` focus path. Dashboard-mode expansion,
-> inbox/broadcast panes, the spawn timeline, and the quick-action
-> context menu remain separate PRs (§3.3 dashboard-mode, §3.5, §3.7).
-> Scoping: when the coordinator's session declares a `colab_group`, the
-> pane is scoped to that group; otherwise every handle is listed.
+> existing `launch_session` focus path. Dashboard-mode expansion and
+> the inbox/broadcast panes remain separate PRs (§3.3 dashboard-mode,
+> §3.5). Scoping: when the coordinator's session declares a
+> `colab_group`, the pane is scoped to that group; otherwise every
+> handle is listed.
+>
+> **Additionally landed** (ui-spawn-timeline PR): the spawn/teardown
+> timeline strip is now a sibling panel under the fleet pane. Backend
+> `list_timeline_events` aggregates spawn events (session-metadata
+> `created`), claim/reclaim/release events (from `<mailbox>/claims/`
+> and its `.released-*` archives), offboard broadcasts (`to: [all]`
+> messages whose subject or body contains "offboard"), and dead events
+> (presence heartbeat older than 15× `poll_interval_sec`). Frontend
+> polls every 30s, filters by handle, and paginates older events by
+> walking `beforeTs` backward 7 days per click.
 
 Activates when the current session declares `role: coordinator` **and**
 at least one other session in the shared dir has a live
@@ -365,9 +375,17 @@ the terminal is the right shape.
   not a direct recipient. This is the only cross-agent peek the
   dashboard does, because "a blocker anywhere in the fleet" is load-
   bearing for the coordinator.
-- **Spawn timeline** — horizontal strip below the panes, one tick per
-  spawn / offboard event in the last 2 hours. Hover = briefing title,
-  exit reason, duration. See §3.7 on the event-log dependency.
+- **Spawn timeline** — chronological list below the fleet pane
+  (ui-spawn-timeline PR). One row per spawn / claim / reclaim / release
+  / offboard / dead event, newest first, default window of 7 days with
+  a *Load more* paginator that extends 7 days back per click. Each row
+  shows a ts chip, a kind chip (styled per kind via
+  `.timeline-chip-{spawn,claim,reclaim,release,offboard,dead}`), the
+  handle, and a one-line description. A free-text handle filter
+  narrows the list without re-fetching. The originally-sketched
+  horizontal strip with hover tooltips is deferred — the list shape
+  fits the sidebar-column layout more naturally and lines up with the
+  fleet pane's vocabulary.
 
 In sidebar-only (non-expanded) mode, only the fleet pane summary
 (`6 active · 1 urgent`) is visible, and it deep-links to the full

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -11,6 +11,7 @@ pub mod pty;
 pub mod sessions;
 pub mod shell_env;
 pub mod tickets;
+pub mod timeline;
 pub mod title;
 pub mod types;
 
@@ -130,6 +131,7 @@ pub fn run(args: GuiArgs) {
             msg::send_message,
             msg::fetch_messages,
             fleet::list_fleet,
+            timeline::list_timeline_events,
             agent_actions::focus_agent_window,
             agent_actions::stop_agent,
             agent_actions::list_agent_prs,

--- a/src-tauri/src/gui/timeline.rs
+++ b/src-tauri/src/gui/timeline.rs
@@ -1,0 +1,902 @@
+//! `list_timeline_events` — coordinator spawn/teardown timeline backend.
+//!
+//! Aggregates spawn / claim / release / offboard / dead events for the
+//! coordinator dashboard's spawn-history panel (design §3.3, timeline row).
+//! Consumed by `src/components/TimelinePane.tsx` on a 30s poll.
+//!
+//! Sources of truth:
+//! - **Spawn**: `SessionData.created` for each `.twapp-session.json` under
+//!   the global work directory. The presence file's first-write is not
+//!   tracked (files are overwritten in place per §2.6), so session metadata
+//!   is the authoritative spawn timestamp.
+//! - **Claim / Release**: `<mailbox>/claims/<lane-id>/owner.json` and
+//!   `released.json`, plus the `<lane-id>.released-<ts>/` archive entries
+//!   that accumulate across repeat claims. This is the structural,
+//!   authoritative record; broadcasts are a shadow (design §1.4).
+//! - **Offboard**: `to: [all]` broadcasts whose subject contains "offboard"
+//!   (free-form — the design doesn't prescribe a subject yet; we match
+//!   substring, case-insensitive, so both "offboard" and "offboarding …"
+//!   are caught).
+//! - **Dead**: presence file exists but `is_dormant` is true past a
+//!   3× multiplier of the normal dormant threshold (i.e. 15× poll_interval).
+//!   A handle whose presence file is simply missing is *not* reported —
+//!   per §2.6 an absent file means "never started or fully offboarded",
+//!   which we can't distinguish at scan time.
+//!
+//! All events are sorted newest-first. Callers pass a `since_ts` lower
+//! bound (default: 7 days ago) and a `before_ts` upper bound for
+//! pagination; events strictly after `since_ts` and strictly before
+//! `before_ts` are returned.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::cli::msg::{parse_message_file, resolve_mailbox_dir};
+use crate::cli::msg_claim::{ClaimOwner, ClaimRelease};
+use crate::cli::msg_presence::{list_presence, PresenceFile};
+use crate::cli::session::list_sessions;
+
+// --- Event model -----------------------------------------------------------
+
+/// One row in the coordinator timeline. `ts` is RFC3339 UTC; `kind` is a
+/// lowercase string so the frontend can drive chip styling by class name
+/// (`timeline-event-{kind}`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TimelineEvent {
+    /// RFC3339 UTC (e.g. `2026-04-20T23:02:00Z`). Pass-through from the
+    /// source file where possible; derived from `now()` for `Dead`.
+    pub ts: String,
+    /// Handle the event is about. "unknown" when we can't derive one
+    /// (keeps rows renderable rather than silently dropped).
+    pub handle: String,
+    /// `"spawn" | "claim" | "reclaim" | "release" | "offboard" | "dead"`.
+    pub kind: String,
+    /// One-line human-readable summary for the row body.
+    pub description: String,
+    /// Present for `claim`, `reclaim`, `release` events. Lets the UI
+    /// cluster events by lane on hover.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lane_id: Option<String>,
+}
+
+impl TimelineEvent {
+    fn spawn(ts: String, handle: String, description: String) -> Self {
+        Self {
+            ts,
+            handle,
+            kind: "spawn".to_string(),
+            description,
+            lane_id: None,
+        }
+    }
+
+    fn claim(ts: String, handle: String, lane_id: String, note: Option<&str>) -> Self {
+        let description = match note {
+            Some(n) if !n.is_empty() => format!("claimed {} — {}", lane_id, n),
+            _ => format!("claimed {}", lane_id),
+        };
+        Self {
+            ts,
+            handle,
+            kind: "claim".to_string(),
+            description,
+            lane_id: Some(lane_id),
+        }
+    }
+
+    fn reclaim(
+        ts: String,
+        handle: String,
+        lane_id: String,
+        previous_owner: &str,
+        note: Option<&str>,
+    ) -> Self {
+        let description = match note {
+            Some(n) if !n.is_empty() => {
+                format!("reclaimed {} from stale owner {} — {}", lane_id, previous_owner, n)
+            }
+            _ => format!("reclaimed {} from stale owner {}", lane_id, previous_owner),
+        };
+        Self {
+            ts,
+            handle,
+            kind: "reclaim".to_string(),
+            description,
+            lane_id: Some(lane_id),
+        }
+    }
+
+    fn release(ts: String, handle: String, lane_id: String, note: Option<&str>) -> Self {
+        let description = match note {
+            Some(n) if !n.is_empty() => format!("released {} — {}", lane_id, n),
+            _ => format!("released {}", lane_id),
+        };
+        Self {
+            ts,
+            handle,
+            kind: "release".to_string(),
+            description,
+            lane_id: Some(lane_id),
+        }
+    }
+
+    fn offboard(ts: String, handle: String, subject: &str) -> Self {
+        Self {
+            ts,
+            handle,
+            kind: "offboard".to_string(),
+            description: subject.to_string(),
+            lane_id: None,
+        }
+    }
+
+    fn dead(ts: String, handle: String, age_sec: i64) -> Self {
+        Self {
+            ts,
+            handle: handle.clone(),
+            kind: "dead".to_string(),
+            description: format!("{} has not heartbeat in {}s (past dead threshold)", handle, age_sec),
+            lane_id: None,
+        }
+    }
+}
+
+// --- Timestamp helpers -----------------------------------------------------
+
+/// Parse RFC3339 with `Z` or offset. Returns `None` on unparseable.
+pub fn parse_rfc3339(ts: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    chrono::DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|t| t.with_timezone(&chrono::Utc))
+}
+
+fn ts_in_range(
+    ts: &str,
+    since: chrono::DateTime<chrono::Utc>,
+    before: Option<chrono::DateTime<chrono::Utc>>,
+) -> bool {
+    let Some(parsed) = parse_rfc3339(ts) else {
+        return false;
+    };
+    if parsed < since {
+        return false;
+    }
+    if let Some(b) = before {
+        if parsed >= b {
+            return false;
+        }
+    }
+    true
+}
+
+// --- Spawn scanner ---------------------------------------------------------
+
+/// Emit one `Spawn` event per session file with a parseable `created`.
+/// `colab_group_filter` scopes to a single group when set; otherwise every
+/// session is included.
+pub fn scan_spawn_events(
+    work_dir: &Path,
+    colab_group_filter: Option<&str>,
+) -> Vec<TimelineEvent> {
+    let mut out = Vec::new();
+    for (data, _dir) in list_sessions(work_dir) {
+        if data.created.trim().is_empty() {
+            continue;
+        }
+        if let Some(want) = colab_group_filter {
+            if let Some(have) = data.colab_group.as_deref() {
+                if have != want {
+                    continue;
+                }
+            } else {
+                // No colab_group on the session: include only when there is
+                // no filter, i.e. never skip here. When filter is set we
+                // treat unknown-group sessions conservatively as in-scope,
+                // matching `build_fleet_rows`' reasoning in `gui/fleet.rs`
+                // (a just-spawned session may not have written its group
+                // yet).
+            }
+        }
+        let description = match (data.role.as_deref(), data.provenance.as_deref()) {
+            (Some(role), Some(prov)) => format!("spawned — role {} · {}", role, prov),
+            (Some(role), None) => format!("spawned — role {}", role),
+            (None, Some(prov)) => format!("spawned — {}", prov),
+            _ => "spawned".to_string(),
+        };
+        out.push(TimelineEvent::spawn(data.created, data.name, description));
+    }
+    out
+}
+
+// --- Claim / release scanner ----------------------------------------------
+
+/// Walk `mailbox/claims/` and its `<lane-id>.released-<ts>/` archive dirs,
+/// emitting one Claim / Reclaim / Release event per observed file. The
+/// same dir can yield up to three events (claim, reclaim, release) when a
+/// lane was reclaimed from a stale owner and then released cleanly.
+pub fn scan_claim_events(mailbox: &Path) -> Vec<TimelineEvent> {
+    let claims = mailbox.join("claims");
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&claims) else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        // Strip `.released-<ts>[ -<suffix>]` to recover the original lane id.
+        // Archived dirs are named `<lane-id>.released-<claimed_slug>` (see
+        // `archive_released_dir` in `msg_claim`); the original lane id never
+        // contains `.released-` because lane ids disallow `/`, and `.` is
+        // only legal inside a lane id via `validate_lane_id`.
+        let lane_id = name.split(".released-").next().unwrap_or(name).to_string();
+
+        if let Some(owner) = read_owner(&path) {
+            if let Some(prev) = owner.reclaimed_from.as_deref() {
+                out.push(TimelineEvent::reclaim(
+                    owner.claimed_at.clone(),
+                    owner.owner.clone(),
+                    lane_id.clone(),
+                    prev,
+                    owner.note.as_deref(),
+                ));
+            } else {
+                out.push(TimelineEvent::claim(
+                    owner.claimed_at.clone(),
+                    owner.owner.clone(),
+                    lane_id.clone(),
+                    owner.note.as_deref(),
+                ));
+            }
+        }
+        if let Some(rel) = read_release(&path) {
+            out.push(TimelineEvent::release(
+                rel.released_at,
+                rel.released_by,
+                lane_id,
+                rel.note.as_deref(),
+            ));
+        }
+    }
+    out
+}
+
+fn read_owner(lane_dir: &Path) -> Option<ClaimOwner> {
+    let s = std::fs::read_to_string(lane_dir.join("owner.json")).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+fn read_release(lane_dir: &Path) -> Option<ClaimRelease> {
+    let s = std::fs::read_to_string(lane_dir.join("released.json")).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+// --- Offboard scanner ------------------------------------------------------
+
+/// Scan recent broadcasts for offboard markers. We check three paths:
+///   - `inbox/broadcast/` (PR-3 split, current)
+///   - `archive/` flat (pre-rotation) and `archive/<YYYY-MM-DD>/broadcast/`
+///     (post-rotation, PR-7)
+/// We match any broadcast whose subject or body contains "offboard"
+/// (case-insensitive). `from` becomes the handle.
+pub fn scan_offboard_events(
+    mailbox: &Path,
+    since: chrono::DateTime<chrono::Utc>,
+) -> Vec<TimelineEvent> {
+    let mut out = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    let mut roots: Vec<PathBuf> = Vec::new();
+    let inbox = mailbox.join("inbox");
+    roots.push(inbox.join("broadcast"));
+    let archive = mailbox.join("archive");
+    roots.push(archive.clone());
+
+    for root in &roots {
+        walk_md_files(root, &mut |path| {
+            let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+            if !name.ends_with(".md") {
+                return;
+            }
+            // Dedup by absolute path — the same message may appear via a
+            // legacy symlink and the canonical file.
+            let key = std::fs::canonicalize(path)
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| path.to_string_lossy().to_string());
+            if !seen.insert(key) {
+                return;
+            }
+            let Some(msg) = parse_message_file(path) else {
+                return;
+            };
+            let is_broadcast = msg.fm.to.iter().any(|t| t == "all");
+            if !is_broadcast {
+                return;
+            }
+            let subject = msg.fm.subject.as_deref().unwrap_or("");
+            let body = msg.body.as_str();
+            let has_offboard = subject.to_ascii_lowercase().contains("offboard")
+                || body.to_ascii_lowercase().contains("offboard");
+            if !has_offboard {
+                return;
+            }
+            // Normalize filename-shape `YYYYMMDDTHHMMSSZ` → RFC3339. The
+            // frontmatter `ts` uses the compact shape too (see `current_ts`
+            // in `cli::msg`).
+            let Some(ts_rfc) = normalize_compact_ts(&msg.fm.ts) else {
+                return;
+            };
+            if parse_rfc3339(&ts_rfc).map(|t| t < since).unwrap_or(true) {
+                return;
+            }
+            let display = if subject.is_empty() {
+                first_non_empty_line(body).unwrap_or("offboard").to_string()
+            } else {
+                subject.to_string()
+            };
+            out.push(TimelineEvent::offboard(ts_rfc, msg.fm.from, &display));
+        });
+    }
+    out
+}
+
+fn first_non_empty_line(body: &str) -> Option<&str> {
+    body.lines().map(str::trim).find(|l| !l.is_empty())
+}
+
+/// Convert `YYYYMMDDTHHMMSSZ` → `YYYY-MM-DDTHH:MM:SSZ`. Input already in
+/// RFC3339 (contains `-` or `:`) is returned as-is.
+pub fn normalize_compact_ts(ts: &str) -> Option<String> {
+    if ts.contains('-') || ts.contains(':') {
+        return Some(ts.to_string());
+    }
+    if ts.len() != 16 || !ts.ends_with('Z') {
+        return None;
+    }
+    let year = &ts[0..4];
+    let month = &ts[4..6];
+    let day = &ts[6..8];
+    let t = &ts[8..9];
+    let hour = &ts[9..11];
+    let min = &ts[11..13];
+    let sec = &ts[13..15];
+    if t != "T" {
+        return None;
+    }
+    Some(format!(
+        "{}-{}-{}T{}:{}:{}Z",
+        year, month, day, hour, min, sec
+    ))
+}
+
+fn walk_md_files(root: &Path, visit: &mut dyn FnMut(&Path)) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if ft.is_symlink() {
+            // Skip symlinks — we'll see the canonical file through its
+            // real directory, and legacy shims point into the split layout.
+            continue;
+        }
+        if ft.is_dir() {
+            walk_md_files(&path, visit);
+        } else if ft.is_file() {
+            visit(&path);
+        }
+    }
+}
+
+// --- Dead scanner ----------------------------------------------------------
+
+/// Dead threshold: 15× `poll_interval_sec`. Picked as 3× the normal
+/// dormant multiplier (§2.6) so "dead" means "has been dormant for two
+/// additional poll cycles past dormant onset", which drains the noise
+/// from an agent that briefly stopped heartbeating.
+pub const DEAD_MULTIPLIER: u64 = 15;
+
+/// Emit a `Dead` event for each presence file whose last heartbeat is
+/// older than `DEAD_MULTIPLIER × poll_interval_sec`. Timestamped at the
+/// *heartbeat* time, not `now`, so the event stays stable across scans
+/// (it's a snapshot, not a change notification).
+pub fn scan_dead_events(
+    presence: &[PresenceFile],
+    now: chrono::DateTime<chrono::Utc>,
+) -> Vec<TimelineEvent> {
+    let mut out = Vec::new();
+    for p in presence {
+        let Some(hb) = parse_rfc3339(&p.last_heartbeat) else {
+            // Unparseable heartbeat — treat as dead, use now() so the
+            // event is surfaced without inventing a fake ts.
+            let now_rfc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
+            out.push(TimelineEvent::dead(now_rfc, p.handle.clone(), 0));
+            continue;
+        };
+        let age = (now - hb).num_seconds();
+        if age < 0 {
+            continue;
+        }
+        let threshold = DEAD_MULTIPLIER.saturating_mul(p.poll_interval_sec.max(1));
+        if (age as u64) > threshold {
+            out.push(TimelineEvent::dead(
+                p.last_heartbeat.clone(),
+                p.handle.clone(),
+                age,
+            ));
+        }
+    }
+    out
+}
+
+// --- Assembly + filtering --------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTimelineArgs {
+    /// Scope rows to this colab_group. When omitted, returns every handle.
+    pub colab_group: Option<String>,
+    /// Lower bound on event ts (inclusive). Defaults to 7 days before now
+    /// when omitted.
+    pub since_ts: Option<String>,
+    /// Upper bound on event ts (exclusive). Used for pagination — front
+    /// passes the oldest loaded ts to fetch the next page.
+    pub before_ts: Option<String>,
+    /// Cap the number of events returned (after filtering and sorting).
+    /// Defaults to 500, matching the §3.3 "renders without jank" budget.
+    pub limit: Option<usize>,
+}
+
+pub const DEFAULT_LIMIT: usize = 500;
+pub const DEFAULT_WINDOW_DAYS: i64 = 7;
+
+/// Pure assembly: given the four event streams, apply window + sort +
+/// limit. Split out so tests can feed deterministic inputs.
+pub fn assemble_events(
+    spawns: Vec<TimelineEvent>,
+    claims: Vec<TimelineEvent>,
+    offboards: Vec<TimelineEvent>,
+    deads: Vec<TimelineEvent>,
+    since: chrono::DateTime<chrono::Utc>,
+    before: Option<chrono::DateTime<chrono::Utc>>,
+    handle_filter: Option<&str>,
+    limit: usize,
+) -> Vec<TimelineEvent> {
+    let mut all: Vec<TimelineEvent> = Vec::with_capacity(
+        spawns.len() + claims.len() + offboards.len() + deads.len(),
+    );
+    all.extend(spawns);
+    all.extend(claims);
+    all.extend(offboards);
+    all.extend(deads);
+
+    all.retain(|e| ts_in_range(&e.ts, since, before));
+    if let Some(h) = handle_filter {
+        let needle = h.to_ascii_lowercase();
+        if !needle.is_empty() {
+            all.retain(|e| e.handle.to_ascii_lowercase().contains(&needle));
+        }
+    }
+
+    // Newest first. String compare works correctly on well-formed RFC3339.
+    all.sort_by(|a, b| b.ts.cmp(&a.ts).then_with(|| a.handle.cmp(&b.handle)));
+    all.truncate(limit);
+    all
+}
+
+// --- Tauri command ---------------------------------------------------------
+
+#[tauri::command]
+pub fn list_timeline_events(args: ListTimelineArgs) -> Result<Vec<TimelineEvent>, String> {
+    let mailbox = resolve_mailbox_dir()?;
+    let now = chrono::Utc::now();
+    let since = match args.since_ts.as_deref().and_then(parse_rfc3339) {
+        Some(t) => t,
+        None => now - chrono::Duration::days(DEFAULT_WINDOW_DAYS),
+    };
+    let before = args.before_ts.as_deref().and_then(parse_rfc3339);
+    let limit = args.limit.unwrap_or(DEFAULT_LIMIT);
+
+    // Session index is best-effort: if the global config can't load (e.g.
+    // brand-new install) we just have no spawn events — the pane still
+    // renders claim/release/offboard/dead from the mailbox alone.
+    let spawns = match crate::cli::config::GlobalConfig::load() {
+        Ok(cfg) => scan_spawn_events(&cfg.work_directory, args.colab_group.as_deref()),
+        Err(_) => Vec::new(),
+    };
+    let claims = scan_claim_events(&mailbox);
+    let offboards = scan_offboard_events(&mailbox, since);
+    let presence = list_presence(&mailbox);
+    let deads = scan_dead_events(&presence, now);
+
+    Ok(assemble_events(
+        spawns, claims, offboards, deads, since, before, None, limit,
+    ))
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::msg::{compose_frontmatter, Frontmatter, MsgPriority};
+    use crate::cli::msg_presence::PresenceStatus;
+
+    fn rfc(secs_ago: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::seconds(secs_ago))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    }
+
+    fn days_ago(d: i64) -> String {
+        (chrono::Utc::now() - chrono::Duration::days(d))
+            .format("%Y-%m-%dT%H:%M:%SZ")
+            .to_string()
+    }
+
+    fn tmp_mailbox() -> PathBuf {
+        let root = std::env::temp_dir()
+            .join(format!("twapp-timeline-test-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&root).unwrap();
+        root
+    }
+
+    fn write_owner_file(mailbox: &Path, lane_id: &str, owner: &ClaimOwner) {
+        let dir = mailbox.join("claims").join(lane_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("owner.json");
+        std::fs::write(path, serde_json::to_string_pretty(owner).unwrap()).unwrap();
+    }
+
+    fn write_release_file(mailbox: &Path, lane_id: &str, rel: &ClaimRelease) {
+        let dir = mailbox.join("claims").join(lane_id);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("released.json");
+        std::fs::write(path, serde_json::to_string_pretty(rel).unwrap()).unwrap();
+    }
+
+    fn write_broadcast(mailbox: &Path, ts_compact: &str, from: &str, subject: &str, body: &str) {
+        let dir = mailbox.join("inbox").join("broadcast");
+        std::fs::create_dir_all(&dir).unwrap();
+        let id6 = "ABCDEF";
+        let path = dir.join(format!("{}-{}.md", ts_compact, id6));
+        let fm = Frontmatter {
+            id: format!("{}FULLID", id6),
+            from: from.to_string(),
+            to: vec!["all".to_string()],
+            cc: Vec::new(),
+            priority: MsgPriority::Routine,
+            subject: Some(subject.to_string()),
+            thread: None,
+            in_reply_to: None,
+            ts: ts_compact.to_string(),
+        };
+        let mut content = compose_frontmatter(&fm);
+        content.push('\n');
+        content.push_str(body);
+        content.push('\n');
+        std::fs::write(path, content).unwrap();
+    }
+
+    fn presence(handle: &str, secs_ago: i64, poll: u64) -> PresenceFile {
+        PresenceFile {
+            handle: handle.to_string(),
+            status: PresenceStatus::Processing,
+            last_heartbeat: rfc(secs_ago),
+            current_task: None,
+            inbox_cursor: None,
+            poll_interval_sec: poll,
+            claims: Vec::new(),
+        }
+    }
+
+    // ---- Claim scanner ---------------------------------------------------
+
+    #[test]
+    fn claim_scanner_emits_claim_and_release_for_live_lane() {
+        let mailbox = tmp_mailbox();
+        write_owner_file(
+            &mailbox,
+            "PR-91",
+            &ClaimOwner {
+                owner: "reviewer-a".to_string(),
+                claimed_at: rfc(60),
+                note: Some("starting review".to_string()),
+                reclaimed_from: None,
+                reclaimed_from_claimed_at: None,
+            },
+        );
+        write_release_file(
+            &mailbox,
+            "PR-91",
+            &ClaimRelease {
+                released_by: "reviewer-a".to_string(),
+                released_at: rfc(10),
+                note: Some("shipped".to_string()),
+            },
+        );
+        let events = scan_claim_events(&mailbox);
+        assert_eq!(events.len(), 2);
+        let kinds: Vec<&str> = events.iter().map(|e| e.kind.as_str()).collect();
+        assert!(kinds.contains(&"claim"));
+        assert!(kinds.contains(&"release"));
+        for e in &events {
+            assert_eq!(e.lane_id.as_deref(), Some("PR-91"));
+            assert_eq!(e.handle, "reviewer-a");
+        }
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+
+    #[test]
+    fn claim_scanner_marks_reclaim_when_field_present() {
+        let mailbox = tmp_mailbox();
+        write_owner_file(
+            &mailbox,
+            "lane-z",
+            &ClaimOwner {
+                owner: "new-owner".to_string(),
+                claimed_at: rfc(30),
+                note: None,
+                reclaimed_from: Some("ghost".to_string()),
+                reclaimed_from_claimed_at: Some(rfc(3600)),
+            },
+        );
+        let events = scan_claim_events(&mailbox);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "reclaim");
+        assert_eq!(events[0].handle, "new-owner");
+        assert_eq!(events[0].lane_id.as_deref(), Some("lane-z"));
+        assert!(events[0].description.contains("ghost"));
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+
+    #[test]
+    fn claim_scanner_reads_released_archive_dirs() {
+        let mailbox = tmp_mailbox();
+        // Pre-archived dir shape: `<lane-id>.released-<ts_slug>/`.
+        let archive_dir = mailbox
+            .join("claims")
+            .join("PR-42.released-20260420T120000Z");
+        std::fs::create_dir_all(&archive_dir).unwrap();
+        let owner = ClaimOwner {
+            owner: "old-owner".to_string(),
+            claimed_at: rfc(7200),
+            note: None,
+            reclaimed_from: None,
+            reclaimed_from_claimed_at: None,
+        };
+        std::fs::write(
+            archive_dir.join("owner.json"),
+            serde_json::to_string_pretty(&owner).unwrap(),
+        )
+        .unwrap();
+        let rel = ClaimRelease {
+            released_by: "old-owner".to_string(),
+            released_at: rfc(3600),
+            note: None,
+        };
+        std::fs::write(
+            archive_dir.join("released.json"),
+            serde_json::to_string_pretty(&rel).unwrap(),
+        )
+        .unwrap();
+
+        let events = scan_claim_events(&mailbox);
+        let lanes: Vec<_> = events
+            .iter()
+            .map(|e| e.lane_id.as_deref().unwrap_or(""))
+            .collect();
+        assert!(lanes.iter().all(|l| *l == "PR-42"));
+        assert_eq!(events.len(), 2);
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+
+    // ---- Offboard scanner ------------------------------------------------
+
+    #[test]
+    fn offboard_scanner_matches_subject_or_body() {
+        let mailbox = tmp_mailbox();
+        write_broadcast(
+            &mailbox,
+            "20260420T120000Z",
+            "worker-a",
+            "offboard — scope delivered",
+            "PR-1 merged, offboarding now",
+        );
+        write_broadcast(
+            &mailbox,
+            "20260420T121000Z",
+            "worker-b",
+            "build green",
+            "OFFBOARD incoming after rebase", // body match
+        );
+        write_broadcast(
+            &mailbox,
+            "20260420T122000Z",
+            "worker-c",
+            "standup in 5",
+            "routine",
+        );
+
+        // `since` well in the past so all messages pass.
+        let since = chrono::Utc::now() - chrono::Duration::days(365);
+        let events = scan_offboard_events(&mailbox, since);
+        let handles: Vec<_> = events.iter().map(|e| e.handle.as_str()).collect();
+        assert!(handles.contains(&"worker-a"));
+        assert!(handles.contains(&"worker-b"));
+        assert!(!handles.contains(&"worker-c"));
+        for e in &events {
+            assert_eq!(e.kind, "offboard");
+        }
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+
+    #[test]
+    fn offboard_scanner_skips_messages_older_than_since() {
+        let mailbox = tmp_mailbox();
+        // Far-past message, body-matches "offboard".
+        write_broadcast(
+            &mailbox,
+            "20200101T000000Z",
+            "ancient",
+            "",
+            "offboard ancient",
+        );
+        // Recent message.
+        let now = chrono::Utc::now();
+        let ts = now.format("%Y%m%dT%H%M%SZ").to_string();
+        write_broadcast(
+            &mailbox,
+            &ts,
+            "recent",
+            "offboard — done",
+            "",
+        );
+        let since = now - chrono::Duration::days(7);
+        let events = scan_offboard_events(&mailbox, since);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].handle, "recent");
+        let _ = std::fs::remove_dir_all(&mailbox);
+    }
+
+    // ---- Dead scanner ----------------------------------------------------
+
+    #[test]
+    fn dead_scanner_fires_past_15x_threshold() {
+        let now = chrono::Utc::now();
+        // interval=60 → dead threshold 900s. 1000s ago is dead, 800s is not.
+        let dead = presence("dead", 1000, 60);
+        let alive = presence("alive", 800, 60);
+        let events = scan_dead_events(&[dead, alive], now);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].handle, "dead");
+        assert_eq!(events[0].kind, "dead");
+    }
+
+    #[test]
+    fn dead_scanner_handles_unparseable_timestamp() {
+        let now = chrono::Utc::now();
+        let bad = PresenceFile {
+            handle: "corrupt".to_string(),
+            status: PresenceStatus::Processing,
+            last_heartbeat: "not a timestamp".to_string(),
+            current_task: None,
+            inbox_cursor: None,
+            poll_interval_sec: 60,
+            claims: Vec::new(),
+        };
+        let events = scan_dead_events(&[bad], now);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].kind, "dead");
+        assert_eq!(events[0].handle, "corrupt");
+    }
+
+    // ---- Assembly / filtering --------------------------------------------
+
+    #[test]
+    fn assemble_sorts_newest_first_and_respects_window() {
+        let now = chrono::Utc::now();
+        let spawns = vec![
+            TimelineEvent::spawn(rfc(3600), "a".to_string(), "spawned".to_string()),
+            TimelineEvent::spawn(days_ago(10), "old".to_string(), "spawned".to_string()),
+        ];
+        let claims = vec![TimelineEvent::claim(
+            rfc(1800),
+            "b".to_string(),
+            "PR-1".to_string(),
+            None,
+        )];
+        let since = now - chrono::Duration::days(7);
+        let events = assemble_events(spawns, claims, vec![], vec![], since, None, None, 100);
+        // `old` is outside the 7-day window.
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].handle, "b");
+        assert_eq!(events[1].handle, "a");
+    }
+
+    #[test]
+    fn assemble_handle_filter_matches_substring_case_insensitive() {
+        let now = chrono::Utc::now();
+        let since = now - chrono::Duration::days(7);
+        let events = assemble_events(
+            vec![
+                TimelineEvent::spawn(rfc(10), "Impl-Parser".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(20), "qa-regression".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(30), "impl-renderer".to_string(), String::new()),
+            ],
+            vec![],
+            vec![],
+            vec![],
+            since,
+            None,
+            Some("IMPL"),
+            100,
+        );
+        let handles: Vec<_> = events.iter().map(|e| e.handle.as_str()).collect();
+        assert_eq!(handles, vec!["Impl-Parser", "impl-renderer"]);
+    }
+
+    #[test]
+    fn assemble_before_ts_paginates() {
+        let now = chrono::Utc::now();
+        let since = now - chrono::Duration::days(7);
+        let events_page1 = assemble_events(
+            vec![
+                TimelineEvent::spawn(rfc(10), "newest".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(100), "mid".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(1000), "oldest".to_string(), String::new()),
+            ],
+            vec![],
+            vec![],
+            vec![],
+            since,
+            None,
+            None,
+            2,
+        );
+        assert_eq!(events_page1.len(), 2);
+        let cutoff = parse_rfc3339(&events_page1[1].ts).unwrap();
+
+        let events_page2 = assemble_events(
+            vec![
+                TimelineEvent::spawn(rfc(10), "newest".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(100), "mid".to_string(), String::new()),
+                TimelineEvent::spawn(rfc(1000), "oldest".to_string(), String::new()),
+            ],
+            vec![],
+            vec![],
+            vec![],
+            since,
+            Some(cutoff),
+            None,
+            2,
+        );
+        assert_eq!(events_page2.len(), 1);
+        assert_eq!(events_page2[0].handle, "oldest");
+    }
+
+    #[test]
+    fn normalize_compact_ts_converts_mailbox_timestamps() {
+        assert_eq!(
+            normalize_compact_ts("20260420T230200Z").as_deref(),
+            Some("2026-04-20T23:02:00Z")
+        );
+        // Already RFC3339 → pass-through.
+        assert_eq!(
+            normalize_compact_ts("2026-04-20T23:02:00Z").as_deref(),
+            Some("2026-04-20T23:02:00Z")
+        );
+        // Wrong length or missing Z.
+        assert_eq!(normalize_compact_ts("20260420T23Z"), None);
+        assert_eq!(normalize_compact_ts("20260420T230200"), None);
+    }
+}

--- a/src-tauri/src/gui/timeline.rs
+++ b/src-tauri/src/gui/timeline.rs
@@ -131,12 +131,17 @@ impl TimelineEvent {
         }
     }
 
-    fn dead(ts: String, handle: String, age_sec: i64) -> Self {
+    fn dead(ts: String, handle: String) -> Self {
         Self {
+            // Intentionally omits age — the age is implicit in `ts` vs
+            // `now()` and the UI computes it from `ts`. Including it here
+            // would make the description drift between polls, breaking the
+            // `(ts, handle, kind, description)` dedup key in `mergeEvents`
+            // on pagination boundaries.
+            description: format!("{} has not heartbeat past the dead threshold", handle),
             ts,
-            handle: handle.clone(),
+            handle,
             kind: "dead".to_string(),
-            description: format!("{} has not heartbeat in {}s (past dead threshold)", handle, age_sec),
             lane_id: None,
         }
     }
@@ -375,6 +380,14 @@ pub fn normalize_compact_ts(ts: &str) -> Option<String> {
     ))
 }
 
+/// Recursively walk `.md` files, skipping symlinks (to avoid double-counting
+/// via legacy/urgent shims) and the non-broadcast subtrees that can appear
+/// under `archive/<YYYY-MM-DD>/` post-rotation (PR-7). Inbox-side direct /
+/// urgent / channel dirs are outside the caller's `root` already, but an
+/// `archive/<date>/direct/<handle>/` subtree is co-located with
+/// `archive/<date>/broadcast/` and would otherwise be parsed only to be
+/// discarded by the `to: [all]` filter — a measurable scan cost on a long-
+/// lived mailbox. We skip by directory name at any depth.
 fn walk_md_files(root: &Path, visit: &mut dyn FnMut(&Path)) {
     let Ok(entries) = std::fs::read_dir(root) else {
         return;
@@ -385,11 +398,14 @@ fn walk_md_files(root: &Path, visit: &mut dyn FnMut(&Path)) {
             continue;
         };
         if ft.is_symlink() {
-            // Skip symlinks — we'll see the canonical file through its
-            // real directory, and legacy shims point into the split layout.
             continue;
         }
         if ft.is_dir() {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if matches!(name, "direct" | "urgent" | "channel" | "cursors") {
+                    continue;
+                }
+            }
             walk_md_files(&path, visit);
         } else if ft.is_file() {
             visit(&path);
@@ -419,7 +435,7 @@ pub fn scan_dead_events(
             // Unparseable heartbeat — treat as dead, use now() so the
             // event is surfaced without inventing a fake ts.
             let now_rfc = now.format("%Y-%m-%dT%H:%M:%SZ").to_string();
-            out.push(TimelineEvent::dead(now_rfc, p.handle.clone(), 0));
+            out.push(TimelineEvent::dead(now_rfc, p.handle.clone()));
             continue;
         };
         let age = (now - hb).num_seconds();
@@ -431,7 +447,6 @@ pub fn scan_dead_events(
             out.push(TimelineEvent::dead(
                 p.last_heartbeat.clone(),
                 p.handle.clone(),
-                age,
             ));
         }
     }
@@ -882,6 +897,70 @@ mod tests {
         );
         assert_eq!(events_page2.len(), 1);
         assert_eq!(events_page2[0].handle, "oldest");
+    }
+
+    #[test]
+    fn assemble_sort_tiebreaks_equal_ts_by_handle_ascending() {
+        let now = chrono::Utc::now();
+        let since = now - chrono::Duration::days(7);
+        let same_ts = rfc(30);
+        let events = assemble_events(
+            vec![
+                TimelineEvent::spawn(same_ts.clone(), "charlie".to_string(), String::new()),
+                TimelineEvent::spawn(same_ts.clone(), "alpha".to_string(), String::new()),
+                TimelineEvent::spawn(same_ts.clone(), "bravo".to_string(), String::new()),
+            ],
+            vec![],
+            vec![],
+            vec![],
+            since,
+            None,
+            None,
+            100,
+        );
+        let handles: Vec<_> = events.iter().map(|e| e.handle.as_str()).collect();
+        assert_eq!(handles, vec!["alpha", "bravo", "charlie"]);
+    }
+
+    #[test]
+    fn offboard_scanner_skips_direct_urgent_channel_under_archive() {
+        let mailbox = tmp_mailbox();
+        // Place an "offboard" message in the direct/ subtree that walk_md_files
+        // must skip — only `to: [all]` broadcasts should surface.
+        let direct = mailbox
+            .join("archive")
+            .join("2026-04-20")
+            .join("direct")
+            .join("coordinator");
+        std::fs::create_dir_all(&direct).unwrap();
+        let direct_content = "---\n\
+            id: DIRECTOFFBRD\n\
+            from: trickster\n\
+            to: [coordinator]\n\
+            priority: routine\n\
+            subject: \"offboard — direct\"\n\
+            ts: 20260420T120000Z\n\
+            ---\n\n\
+            offboard body\n";
+        std::fs::write(
+            direct.join("20260420T120000Z-DIRECT.md"),
+            direct_content,
+        )
+        .unwrap();
+        // Also drop a legit broadcast offboard so we know the scanner ran.
+        write_broadcast(
+            &mailbox,
+            "20260420T130000Z",
+            "legit",
+            "offboard — scope delivered",
+            "",
+        );
+
+        let since = chrono::Utc::now() - chrono::Duration::days(365);
+        let events = scan_offboard_events(&mailbox, since);
+        let handles: Vec<_> = events.iter().map(|e| e.handle.as_str()).collect();
+        assert_eq!(handles, vec!["legit"], "direct-subtree offboard must be skipped");
+        let _ = std::fs::remove_dir_all(&mailbox);
     }
 
     #[test]

--- a/src/App.css
+++ b/src/App.css
@@ -4995,6 +4995,208 @@ a.file-link {
   white-space: nowrap;
 }
 
+/* ----- Coordinator spawn/teardown timeline (§3.3) ----- */
+
+.timeline-panel {
+  border-bottom: 1px solid var(--border-color);
+  padding: 8px 12px 6px;
+  background: var(--bg-primary);
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.timeline-header h2 {
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.timeline-title {
+  font-weight: 600;
+}
+
+.timeline-summary {
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: 6px;
+}
+
+.timeline-body {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.timeline-filter {
+  width: 100%;
+  padding: 4px 8px;
+  font-size: 12px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  box-sizing: border-box;
+}
+
+.timeline-filter:focus {
+  outline: none;
+  border-color: var(--text-muted);
+}
+
+.timeline-empty {
+  padding: 8px 0 2px;
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+.timeline-error {
+  padding: 6px 8px;
+  background: rgba(220, 38, 38, 0.10);
+  border: 1px solid rgba(220, 38, 38, 0.45);
+  color: #b91c1c;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.timeline-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.timeline-row {
+  display: grid;
+  grid-template-columns: auto auto auto 1fr;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.timeline-ts {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.timeline-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: lowercase;
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.timeline-chip-spawn {
+  border-color: rgba(22, 163, 74, 0.55);
+  color: #15803d;
+}
+
+.timeline-chip-claim {
+  border-color: rgba(37, 99, 235, 0.55);
+  color: #1d4ed8;
+}
+
+.timeline-chip-reclaim {
+  border-color: rgba(202, 138, 4, 0.55);
+  color: #a16207;
+}
+
+.timeline-chip-release {
+  border-color: rgba(100, 116, 139, 0.55);
+  color: #475569;
+}
+
+.timeline-chip-offboard {
+  border-color: rgba(124, 58, 237, 0.55);
+  color: #6d28d9;
+}
+
+.timeline-chip-dead {
+  border-color: rgba(220, 38, 38, 0.55);
+  color: #b91c1c;
+}
+
+.timeline-handle {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-weight: 600;
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 140px;
+}
+
+.timeline-desc {
+  color: var(--text-muted);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.timeline-footer {
+  display: flex;
+  justify-content: center;
+  padding-top: 2px;
+}
+
+.timeline-load-more {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 3px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.timeline-load-more:hover:not(:disabled) {
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+.timeline-load-more:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
 /* ----- Agent context menu (§3.5 fleet-pane quick actions) ----- */
 
 .agent-menu-backdrop {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import SessionLauncher from "./components/SessionLauncher";
 import MessageComposer from "./components/MessageComposer";
 import UrgentInbox from "./components/UrgentInbox";
 import FleetPane from "./components/FleetPane";
+import TimelinePane from "./components/TimelinePane";
 
 
 const SESSION_COLORS = [
@@ -2392,6 +2393,12 @@ function App() {
 
         {/* Coordinator fleet pane — renders only when role === "coordinator". */}
         <FleetPane
+          isCoordinator={sessionRole === "coordinator"}
+          colabGroup={sessionColabGroup}
+        />
+
+        {/* Coordinator spawn/teardown timeline — renders only when role === "coordinator". */}
+        <TimelinePane
           isCoordinator={sessionRole === "coordinator"}
           colabGroup={sessionColabGroup}
         />

--- a/src/components/TimelinePane.test.ts
+++ b/src/components/TimelinePane.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  chipLabel,
+  filterByHandle,
+  mergeEvents,
+  sortNewestFirst,
+  type TimelineEvent,
+} from "./TimelinePane";
+
+const evt = (o: Partial<TimelineEvent> & { ts: string; handle: string }): TimelineEvent => ({
+  kind: "spawn",
+  description: "",
+  ...o,
+});
+
+describe("chipLabel", () => {
+  it("returns known kind labels", () => {
+    expect(chipLabel("spawn")).toBe("spawn");
+    expect(chipLabel("claim")).toBe("claim");
+    expect(chipLabel("release")).toBe("release");
+    expect(chipLabel("reclaim")).toBe("reclaim");
+    expect(chipLabel("offboard")).toBe("offboard");
+    expect(chipLabel("dead")).toBe("dead");
+  });
+
+  it("passes unknown kinds through", () => {
+    expect(chipLabel("future-kind")).toBe("future-kind");
+  });
+});
+
+describe("sortNewestFirst", () => {
+  it("sorts by ts descending with handle tiebreak", () => {
+    const sorted = sortNewestFirst([
+      evt({ ts: "2026-04-20T10:00:00Z", handle: "b" }),
+      evt({ ts: "2026-04-21T10:00:00Z", handle: "a" }),
+      evt({ ts: "2026-04-20T10:00:00Z", handle: "a" }),
+    ]);
+    expect(sorted.map((e) => `${e.ts} ${e.handle}`)).toEqual([
+      "2026-04-21T10:00:00Z a",
+      "2026-04-20T10:00:00Z a",
+      "2026-04-20T10:00:00Z b",
+    ]);
+  });
+
+  it("does not mutate the input", () => {
+    const input = [
+      evt({ ts: "2026-04-20T10:00:00Z", handle: "b" }),
+      evt({ ts: "2026-04-21T10:00:00Z", handle: "a" }),
+    ];
+    const before = [...input];
+    sortNewestFirst(input);
+    expect(input).toEqual(before);
+  });
+});
+
+describe("filterByHandle", () => {
+  const events = [
+    evt({ ts: "2026-04-21T10:00:00Z", handle: "Impl-Parser" }),
+    evt({ ts: "2026-04-21T10:00:00Z", handle: "qa-regression" }),
+    evt({ ts: "2026-04-21T10:00:00Z", handle: "impl-renderer" }),
+  ];
+
+  it("returns all events when filter is empty", () => {
+    expect(filterByHandle(events, "").length).toBe(3);
+    expect(filterByHandle(events, "   ").length).toBe(3);
+  });
+
+  it("filters case-insensitive substring on handle", () => {
+    const out = filterByHandle(events, "IMPL");
+    expect(out.map((e) => e.handle)).toEqual(["Impl-Parser", "impl-renderer"]);
+  });
+});
+
+describe("mergeEvents", () => {
+  it("dedups by (ts, handle, kind, description) and sorts newest first", () => {
+    const page1 = [
+      evt({ ts: "2026-04-21T10:00:00Z", handle: "a", kind: "spawn" }),
+      evt({ ts: "2026-04-21T09:00:00Z", handle: "b", kind: "spawn" }),
+    ];
+    const page2 = [
+      evt({ ts: "2026-04-21T10:00:00Z", handle: "a", kind: "spawn" }),
+      evt({ ts: "2026-04-21T08:00:00Z", handle: "c", kind: "claim", description: "PR-1" }),
+    ];
+    const merged = mergeEvents(page1, page2);
+    expect(merged.map((e) => `${e.ts} ${e.handle} ${e.kind}`)).toEqual([
+      "2026-04-21T10:00:00Z a spawn",
+      "2026-04-21T09:00:00Z b spawn",
+      "2026-04-21T08:00:00Z c claim",
+    ]);
+  });
+
+  it("keeps two events with the same handle but different descriptions", () => {
+    // Re-claim after stale — different kind, same handle.
+    const merged = mergeEvents(
+      [evt({ ts: "2026-04-21T10:00:00Z", handle: "a", kind: "claim", description: "claimed PR-1" })],
+      [evt({ ts: "2026-04-21T10:00:00Z", handle: "a", kind: "reclaim", description: "reclaimed PR-1 from stale owner b" })],
+    );
+    expect(merged).toHaveLength(2);
+  });
+});

--- a/src/components/TimelinePane.tsx
+++ b/src/components/TimelinePane.tsx
@@ -1,0 +1,321 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export type TimelineEventKind =
+  | "spawn"
+  | "claim"
+  | "reclaim"
+  | "release"
+  | "offboard"
+  | "dead";
+
+export type TimelineEvent = {
+  ts: string;
+  handle: string;
+  kind: TimelineEventKind | string;
+  description: string;
+  lane_id?: string | null;
+};
+
+type TimelinePaneProps = {
+  /** True when the current session has role === "coordinator" — pane is hidden otherwise. */
+  isCoordinator: boolean;
+  /** If non-null, scope the timeline to this colab_group (spawn events only; claims/offboard/dead come from the shared mailbox). */
+  colabGroup?: string | null;
+  /** Injected in tests; defaults to the Tauri invoke bridge. */
+  fetcher?: (args: TimelineFetchArgs) => Promise<TimelineEvent[]>;
+  /** Poll interval while visible. 30s per briefing. */
+  pollMs?: number;
+  /** Initial window in days. 7 per design. */
+  windowDays?: number;
+};
+
+export type TimelineFetchArgs = {
+  colabGroup?: string | null;
+  sinceTs?: string | null;
+  beforeTs?: string | null;
+  limit?: number | null;
+};
+
+const tauriFetcher = (args: TimelineFetchArgs): Promise<TimelineEvent[]> =>
+  invoke<TimelineEvent[]>("list_timeline_events", {
+    args: {
+      colabGroup: args.colabGroup ?? null,
+      sinceTs: args.sinceTs ?? null,
+      beforeTs: args.beforeTs ?? null,
+      limit: args.limit ?? null,
+    },
+  });
+
+/** Format timestamp for row label. Short local date + HH:MM. */
+export function formatTs(ts: string): string {
+  const d = new Date(ts);
+  if (Number.isNaN(d.getTime())) return ts;
+  const today = new Date();
+  const sameDay =
+    d.getFullYear() === today.getFullYear() &&
+    d.getMonth() === today.getMonth() &&
+    d.getDate() === today.getDate();
+  const hm = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  if (sameDay) return hm;
+  const md = d.toLocaleDateString([], { month: "short", day: "numeric" });
+  return `${md} ${hm}`;
+}
+
+/** Label for a kind chip. Short so the chip stays compact in dense rows. */
+export function chipLabel(kind: string): string {
+  switch (kind) {
+    case "spawn":
+      return "spawn";
+    case "claim":
+      return "claim";
+    case "reclaim":
+      return "reclaim";
+    case "release":
+      return "release";
+    case "offboard":
+      return "offboard";
+    case "dead":
+      return "dead";
+    default:
+      return kind;
+  }
+}
+
+/** Sort events newest-first; handle-tiebreak for stable ordering. */
+export function sortNewestFirst(events: TimelineEvent[]): TimelineEvent[] {
+  return [...events].sort((a, b) => {
+    if (a.ts === b.ts) return a.handle.localeCompare(b.handle);
+    return b.ts.localeCompare(a.ts);
+  });
+}
+
+/** Apply a case-insensitive substring filter on handle. */
+export function filterByHandle(
+  events: TimelineEvent[],
+  needle: string,
+): TimelineEvent[] {
+  const n = needle.trim().toLowerCase();
+  if (!n) return events;
+  return events.filter((e) => e.handle.toLowerCase().includes(n));
+}
+
+/** Merge a newer page into an existing list, dedup'd by (ts, handle, kind, description).
+ *  The backend sort is authoritative, but the UI may hold older pages that
+ *  should stay visible across refreshes. */
+export function mergeEvents(
+  prior: TimelineEvent[],
+  incoming: TimelineEvent[],
+): TimelineEvent[] {
+  const seen = new Set<string>();
+  const out: TimelineEvent[] = [];
+  for (const e of [...incoming, ...prior]) {
+    const key = `${e.ts}|${e.handle}|${e.kind}|${e.description}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(e);
+  }
+  return sortNewestFirst(out);
+}
+
+/** Coordinator spawn/teardown timeline — collapsible panel that sits below
+ *  the fleet pane. Polls `list_timeline_events` every 30s while expanded.
+ *  Hidden entirely for non-coordinators so single-session users and regular
+ *  workers see no new chrome. */
+export default function TimelinePane({
+  isCoordinator,
+  colabGroup = null,
+  fetcher = tauriFetcher,
+  pollMs = 30_000,
+  windowDays = 7,
+}: TimelinePaneProps) {
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [expanded, setExpanded] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [reachedEnd, setReachedEnd] = useState(false);
+  const [handleFilter, setHandleFilter] = useState("");
+
+  // Oldest ts currently loaded — used as `beforeTs` for the next page.
+  const oldestTsRef = useRef<string | null>(null);
+  // Monotonic request id so stale responses never overwrite fresh state.
+  const fetchSeqRef = useRef(0);
+
+  const defaultSinceTs = useCallback(() => {
+    const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+    return since.toISOString();
+  }, [windowDays]);
+
+  const doRefresh = useCallback(async () => {
+    const seq = ++fetchSeqRef.current;
+    try {
+      const result = await fetcher({
+        colabGroup,
+        sinceTs: defaultSinceTs(),
+        beforeTs: null,
+        limit: null,
+      });
+      if (seq !== fetchSeqRef.current) return;
+      const sorted = sortNewestFirst(result || []);
+      setEvents(sorted);
+      oldestTsRef.current = sorted.length > 0 ? sorted[sorted.length - 1].ts : null;
+      setReachedEnd(false);
+      setError(null);
+      setLoaded(true);
+    } catch (e) {
+      if (seq !== fetchSeqRef.current) return;
+      setError(String(e));
+      setLoaded(true);
+    }
+  }, [fetcher, colabGroup, defaultSinceTs]);
+
+  const doLoadMore = useCallback(async () => {
+    if (loadingMore || reachedEnd) return;
+    const beforeTs = oldestTsRef.current;
+    if (!beforeTs) return;
+    setLoadingMore(true);
+    const seq = ++fetchSeqRef.current;
+    try {
+      // Extend the window back by the same number of days each click.
+      const nextSince = new Date(
+        new Date(beforeTs).getTime() - windowDays * 24 * 60 * 60 * 1000,
+      ).toISOString();
+      const result = await fetcher({
+        colabGroup,
+        sinceTs: nextSince,
+        beforeTs,
+        limit: null,
+      });
+      if (seq !== fetchSeqRef.current) return;
+      if (!result || result.length === 0) {
+        setReachedEnd(true);
+      } else {
+        setEvents((prev) => {
+          const merged = mergeEvents(prev, result);
+          const last = merged[merged.length - 1];
+          oldestTsRef.current = last?.ts ?? oldestTsRef.current;
+          return merged;
+        });
+      }
+      setError(null);
+    } catch (e) {
+      if (seq !== fetchSeqRef.current) return;
+      setError(String(e));
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [fetcher, colabGroup, loadingMore, reachedEnd, windowDays]);
+
+  useEffect(() => {
+    if (!isCoordinator) return;
+    doRefresh();
+    const h = window.setInterval(doRefresh, pollMs);
+    return () => window.clearInterval(h);
+  }, [isCoordinator, doRefresh, pollMs]);
+
+  const visible = useMemo(
+    () => filterByHandle(events, handleFilter),
+    [events, handleFilter],
+  );
+
+  if (!isCoordinator) return null;
+
+  return (
+    <div className="timeline-panel">
+      <div
+        className="timeline-header"
+        onClick={() => setExpanded((v) => !v)}
+        role="button"
+        aria-expanded={expanded}
+      >
+        <h2>
+          <span className={`prompt-chevron ${expanded ? "expanded" : ""}`}>
+            &#9654;
+          </span>
+          <span className="timeline-title">Timeline</span>
+          {loaded && (
+            <span className="timeline-summary">
+              {visible.length}
+              {handleFilter && visible.length !== events.length
+                ? ` / ${events.length}`
+                : ""}{" "}
+              event{visible.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </h2>
+        <button
+          className="section-refresh-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            doRefresh();
+          }}
+          title="Refresh timeline"
+        >
+          &#8635;
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="timeline-body">
+          <input
+            type="text"
+            className="timeline-filter"
+            placeholder="Filter by handle…"
+            value={handleFilter}
+            onChange={(e) => setHandleFilter(e.target.value)}
+            aria-label="Filter timeline by handle"
+          />
+
+          {error && <div className="timeline-error">{error}</div>}
+
+          {!error && loaded && visible.length === 0 && (
+            <div className="timeline-empty">
+              {handleFilter ? "No matching events." : "No events yet."}
+            </div>
+          )}
+
+          {!error && visible.length > 0 && (
+            <ul className="timeline-list" role="list">
+              {visible.map((e, idx) => (
+                <li
+                  key={`${e.ts}-${e.handle}-${e.kind}-${idx}`}
+                  className={`timeline-row timeline-row-${e.kind}`}
+                  title={`${e.ts} — ${e.handle}`}
+                >
+                  <span
+                    className="timeline-ts"
+                    title={e.ts}
+                  >
+                    {formatTs(e.ts)}
+                  </span>
+                  <span className={`timeline-chip timeline-chip-${e.kind}`}>
+                    {chipLabel(e.kind)}
+                  </span>
+                  <span className="timeline-handle">{e.handle}</span>
+                  <span className="timeline-desc">{e.description}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {!error && visible.length > 0 && (
+            <div className="timeline-footer">
+              <button
+                className="timeline-load-more"
+                onClick={doLoadMore}
+                disabled={loadingMore || reachedEnd}
+              >
+                {reachedEnd
+                  ? "No more events"
+                  : loadingMore
+                  ? "Loading…"
+                  : "Load more"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a **Timeline** panel to the coordinator dashboard (below the fleet pane from PR #62). Lists spawn / claim / reclaim / release / offboard / dead events for the co-lab, newest-first, with a 7-day window + *Load more* pagination and a handle-substring filter. Renders only when `sessionRole === "coordinator"`, so single-session and worker UX are byte-unchanged.
- Backend `list_timeline_events` (`src-tauri/src/gui/timeline.rs`) aggregates four streams:
  - **Spawn** — `SessionData.created` per `.twapp-session.json` under the work directory (respects `colab_group`).
  - **Claim / reclaim / release** — `<mailbox>/claims/<lane-id>/owner.json` + `released.json`, plus the `.released-<ts>/` archives. Reuses `ClaimOwner` / `ClaimRelease` from the lane-claim primitive.
  - **Offboard** — `to: [all]` broadcasts whose subject or body contains "offboard" (case-insensitive), walked across `inbox/broadcast/` and `archive/` (flat + dated subdirs from PR #51's rotation).
  - **Dead** — presence handles whose `last_heartbeat` is older than `15 × poll_interval_sec` (3× the dormant threshold, to drain noise from briefly-paused agents).
- Filenames in the broadcast archive use the compact `YYYYMMDDTHHMMSSZ` shape, so the scanner normalizes to RFC3339 before comparing against the `since` cutoff.
- 11 Rust tests (claim/release pairs, stale-reclaim, archived `.released-*` dirs, offboard subject+body match, 7-day cutoff, dead threshold, unparseable timestamps, window/sort/filter/pagination).
- 8 frontend tests (chip label, sort-newest-first no-mutate, case-insensitive handle filter, page-merge dedup that keeps different-kind rows under the same handle).
- Matches §3.3 of `docs/designs/agent-aware-ui.md` (now updated to mark spawn-history as landed) and re-uses the same claim/release primitive documented in `docs/designs/worker-coordination.md`.

The original §3.3 sketched a horizontal hover-strip; this PR ships a chronological list in the sidebar column instead — fits the existing panel vocabulary (fleet pane rows, urgent-inbox rows) better, and the timeline-chip kinds map cleanly to a kind-specific color via `.timeline-chip-{spawn,claim,reclaim,release,offboard,dead}`.

## Test plan

- [x] `cargo test --lib` — 262 passed (11 new in `gui::timeline::tests`)
- [x] `npm test` — 157 passed (8 new in `src/components/TimelinePane.test.ts`)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run dev` smoke (Vite serves 200 at :1420, no import errors)
- [ ] Visual verification — the panel is gated on `sessionRole === "coordinator"`, so it only renders when the current session's `.twapp-session.json` has that role. Reviewer: open a coordinator session with a populated mailbox (presence + claims + a "offboard" broadcast) to exercise rows of each kind; confirm the *Load more* button and the handle-filter input behave as described.