### PR TITLE
feat(msg): channels — design PR-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,13 +606,12 @@ back. See
 [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) for
 the full model. Today's CLI covers **PR-1** (scaffolding), **PR-2**
 (threading), **PR-3** (directory split + read cursors), **PR-4**
-(priority lane), **PR-5** (presence / heartbeat), and **PR-7** (archive
-rotation) of that design. Sends land under a per-recipient layout
-(`inbox/broadcast/`, `inbox/direct/<handle>/`, `inbox/channel/<name>/`);
-every send also drops a grace-period symlink at the flat
-`inbox/<filename>.md` path so un-upgraded readers doing `ls inbox/`
-keep working. First-class channel subscriptions still land in a later
-PR.
+(priority lane), **PR-5** (presence / heartbeat), **PR-6** (channels),
+and **PR-7** (archive rotation) of that design. Sends land under a
+per-recipient layout (`inbox/broadcast/`, `inbox/direct/<handle>/`,
+`inbox/channel/<name>/`); every send also drops a grace-period symlink
+at the flat `inbox/<filename>.md` path so un-upgraded readers doing
+`ls inbox/` keep working.
 
 #### Configure the mailbox
 
@@ -847,6 +846,56 @@ Agents are expected to heartbeat on their /loop cadence (today, manually;
 a follow-up PR will wire heartbeats into the /loop skill itself). The
 `spawn-agent` and `agent-coordinator` skill docs call this out in the
 worker protocol.
+
+#### Channels (PR-6)
+
+Channels are topic-scoped fan-in: a sender writes to a *name*, not a
+handle, and any subscriber watching that name picks up the traffic.
+They replace the ad-hoc `-standby`-handle hack the pre-PR-6 corpus used
+to signal "a reviewer, currently in standby mode, please pick this up
+if that's you". Design §2.3.
+
+```bash
+# Send — either `channel:<name>` as the positional recipient, or
+# `--channel <name>`. Both forms write to inbox/channel/<name>/.
+twapp msg send channel:reviewers "anyone free to look at PR-91?"
+twapp msg send --channel reviewers "anyone free to look at PR-91?"
+
+# Multi-destination: direct + channel in the same send.
+twapp msg send worker-a --channel announcements --priority urgent \
+  "merge freeze starts at 5pm"
+
+# Broadcasts can also fan into a channel instead of every handle.
+twapp msg broadcast --channel reviewers-standby "PR-91 needs eyes"
+
+# Fetch — scope to a single channel. Optional --for filters out the
+# caller's own sends (so your loop doesn't re-surface messages you just
+# wrote).
+twapp msg fetch --channel reviewers
+twapp msg fetch --channel reviewers --for reviewer-a
+
+# Observability — what channels exist and who's listening.
+twapp msg channel list                      # pretty table of name + count
+twapp msg channel list --format json | jq
+twapp msg channel subscribers reviewers     # handles whose presence.claims holds channel:reviewers
+twapp msg channel subscribers reviewers --format json
+```
+
+Subscription is by-convention (design §2.3): a worker declares its
+interest by putting `channel:<name>` into its `presence/<handle>.json`
+`claims` array — typically via `twapp msg presence heartbeat --claims
+channel:reviewers,channel:announcements`. The claims list is coordinator-
+facing observability; senders don't consult it, and nothing enforces
+that a non-subscriber won't read the channel. Actual delivery = every
+subscriber scanning its own claimed channels in its /loop fetch cycle.
+
+> Unknown channel fetch is a no-op: `twapp msg fetch --channel
+> never-created-yet` returns `(no messages)` and exit 0, not a crash.
+
+Channel messages archive under the same daily rotation as every other
+message — drop a channel file into `archive/` (flat) and
+`twapp msg archive rotate` groups it under `archive/<YYYY-MM-DD>/`
+by its frontmatter `ts`, same as broadcasts and direct messages.
 
 #### Migrating the inbox layout
 

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -311,7 +311,47 @@ so its workers can see it's alive.
 
 - `to: all` — broadcast (every online agent reads and archives).
 - `to: <handle>` — directed (only that agent archives; others ignore).
+- `to: channel:<name>` — topic-scoped fan-in; any subscriber reading that channel picks it up (see below).
 - `cc: <handle>` — optional courtesy copy.
+
+### Channels (PR-6) — topic-scoped fan-in
+
+Channels replace the `reviewer-standby`-style pseudo-handle hack the
+pre-PR-6 corpus used to signal "any reviewer, please pick this up".
+Instead of renaming the recipient slot, send to a channel name and let
+any worker that subscribes pick it up:
+
+```bash
+# Send — either positional `channel:<name>` or `--channel <name>`.
+twapp msg send channel:reviewers "PR-91 needs eyes"
+twapp msg broadcast --channel reviewers-standby "anyone free for a pass?"
+
+# Read — scope to one channel; optional --for filters out own sends.
+twapp msg fetch --channel reviewers
+twapp msg fetch --channel reviewers --for <me>
+
+# Observability — what channels exist, who's listening where.
+twapp msg channel list
+twapp msg channel subscribers reviewers
+```
+
+Subscription is by-convention: each worker declares what it listens
+to via its presence `claims` array, typically as part of its heartbeat:
+
+```bash
+twapp msg presence heartbeat \
+  --claims channel:reviewers,channel:announcements
+```
+
+`twapp msg channel subscribers <name>` reads those claim arrays and
+prints the handles currently claiming that channel. Senders don't
+consult the list — a channel send is fan-in, not fan-out, and every
+subscriber scans its own claimed channels in its /loop fetch cycle.
+
+> **Prefer channels over the `-standby` handle convention.** The
+> filename hack (`reviewer-standby`, `<worker>-URGENT`) was always
+> routing state leaked into the receiver slot. Channels give that
+> state a real home.
 
 ### Priority lanes (urgent / blocker)
 
@@ -707,7 +747,7 @@ A handful of role patterns recur. Pick the closest archetype and adapt the brief
 |---|---|---|---|---|
 | `coordinator` | session-long | mailbox, PRs, processes | briefings, mailbox, merges | singleton |
 | `implementer` | until its PR merges | briefing, code | one PR in one scope | scope-named |
-| `reviewer` | until user-stop | open PRs + diffs | PR comments only | `reviewer-standby` |
+| `reviewer` | until user-stop | open PRs + diffs | PR comments only | `reviewer` (subscribes to `channel:reviewers`) |
 | `auditor` | until report posted | codebase + logs | mailbox report (no code) | `audit-<area>`, `<topic>-autopsy` |
 | `log-watcher` | live session | log stream | mailbox PING/STOP/NOTE | `log-watcher` |
 | `architect` | topic-bounded | codebase | RFC / design doc in `docs/` | `architect`, `innovator` |

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -321,24 +321,33 @@ kill -TERM "$(pgrep -f 'twapp --name my-feature-fix')"
 
 ### Example B — Spawn a long-running reviewer that polls for PR reviews
 
+Reviewers are a natural fit for **channels** (design §2.3) — a
+coordinator dispatches review requests to `channel:reviewers` rather
+than a specific handle, and any online reviewer picks them up. The
+reviewer declares its subscription via its presence `claims`.
+
 ```bash
 # 1. Briefing with an explicit "runs until stopped" loop.
 cat > /tmp/briefings/my-reviewer.md <<'EOF'
 # my-reviewer — review open PRs on example-repo until stopped
 
-Loop: every 90s, `gh pr list --repo example-org/example-repo --state open`.
+Loop: every 90s,
+  1. `twapp msg presence heartbeat --task "reviewing" --claims channel:reviewers`
+  2. `twapp msg fetch --channel reviewers --for my-reviewer` — scoop pending asks.
+  3. `gh pr list --repo example-org/example-repo --state open`.
 For each unreviewed PR, run `gh pr view`, post a review via `gh pr review`,
-then write a summary line to `/tmp/agent-mailbox/inbox/<iso>-my-reviewer-review.md`.
+then `twapp msg send channel:reviewers --from my-reviewer "reviewed PR-<n>"`
+so peers and the coordinator see progress.
 
 No time limit. Run until the caller sends SIGTERM.
 
 ## Protocol
 
-- Handle: `my-reviewer`
+- Handle: `my-reviewer`.
+- Subscribes to `channel:reviewers` (see `claims` in presence heartbeat above).
 - Hello within 2 min.
-- After every review, post a one-line note to the mailbox so the caller can
-  see progress.
-- On SIGTERM, post an offboard message before exiting.
+- After every review, post a one-line note to `channel:reviewers`.
+- On SIGTERM, post an offboard message and `twapp msg presence clear`.
 EOF
 
 # 2. No worktree needed (reviewer only reads + uses `gh`). Any cwd with

--- a/src-tauri/src/cli/coordinator.rs
+++ b/src-tauri/src/cli/coordinator.rs
@@ -631,20 +631,8 @@ pub fn find_session_dir(name: Option<&str>) -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::test_env;
     use std::fs;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    // Serialize every test that mutates TWAPP_MAILBOX_DIR. `cargo test` runs
-    // tests in parallel within a binary, and process-wide env is shared
-    // state — without this lock, `mailbox_creates_fallback_when_nothing_configured`
-    // and `mailbox_inherits_env_var` race and intermittently see each other's
-    // env mutation.
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
 
     fn unique_tmp(prefix: &str) -> PathBuf {
         std::env::temp_dir().join(format!("{}-{}", prefix, uuid::Uuid::new_v4()))
@@ -831,7 +819,7 @@ mod tests {
 
     #[test]
     fn mailbox_creates_fallback_when_nothing_configured() {
-        let _guard = env_lock();
+        let _guard = test_env::lock();
         let work_dir = unique_tmp("twapp-coord-mbx-fallback");
         fs::create_dir_all(&work_dir).unwrap();
         let prev = std::env::var("TWAPP_MAILBOX_DIR").ok();
@@ -851,7 +839,7 @@ mod tests {
 
     #[test]
     fn mailbox_inherits_env_var_when_set() {
-        let _guard = env_lock();
+        let _guard = test_env::lock();
         let work_dir = unique_tmp("twapp-coord-mbx-inherit");
         fs::create_dir_all(&work_dir).unwrap();
         let inherited = unique_tmp("twapp-coord-mbx-inherit-env");
@@ -876,7 +864,7 @@ mod tests {
 
     #[test]
     fn mailbox_reuses_existing_local_mailbox() {
-        let _guard = env_lock();
+        let _guard = test_env::lock();
         let work_dir = unique_tmp("twapp-coord-mbx-reuse");
         fs::create_dir_all(work_dir.join("mailbox").join("inbox")).unwrap();
         let prev = std::env::var("TWAPP_MAILBOX_DIR").ok();

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod models;
 pub mod monitor;
 pub mod msg;
 pub mod msg_archive;
+pub mod msg_channel;
 pub mod msg_claim;
 pub mod msg_cursors;
 pub mod msg_migrate;
@@ -15,6 +16,8 @@ pub mod prompts;
 pub mod session;
 pub mod session_attribution;
 pub mod stop;
+#[cfg(test)]
+pub mod test_env;
 pub mod theme;
 pub mod ticket;
 
@@ -561,6 +564,12 @@ pub fn run(cmd: Commands) -> i32 {
                 }
                 msg_presence::PresenceCommands::Clear { handle } => {
                     msg_presence::cmd_clear(handle)
+                }
+            },
+            MsgCommands::Channel { command } => match command {
+                msg_channel::ChannelCommands::List { format } => msg_channel::cmd_list(format),
+                msg_channel::ChannelCommands::Subscribers { name, format } => {
+                    msg_channel::cmd_subscribers(name, format)
                 }
             },
         },

--- a/src-tauri/src/cli/msg.rs
+++ b/src-tauri/src/cli/msg.rs
@@ -80,10 +80,12 @@ pub struct ParsedMessage {
 #[derive(Subcommand, Debug)]
 pub enum MsgCommands {
     /// Send a directed message
-    #[command(after_help = "Examples:\n  twapp msg send reviewer \"heads up, PR-1 is landing\"\n  twapp msg send a,b --priority urgent --subject 'build broke' \"see CI 1234\"\n  twapp msg send reviewer --reply-to 01JS4M7Q8W \"ack\"\n  echo \"long body\" | twapp msg send reviewer --from me --subject hi")]
+    #[command(after_help = "Examples:\n  twapp msg send reviewer \"heads up, PR-1 is landing\"\n  twapp msg send a,b --priority urgent --subject 'build broke' \"see CI 1234\"\n  twapp msg send reviewer --reply-to 01JS4M7Q8W \"ack\"\n  twapp msg send channel:reviewers \"anyone free?\"          # positional form\n  twapp msg send --channel reviewers \"anyone free?\"         # flag form\n  echo \"long body\" | twapp msg send reviewer --from me --subject hi")]
     Send {
-        /// Recipient handle(s). Comma-separate for multiple, or use --channel for channels.
-        to: String,
+        /// Recipient handle(s). Comma-separate for multiple, or use
+        /// `channel:<name>` for a channel. Optional when `--channel <name>`
+        /// is supplied (the channel then becomes the sole recipient).
+        to: Option<String>,
         /// Sender handle. Defaults to the current .twapp-session.json name.
         #[arg(long)]
         from: Option<String>,
@@ -278,6 +280,26 @@ pub enum MsgCommands {
     Presence {
         #[command(subcommand)]
         command: super::msg_presence::PresenceCommands,
+    },
+    /// Channel observability (design §2.3, PR-6).
+    ///
+    /// Channels are topic-scoped fan-in: messages addressed to
+    /// `channel:<name>` land under `<mailbox>/inbox/channel/<name>/`.
+    /// Sending is just `twapp msg send channel:<name> ...` or
+    /// `twapp msg send --channel <name> ...`; this subcommand group is the
+    /// read side — what channels exist, and who is listening.
+    ///
+    /// Subscription is by-convention: a subscriber declares its claims in
+    /// `presence/<handle>.json`'s `claims` array
+    /// (e.g. `channel:reviewers`), and the coordinator uses
+    /// `channel subscribers` to see who has claimed what. Senders don't
+    /// consult the list.
+    #[command(
+        after_help = "Examples:\n  twapp msg channel list\n  twapp msg channel list --format json\n  twapp msg channel subscribers reviewers"
+    )]
+    Channel {
+        #[command(subcommand)]
+        command: super::msg_channel::ChannelCommands,
     },
 }
 
@@ -660,7 +682,12 @@ pub fn write_message(inbox: &Path, args: SendArgs) -> Result<SentMessage, String
 fn create_urgent_symlinks(inbox: &Path, canonical: &Path, filename: &str, to: &[String]) {
     let urgent_root = urgent_dir(inbox);
     for recipient in to {
-        // Channel lane lives in PR-6; skip for now.
+        // Channel urgent lane is deferred — the read path
+        // (`fetch --priority urgent --channel X`) would need a matching
+        // `scan_urgent_lane` extension to pick them up, and the PR-6
+        // briefing keeps priority+channel combined use out of scope.
+        // Channel messages still land in `inbox/channel/<name>/` regardless
+        // of priority, so they're reachable via the full inbox scan.
         if recipient.starts_with("channel:") {
             continue;
         }
@@ -850,15 +877,33 @@ pub fn select_messages(
 ) -> Vec<ParsedMessage> {
     // Fast path for --priority urgent|blocker: scan the priority lane under
     // inbox/urgent/<handle>/ (+ inbox/urgent/all/ for broadcasts) instead of
-    // the whole flat inbox. Design §2.5 / §2.9.
-    let mut msgs = match priority {
-        Some(MsgPriority::Urgent) | Some(MsgPriority::Blocker) => {
-            scan_urgent_lane(inbox, for_handle)
-        }
-        _ => list_messages(inbox),
+    // the whole flat inbox. Design §2.5 / §2.9. The fast path is disabled
+    // when --channel is set — channel recipients don't get urgent/
+    // symlinks (PR-6), so scanning the urgent lane would miss them.
+    let use_urgent_fast_path = matches!(
+        priority,
+        Some(MsgPriority::Urgent) | Some(MsgPriority::Blocker)
+    ) && channel.is_none();
+    let mut msgs = if use_urgent_fast_path {
+        scan_urgent_lane(inbox, for_handle)
+    } else {
+        list_messages(inbox)
     };
 
-    if let Some(h) = for_handle {
+    // Addressing filter: the interaction between `--for` and `--channel`
+    // matters. A channel message is addressed to `channel:<name>`, not to
+    // any direct handle — so the default `matches_for_handle` check would
+    // drop every channel message when both `--for` and `--channel` are set,
+    // which defeats the briefing's "fetch --channel X --for Y" use case
+    // (design §2.3, PR-6). When `--channel` is specified, treat the channel
+    // filter as the primary addressing check and let `--for` downgrade to
+    // "exclude messages sent by this handle".
+    if let Some(ch) = channel {
+        msgs.retain(|m| matches_channel(&m.fm, ch));
+        if let Some(h) = for_handle {
+            msgs.retain(|m| m.fm.from != h);
+        }
+    } else if let Some(h) = for_handle {
         msgs.retain(|m| matches_for_handle(&m.fm, h));
     }
     if let Some(ts_or_cursor) = since {
@@ -881,9 +926,6 @@ pub fn select_messages(
     }
     if let Some(t) = thread {
         msgs.retain(|m| m.fm.thread.as_deref() == Some(t) || m.fm.id == t);
-    }
-    if let Some(ch) = channel {
-        msgs.retain(|m| matches_channel(&m.fm, ch));
     }
     if let Some(n) = limit {
         msgs.truncate(n);
@@ -1157,7 +1199,7 @@ pub fn find_by_id(inbox: &Path, id: &str) -> Option<Frontmatter> {
 // --- Command entry points --------------------------------------------------
 
 pub fn cmd_send(
-    to: String,
+    to: Option<String>,
     from: Option<String>,
     priority: MsgPriority,
     subject: Option<String>,
@@ -1183,7 +1225,27 @@ pub fn cmd_send(
         }
     };
 
-    let mut to_list: Vec<String> = split_csv(&to);
+    // Clap can't distinguish `twapp msg send --channel X "body"` (where the
+    // single positional is the body, routing comes from --channel) from
+    // `twapp msg send reviewer "body"` (positional is the recipient). When
+    // --channel is supplied AND there is exactly one positional AND no
+    // explicit body, reinterpret that positional as the body — the channel
+    // is already the sole recipient.
+    let channel_nonempty = channel
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .is_some();
+    let (to_arg, body_arg) = if channel_nonempty && body.is_none() {
+        (None, to)
+    } else {
+        (to, body)
+    };
+
+    let mut to_list: Vec<String> = match to_arg.as_deref() {
+        Some(s) => split_csv(s),
+        None => Vec::new(),
+    };
     if let Some(ch) = channel.as_ref() {
         let ch = ch.trim();
         if !ch.is_empty() {
@@ -1216,7 +1278,7 @@ pub fn cmd_send(
         (thread, None)
     };
 
-    let body_text = match body {
+    let body_text = match body_arg {
         Some(b) => b,
         None => match read_stdin_body() {
             Ok(b) => b,
@@ -1554,18 +1616,14 @@ fn read_stdin_body() -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
+    use crate::cli::test_env;
+    use std::sync::MutexGuard;
 
-    // Serialize every test that touches TWAPP_MAILBOX_DIR / TWAPP_SHARED_DIR.
-    // `cargo test` runs tests in parallel, and process-wide env is global state.
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
-
-    // Per-test temp mailbox with automatic env var setup.
+    // Per-test temp mailbox with automatic env var setup. Every test that
+    // mutates TWAPP_MAILBOX_DIR / TWAPP_SHARED_DIR acquires the shared
+    // `test_env::lock()` — process-wide env is global state, so one lock
+    // across every module is the only thing that makes cross-module
+    // parallel runs deterministic.
     struct MailboxGuard {
         root: PathBuf,
         prev_mailbox: Option<String>,
@@ -1575,7 +1633,7 @@ mod tests {
 
     impl MailboxGuard {
         fn new() -> Self {
-            let _guard = env_lock();
+            let _guard = test_env::lock();
             let root = std::env::temp_dir().join(format!(
                 "twapp-msg-test-{}",
                 uuid::Uuid::new_v4()
@@ -2141,7 +2199,7 @@ new\n";
 
     #[test]
     fn resolve_mailbox_falls_back_to_shared_dir() {
-        let _lock = env_lock();
+        let _lock = test_env::lock();
         let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
         let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
         std::env::remove_var("TWAPP_MAILBOX_DIR");
@@ -2162,7 +2220,7 @@ new\n";
 
     #[test]
     fn resolve_mailbox_errors_when_unset() {
-        let _lock = env_lock();
+        let _lock = test_env::lock();
         let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
         let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
         std::env::remove_var("TWAPP_MAILBOX_DIR");
@@ -2212,12 +2270,58 @@ new\n";
     }
 
     #[test]
-    fn clap_send_without_positional_to_fails() {
+    fn clap_send_without_positional_to_parses_but_runtime_rejects() {
         use clap::Parser;
-        let err = MsgCliTest::try_parse_from(["send"]).unwrap_err();
-        // Clap complains about the missing required `<TO>` argument.
-        let s = format!("{}", err);
-        assert!(s.to_ascii_lowercase().contains("to"), "got: {}", s);
+        // `<to>` is now optional at the clap level so `--channel <name>` can
+        // be the sole recipient (design §2.3, PR-6). Clap accepts a bare
+        // `send` with no positional; `cmd_send` then rejects at runtime with
+        // a human-readable error when neither `to` nor `--channel` produce a
+        // recipient.
+        let parsed = MsgCliTest::try_parse_from(["send"]).unwrap();
+        match parsed.cmd {
+            MsgCommands::Send {
+                to,
+                channel,
+                body,
+                ..
+            } => {
+                assert!(to.is_none());
+                assert!(channel.is_none());
+                assert!(body.is_none());
+            }
+            _ => panic!("expected Send"),
+        }
+    }
+
+    #[test]
+    fn clap_send_accepts_channel_flag_with_single_positional() {
+        use clap::Parser;
+        // `twapp msg send --channel X "body"` — clap fills `to` first
+        // (that's the argv-positional assignment rule), so at the parsed
+        // level the positional lands in `to` and `body` stays None. The
+        // runtime reinterpretation in `cmd_send` is what makes this shape
+        // work as a channel-only send; see
+        // `channel_flag_alone_reroutes_single_positional_to_body`.
+        let parsed = MsgCliTest::try_parse_from([
+            "send",
+            "--channel",
+            "reviewers",
+            "hello channel",
+        ])
+        .unwrap();
+        match parsed.cmd {
+            MsgCommands::Send {
+                to,
+                channel,
+                body,
+                ..
+            } => {
+                assert_eq!(to.as_deref(), Some("hello channel"));
+                assert_eq!(channel.as_deref(), Some("reviewers"));
+                assert!(body.is_none());
+            }
+            _ => panic!("expected Send"),
+        }
     }
 
     #[test]
@@ -2252,7 +2356,7 @@ new\n";
                 body,
                 ..
             } => {
-                assert_eq!(to, "reviewer");
+                assert_eq!(to.as_deref(), Some("reviewer"));
                 assert_eq!(from.as_deref(), Some("me"));
                 assert_eq!(priority, MsgPriority::Urgent);
                 assert_eq!(body.as_deref(), Some("hello"));
@@ -3006,5 +3110,219 @@ new\n";
         let thread = list_thread(&empty_mailbox.join("inbox"), "ANY");
         assert!(thread.is_empty());
         let _ = std::fs::remove_dir_all(&empty_mailbox);
+    }
+
+    // ---- PR-6: channels --------------------------------------------------
+
+    fn send_channel_msg(
+        inbox: &Path,
+        channel: &str,
+        from: &str,
+        body: &str,
+    ) -> SentMessage {
+        write_message(
+            inbox,
+            SendArgs {
+                to: vec![format!("channel:{}", channel)],
+                from: from.to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: body.to_string(),
+            },
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn channel_fetch_returns_only_messages_on_that_channel() {
+        let g = MailboxGuard::new();
+        send_channel_msg(&g.inbox(), "reviewers", "coordinator", "r1");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send_channel_msg(&g.inbox(), "reviewers", "coordinator", "r2");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send_channel_msg(&g.inbox(), "announcements", "coordinator", "a1");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            None,
+            None,
+            None,
+            None,
+            Some("reviewers"),
+            None,
+        );
+        let bodies: Vec<&str> = msgs.iter().map(|m| m.body.trim()).collect();
+        assert_eq!(msgs.len(), 2, "got: {:?}", bodies);
+        assert!(bodies.contains(&"r1"));
+        assert!(bodies.contains(&"r2"));
+        assert!(!bodies.contains(&"a1"));
+    }
+
+    #[test]
+    fn channel_fetch_with_for_excludes_self_sent_messages() {
+        // `fetch --channel X --for Y` returns everything on channel X except
+        // messages Y itself sent. Previously, the stacked `matches_for_handle`
+        // filter would reject every channel message (channel:X isn't in the
+        // direct/broadcast/cc lanes Y would normally match on) — this test
+        // pins the PR-6 fix.
+        let g = MailboxGuard::new();
+        send_channel_msg(&g.inbox(), "reviewers", "coordinator", "from-coord");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send_channel_msg(&g.inbox(), "reviewers", "reviewer-a", "from-self");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            Some("reviewer-a"),
+            None,
+            None,
+            None,
+            Some("reviewers"),
+            None,
+        );
+        let bodies: Vec<&str> = msgs.iter().map(|m| m.body.trim()).collect();
+        assert_eq!(msgs.len(), 1, "got: {:?}", bodies);
+        assert_eq!(bodies[0], "from-coord");
+    }
+
+    #[test]
+    fn channel_fetch_on_unknown_channel_returns_empty_no_crash() {
+        // The briefing's "Unknown channel fetch returns empty, no crash"
+        // checklist item. Exercises the cold path where no subdir exists
+        // under inbox/channel/ — list_messages must still succeed and the
+        // channel filter must leave the result empty.
+        let g = MailboxGuard::new();
+        // One channel message to another channel; a direct message; and a
+        // broadcast — proof that the filter is channel-specific, not just
+        // "everything is empty".
+        send_channel_msg(&g.inbox(), "reviewers", "coordinator", "r");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Routine, "d");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send(&g.inbox(), vec!["all"], MsgPriority::Routine, "b");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            None,
+            None,
+            None,
+            None,
+            Some("never-created-channel"),
+            None,
+        );
+        assert!(msgs.is_empty(), "got: {:?}", msgs.iter().map(|m| &m.fm.id).collect::<Vec<_>>());
+
+        // And the same on a truly empty mailbox (no inbox/channel/ at all).
+        let empty = std::env::temp_dir()
+            .join(format!("twapp-msg-empty-chan-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(empty.join("inbox")).unwrap();
+        let msgs = select_messages(
+            &empty.join("inbox"),
+            None,
+            None,
+            None,
+            None,
+            Some("nothing"),
+            None,
+        );
+        assert!(msgs.is_empty());
+        let _ = std::fs::remove_dir_all(&empty);
+    }
+
+    #[test]
+    fn channel_flag_alone_reroutes_single_positional_to_body() {
+        // `twapp msg send --channel X "body"` — clap fills the one
+        // positional into `to`, but `cmd_send` reinterprets that as the
+        // body when --channel is set and no explicit body is present.
+        // End-to-end via the real CLI entry point with stdin closed
+        // (empty stdin would otherwise swallow the body).
+        let g = MailboxGuard::new();
+        let code = cmd_send(
+            Some("body text goes here".to_string()),
+            Some("coordinator".to_string()),
+            MsgPriority::Routine,
+            None,
+            None,
+            None,
+            None,
+            Some("reviewers".to_string()),
+            None, // body explicitly None — mimics the clap parse shape
+        );
+        assert_eq!(code, 0);
+        let msgs = list_messages(&g.inbox());
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].fm.to, vec!["channel:reviewers".to_string()]);
+        assert_eq!(msgs[0].body.trim(), "body text goes here");
+    }
+
+    #[test]
+    fn fetch_priority_urgent_with_channel_filter_sees_channel_messages() {
+        // Urgent channel messages don't get an urgent/ symlink today
+        // (PR-6's deferred urgent lane for channels). When --priority is
+        // combined with --channel, select_messages must fall back to the
+        // full inbox scan instead of the urgent-lane fast path — otherwise
+        // the urgent channel message is invisible on fetch.
+        let g = MailboxGuard::new();
+        write_message(
+            &g.inbox(),
+            SendArgs {
+                to: vec!["channel:reviewers".to_string()],
+                from: "coordinator".to_string(),
+                priority: MsgPriority::Urgent,
+                subject: Some("urgent review please".to_string()),
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: "please look".to_string(),
+            },
+        )
+        .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // Noise: urgent direct, routine channel. Neither should show up.
+        send(&g.inbox(), vec!["reviewer"], MsgPriority::Urgent, "direct urgent");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send_channel_msg(&g.inbox(), "reviewers", "coordinator", "routine on channel");
+
+        let msgs = select_messages(
+            &g.inbox(),
+            None,
+            None,
+            Some(MsgPriority::Urgent),
+            None,
+            Some("reviewers"),
+            None,
+        );
+        let bodies: Vec<&str> = msgs.iter().map(|m| m.body.trim()).collect();
+        assert_eq!(msgs.len(), 1, "got: {:?}", bodies);
+        assert_eq!(bodies[0], "please look");
+    }
+
+    #[test]
+    fn channel_message_written_to_flat_archive_rotates_by_day_pr7() {
+        // The briefing promises "Channel messages archive with the same
+        // daily rotation as other messages (PR-7 behavior, already
+        // shipped)". This test documents the contract: a channel message
+        // dropped into `archive/` (flat) by an archival tool rotates into
+        // `archive/<YYYY-MM-DD>/` keyed off its fenced-frontmatter `ts`,
+        // same as a broadcast or direct message would.
+        let g = MailboxGuard::new();
+        let sent = send_channel_msg(&g.inbox(), "reviewers", "coordinator", "archived");
+        let archive = g.root.join("archive");
+        std::fs::create_dir_all(&archive).unwrap();
+        let flat = archive.join(sent.path.file_name().unwrap());
+        std::fs::rename(&sent.path, &flat).unwrap();
+
+        let moves = crate::cli::msg_archive::rotate_archive(&archive, false).unwrap();
+        assert_eq!(moves.len(), 1);
+        // Day taken from the fenced-frontmatter ts — e.g. `20260420T...`
+        // becomes `2026-04-20`. We reconstruct the expected date from the
+        // same ts the sender wrote, so the assertion survives running on
+        // any calendar day.
+        let ts = &sent.fm.ts;
+        let expected_date = format!("{}-{}-{}", &ts[..4], &ts[4..6], &ts[6..8]);
+        assert_eq!(moves[0].date, expected_date);
+        assert!(moves[0].to.exists(), "rotated file missing at {}", moves[0].to.display());
     }
 }

--- a/src-tauri/src/cli/msg_channel.rs
+++ b/src-tauri/src/cli/msg_channel.rs
@@ -1,0 +1,398 @@
+//! `twapp msg channel` — channel listing + subscriber lookup.
+//!
+//! PR-6 of the design in `docs/designs/agent-messaging.md` (§2.3). Channels
+//! are topic-scoped fan-in, written under `inbox/channel/<name>/<ts>-<id>.md`.
+//! Addressing is already first-class in `msg.rs` (recipients of the form
+//! `channel:<name>`); this module adds the two observability lookups the
+//! design spec calls for:
+//!
+//! - `twapp msg channel list` — every channel name present under
+//!   `inbox/channel/`, with message counts.
+//! - `twapp msg channel subscribers <name>` — handles whose
+//!   `presence/<handle>.json`'s `claims` array contains `channel:<name>`.
+//!
+//! Subscription is by-convention (design §2.3). Senders don't consult this
+//! list; it's a coordinator-facing view of "who has declared interest in
+//! channel X". Actual delivery is every subscriber scanning their claimed
+//! channels in their own fetch cycle.
+
+use clap::{Subcommand, ValueEnum};
+use std::path::Path;
+
+use super::msg::{channel_dir, inbox_dir};
+use super::msg_presence::{list_presence, PresenceFile};
+
+// --- Output format ----------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum ChannelFormat {
+    Pretty,
+    Json,
+}
+
+// --- CLI subcommand model ---------------------------------------------------
+
+#[derive(Subcommand, Debug)]
+pub enum ChannelCommands {
+    /// List every channel present under `<mailbox>/inbox/channel/`, with
+    /// message counts. A channel exists for the purposes of this listing if
+    /// its directory has been created — empty channels are reported with a
+    /// count of 0 so operators can see a newly-declared channel before its
+    /// first message lands.
+    #[command(
+        after_help = "Examples:\n  twapp msg channel list\n  twapp msg channel list --format json"
+    )]
+    List {
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = ChannelFormat::Pretty)]
+        format: ChannelFormat,
+    },
+    /// Print handles whose `presence/<handle>.json`'s `claims` array
+    /// contains `channel:<name>`.
+    ///
+    /// Subscription is by-convention (design §2.3). A handle without a
+    /// presence file — including a dead / offboarded handle — is never
+    /// listed. This is the coordinator's "who is listening on channel X?"
+    /// view; senders don't need it, since a channel send is fan-in, not
+    /// fan-out.
+    #[command(
+        after_help = "Examples:\n  twapp msg channel subscribers reviewers\n  twapp msg channel subscribers reviewers --format json"
+    )]
+    Subscribers {
+        /// Channel name (without the `channel:` prefix).
+        name: String,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = ChannelFormat::Pretty)]
+        format: ChannelFormat,
+    },
+}
+
+// --- Listing ----------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ChannelCount {
+    pub name: String,
+    pub count: usize,
+}
+
+/// Return every channel subdirectory under `inbox/channel/` along with a
+/// count of its `.md` files (non-recursive — channels don't nest). Sorted
+/// by name ascending. Missing `inbox/channel/` → empty vec.
+pub fn list_channels(inbox: &Path) -> Vec<ChannelCount> {
+    let root = channel_dir(inbox);
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(ft) = entry.file_type() else {
+            continue;
+        };
+        if !ft.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let count = count_md_files(&path);
+        out.push(ChannelCount {
+            name: name.to_string(),
+            count,
+        });
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
+}
+
+fn count_md_files(dir: &Path) -> usize {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    let mut n = 0usize;
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(|s| s.to_string()) else {
+            continue;
+        };
+        if !name.ends_with(".md") {
+            continue;
+        }
+        // Count every .md — symlinks included, because a channel message is
+        // real the moment a sender writes to `inbox/channel/<name>/`,
+        // regardless of whether the file on disk is the canonical copy or a
+        // secondary shim from multi-recipient delivery.
+        n += 1;
+    }
+    n
+}
+
+// --- Subscribers ------------------------------------------------------------
+
+/// Return every handle whose `presence/<handle>.json`'s `claims` array
+/// contains `channel:<name>`. Dead handles (no presence file) are excluded
+/// by construction, since `list_presence` only sees files that are on disk.
+/// Sorted by handle name ascending.
+pub fn channel_subscribers(mailbox: &Path, name: &str) -> Vec<String> {
+    let target = format!("channel:{}", name);
+    list_presence(mailbox)
+        .into_iter()
+        .filter(|p| p.claims.iter().any(|c| c == &target))
+        .map(|p: PresenceFile| p.handle)
+        .collect()
+}
+
+// --- Command entry points ---------------------------------------------------
+
+pub fn cmd_list(format: ChannelFormat) -> i32 {
+    let inbox = match inbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let channels = list_channels(&inbox);
+    match format {
+        ChannelFormat::Json => match serde_json::to_string_pretty(&channels) {
+            Ok(s) => {
+                println!("{}", s);
+                0
+            }
+            Err(e) => {
+                eprintln!("Error serializing: {}", e);
+                1
+            }
+        },
+        ChannelFormat::Pretty => {
+            if channels.is_empty() {
+                println!("(no channels)");
+                return 0;
+            }
+            let total: usize = channels.iter().map(|c| c.count).sum();
+            for c in &channels {
+                println!("{:<32} {}", c.name, c.count);
+            }
+            println!(
+                "total: {} message(s) across {} channel(s)",
+                total,
+                channels.len()
+            );
+            0
+        }
+    }
+}
+
+pub fn cmd_subscribers(name: String, format: ChannelFormat) -> i32 {
+    let mailbox = match super::msg::resolve_mailbox_dir() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            return 1;
+        }
+    };
+    let subscribers = channel_subscribers(&mailbox, &name);
+    match format {
+        ChannelFormat::Json => match serde_json::to_string_pretty(&subscribers) {
+            Ok(s) => {
+                println!("{}", s);
+                0
+            }
+            Err(e) => {
+                eprintln!("Error serializing: {}", e);
+                1
+            }
+        },
+        ChannelFormat::Pretty => {
+            if subscribers.is_empty() {
+                println!("(no subscribers to channel:{})", name);
+                return 0;
+            }
+            for h in &subscribers {
+                println!("{}", h);
+            }
+            0
+        }
+    }
+}
+
+// --- Tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::msg::{write_message, MsgPriority, SendArgs};
+    use crate::cli::msg_presence::{write_presence, PresenceStatus};
+    use crate::cli::test_env;
+    use std::path::PathBuf;
+    use std::sync::MutexGuard;
+
+    struct Guard {
+        root: PathBuf,
+        prev_mailbox: Option<String>,
+        prev_shared: Option<String>,
+        _guard: MutexGuard<'static, ()>,
+    }
+
+    impl Guard {
+        fn new() -> Self {
+            let _guard = test_env::lock();
+            let root = std::env::temp_dir().join(format!(
+                "twapp-channel-test-{}",
+                uuid::Uuid::new_v4()
+            ));
+            std::fs::create_dir_all(root.join("inbox")).unwrap();
+            let prev_mailbox = std::env::var("TWAPP_MAILBOX_DIR").ok();
+            let prev_shared = std::env::var("TWAPP_SHARED_DIR").ok();
+            std::env::set_var("TWAPP_MAILBOX_DIR", &root);
+            std::env::remove_var("TWAPP_SHARED_DIR");
+            Guard {
+                root,
+                prev_mailbox,
+                prev_shared,
+                _guard,
+            }
+        }
+
+        fn inbox(&self) -> PathBuf {
+            self.root.join("inbox")
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            match &self.prev_mailbox {
+                Some(v) => std::env::set_var("TWAPP_MAILBOX_DIR", v),
+                None => std::env::remove_var("TWAPP_MAILBOX_DIR"),
+            }
+            match &self.prev_shared {
+                Some(v) => std::env::set_var("TWAPP_SHARED_DIR", v),
+                None => std::env::remove_var("TWAPP_SHARED_DIR"),
+            }
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn send_channel(inbox: &Path, channel: &str, from: &str, body: &str) {
+        write_message(
+            inbox,
+            SendArgs {
+                to: vec![format!("channel:{}", channel)],
+                from: from.to_string(),
+                priority: MsgPriority::Routine,
+                subject: None,
+                thread: None,
+                in_reply_to: None,
+                cc: Vec::new(),
+                body: body.to_string(),
+            },
+        )
+        .unwrap();
+    }
+
+    fn seed_presence(mailbox: &Path, handle: &str, claims: Vec<&str>) {
+        let file = PresenceFile {
+            handle: handle.to_string(),
+            status: PresenceStatus::Processing,
+            last_heartbeat: "2026-04-20T20:29:57Z".to_string(),
+            current_task: None,
+            inbox_cursor: None,
+            poll_interval_sec: 90,
+            claims: claims.into_iter().map(|s| s.to_string()).collect(),
+        };
+        write_presence(mailbox, &file).unwrap();
+    }
+
+    #[test]
+    fn list_channels_reports_every_directory_with_counts() {
+        let g = Guard::new();
+        send_channel(&g.inbox(), "reviewers", "coordinator", "m1");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        send_channel(&g.inbox(), "reviewers", "coordinator", "m2");
+        send_channel(&g.inbox(), "announcements", "coordinator", "hi");
+
+        let channels = list_channels(&g.inbox());
+        assert_eq!(channels.len(), 2);
+        // Sorted alphabetically.
+        assert_eq!(channels[0].name, "announcements");
+        assert_eq!(channels[0].count, 1);
+        assert_eq!(channels[1].name, "reviewers");
+        assert_eq!(channels[1].count, 2);
+    }
+
+    #[test]
+    fn list_channels_empty_inbox_returns_empty() {
+        let g = Guard::new();
+        // No channel/ dir at all.
+        let channels = list_channels(&g.inbox());
+        assert!(channels.is_empty());
+    }
+
+    #[test]
+    fn list_channels_includes_empty_channel_dir() {
+        // A channel dir that exists but has no messages yet — e.g., created
+        // by a subscriber as a hint before any sender uses it — still shows
+        // up in the listing with count 0.
+        let g = Guard::new();
+        std::fs::create_dir_all(g.inbox().join("channel/placeholder")).unwrap();
+        let channels = list_channels(&g.inbox());
+        assert_eq!(channels.len(), 1);
+        assert_eq!(channels[0].name, "placeholder");
+        assert_eq!(channels[0].count, 0);
+    }
+
+    #[test]
+    fn channel_subscribers_filters_by_claim() {
+        let g = Guard::new();
+        seed_presence(&g.root, "alpha", vec!["channel:reviewers"]);
+        seed_presence(
+            &g.root,
+            "beta",
+            vec!["channel:reviewers", "channel:announcements"],
+        );
+        seed_presence(&g.root, "gamma", vec!["channel:announcements"]);
+        // No claims at all — never appears.
+        seed_presence(&g.root, "delta", vec![]);
+
+        let reviewers = channel_subscribers(&g.root, "reviewers");
+        assert_eq!(reviewers, vec!["alpha".to_string(), "beta".to_string()]);
+        let announcements = channel_subscribers(&g.root, "announcements");
+        assert_eq!(
+            announcements,
+            vec!["beta".to_string(), "gamma".to_string()]
+        );
+        let unknown = channel_subscribers(&g.root, "nobody-listens-here");
+        assert!(unknown.is_empty());
+    }
+
+    #[test]
+    fn channel_subscribers_with_no_presence_files_returns_empty() {
+        let g = Guard::new();
+        // No presence/ directory at all — common on a fresh mailbox.
+        let subs = channel_subscribers(&g.root, "whatever");
+        assert!(subs.is_empty());
+    }
+
+    #[test]
+    fn cmd_list_and_cmd_subscribers_exit_zero() {
+        let g = Guard::new();
+        send_channel(&g.inbox(), "reviewers", "coordinator", "hi");
+        seed_presence(&g.root, "alpha", vec!["channel:reviewers"]);
+
+        assert_eq!(cmd_list(ChannelFormat::Json), 0);
+        assert_eq!(cmd_list(ChannelFormat::Pretty), 0);
+        assert_eq!(
+            cmd_subscribers("reviewers".to_string(), ChannelFormat::Json),
+            0
+        );
+        assert_eq!(
+            cmd_subscribers("reviewers".to_string(), ChannelFormat::Pretty),
+            0
+        );
+        // Unknown channel name — still exits 0, just reports empty.
+        assert_eq!(
+            cmd_subscribers("nope".to_string(), ChannelFormat::Pretty),
+            0
+        );
+    }
+}

--- a/src-tauri/src/cli/msg_claim.rs
+++ b/src-tauri/src/cli/msg_claim.rs
@@ -654,14 +654,8 @@ impl From<ClaimListFormat> for FetchFormat {
 mod tests {
     use super::*;
     use crate::cli::msg::parse_message_file;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
+    use crate::cli::test_env;
+    use std::sync::MutexGuard;
 
     struct MailboxGuard {
         root: PathBuf,
@@ -672,7 +666,7 @@ mod tests {
 
     impl MailboxGuard {
         fn new() -> Self {
-            let _guard = env_lock();
+            let _guard = test_env::lock();
             let root = std::env::temp_dir()
                 .join(format!("twapp-claim-test-{}", uuid::Uuid::new_v4()));
             std::fs::create_dir_all(root.join("inbox")).unwrap();

--- a/src-tauri/src/cli/msg_cursors.rs
+++ b/src-tauri/src/cli/msg_cursors.rs
@@ -161,14 +161,8 @@ pub fn cmd_ack(msg_id: String, from: Option<String>, note: Option<String>) -> i3
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
+    use crate::cli::test_env;
+    use std::sync::MutexGuard;
 
     struct Guard {
         root: PathBuf,
@@ -179,7 +173,7 @@ mod tests {
 
     impl Guard {
         fn new() -> Self {
-            let _guard = env_lock();
+            let _guard = test_env::lock();
             let root = std::env::temp_dir().join(format!(
                 "twapp-cursor-test-{}",
                 uuid::Uuid::new_v4()

--- a/src-tauri/src/cli/msg_migrate.rs
+++ b/src-tauri/src/cli/msg_migrate.rs
@@ -214,14 +214,8 @@ pub fn cmd_migrate(dry_run: bool, drop_legacy: bool) -> i32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
+    use crate::cli::test_env;
+    use std::sync::MutexGuard;
 
     struct Guard {
         root: PathBuf,
@@ -232,7 +226,7 @@ mod tests {
 
     impl Guard {
         fn new() -> Self {
-            let _guard = env_lock();
+            let _guard = test_env::lock();
             let root = std::env::temp_dir().join(format!(
                 "twapp-migrate-test-{}",
                 uuid::Uuid::new_v4()

--- a/src-tauri/src/cli/msg_presence.rs
+++ b/src-tauri/src/cli/msg_presence.rs
@@ -479,14 +479,8 @@ fn print_pretty(file: &PresenceFile, now: chrono::DateTime<chrono::Utc>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, MutexGuard, OnceLock};
-
-    fn env_lock() -> MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
-    }
+    use crate::cli::test_env;
+    use std::sync::MutexGuard;
 
     struct Guard {
         root: PathBuf,
@@ -497,7 +491,7 @@ mod tests {
 
     impl Guard {
         fn new() -> Self {
-            let _guard = env_lock();
+            let _guard = test_env::lock();
             let root =
                 std::env::temp_dir().join(format!("twapp-presence-test-{}", uuid::Uuid::new_v4()));
             std::fs::create_dir_all(&root).unwrap();

--- a/src-tauri/src/cli/test_env.rs
+++ b/src-tauri/src/cli/test_env.rs
@@ -1,0 +1,21 @@
+//! Process-wide test env lock, shared by every test module that mutates
+//! environment variables like `TWAPP_MAILBOX_DIR` / `TWAPP_SHARED_DIR`.
+//!
+//! Each module used to define its own `OnceLock<Mutex<()>>` inside `tests`,
+//! but those were independent mutexes — so tests in module A could run
+//! concurrently with tests in module B even though both were mutating the
+//! same global process env, producing flakes where one test read the env
+//! var that another test had just clobbered. A single shared lock fixes
+//! that without giving up parallelism between tests that don't touch env.
+#![cfg(test)]
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Acquire the shared test env mutex. Poisoned locks are recovered — a
+/// panicking test must not permanently brick the rest of the suite.
+pub fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}


### PR DESCRIPTION
## Summary

PR-6 of [`docs/designs/agent-messaging.md`](docs/designs/agent-messaging.md) §2.3. Channels are topic-scoped fan-in — a sender writes to a *name*, not a handle, and any subscriber watching that name picks up the traffic. Replaces the ad-hoc `reviewer-standby`-style pseudo-handle hack that previously leaked channel state into the receiver slot.

The addressing primitive (`to: channel:<name>` → `inbox/channel/<name>/`) already landed in PR-3 — PR-6 fills in the observability lookups the design spec calls for and fixes the edge cases that blocked channel use end-to-end.

### What ships

- **`twapp msg send --channel <name>` form**: the positional `<to>` is now optional; the one positional is reinterpreted as the body when `--channel` supplies the routing. Positional `channel:<name>` form already worked and is unchanged.
- **`twapp msg fetch --channel <name> [--for <handle>]`**: both flags can coexist — channel becomes the primary addressing check, and `--for` downgrades to "exclude messages I sent". Previously the stacked `matches_for_handle` filter dropped every channel message.
- **`twapp msg fetch --priority urgent --channel <name>`**: disables the urgent-lane fast path when `--channel` is set, since channel messages don't get `urgent/` symlinks today (deferred to a later PR).
- **New `twapp msg channel list [--format json]`** — every channel under `inbox/channel/` with a message count, empty channels included.
- **New `twapp msg channel subscribers <name> [--format json]`** — handles whose `presence/<handle>.json` `claims` array contains `channel:<name>`.

Subscription remains by-convention (design §2.3): senders don't consult the subscribers list; every subscriber scans its own claimed channels in its `/loop` fetch cycle. **Out of scope**: enforcement of subscription, per-channel ACLs, urgent-lane for channels.

### Test isolation cleanup

Adding `msg_channel`'s own `env_lock()` static tipped over a pre-existing flake: every `msg_*` test module had its own `OnceLock<Mutex<()>>`, so they didn't coordinate across modules even though they all mutate process-wide `TWAPP_MAILBOX_DIR`. Consolidated into a single `cli::test_env::lock()` shared by every test that touches env. The whole 263-test suite now passes in parallel (previously did only serially).

### Docs

- README "Channels (PR-6)" subsection + PR-6 added to the design coverage list.
- `skills/agent-coordinator/SKILL.md`: channels supersede the `-standby` handle hack; added a Channels subsection and updated the reviewer archetype row.
- `skills/spawn-agent/SKILL.md`: Example B (reviewer) shows the channel subscription pattern via `presence heartbeat --claims`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test --lib` — 263 passed (was 251 pre-PR; added 12 channel + cmd_send tests)
- [x] `cargo clippy --lib` — no new warnings from this PR
- [x] E2E CLI smoke: send (both forms), broadcast --channel, channel list (pretty + json), channel subscribers (with and without presence seeds), fetch --channel, fetch --channel --for, unknown channel fetch
- [ ] Reviewer to verify the `fetch --for X --channel Y` semantics match their mental model — the PR interprets `--for` as "exclude self-sends" when `--channel` is also set, so a subscriber's loop doesn't re-surface its own messages.