### PR TITLE
fix(ui): hide urgent panel when no mailbox + inherit session theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,12 +744,18 @@ trace, not a crash.
 > top of any long write cycle — before the first line of code.
 
 Inside the session window, the sidebar shows an **Urgent** panel directly
-above Notes whenever the session has a handle. It polls `twapp msg fetch
---for <self> --priority urgent|blocker` every 10s, renders each message
-as a row (from + subject + priority chip + relative time), and auto-
-collapses after the queue has been empty for a minute. Click a row to
-open a read-only message view. Blockers get the strongest red accent,
-urgents a muted one. Single-session users with no handle see no panel.
+above Notes whenever the session has a handle **and a mailbox is
+configured** (i.e. `TWAPP_MAILBOX_DIR`, `TWAPP_SHARED_DIR/mailbox/`, or
+a `./mailbox/inbox/` directory under the session cwd resolves to an
+existing directory). It polls `twapp msg fetch --for <self> --priority
+urgent|blocker` every 10s, renders each message as a row (from + subject
++ priority chip + relative time), and auto-collapses after the queue has
+been empty for a minute. Click a row to open a read-only message view.
+Blockers get the strongest red accent, urgents a muted one.
+Single-session users with no handle — and regular twapp instances with
+no mailbox in sight — see no panel at all; a transient fetch failure
+shows a discreet "Urgent feed unavailable" footer instead of a red
+banner.
 
 #### Per-agent quick actions (context menu)
 

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -130,6 +130,7 @@ pub fn run(args: GuiArgs) {
             files::reveal_in_finder,
             msg::send_message,
             msg::fetch_messages,
+            msg::get_mailbox_status,
             fleet::list_fleet,
             timeline::list_timeline_events,
             agent_actions::focus_agent_window,

--- a/src-tauri/src/gui/msg.rs
+++ b/src-tauri/src/gui/msg.rs
@@ -273,6 +273,14 @@ pub struct MailboxStatus {
 /// The briefing says: TWAPP_MAILBOX_DIR → TWAPP_SHARED_DIR/mailbox → `<cwd>/mailbox/inbox`.
 /// A path counts as "configured" only if it actually exists on disk — empty
 /// env strings, missing dirs, and non-dir files all fall through.
+///
+/// This is a *cheap* existence check, not an authoritative reachability one:
+/// a read-only inbox, a permission-stripped directory, or a stale NFS mount
+/// still pass the probe and will surface their real failure when
+/// `fetch_messages` runs. That's deliberate — the probe is there to spare
+/// vanilla single-session users any urgent-lane UI at all, not to guarantee
+/// the feed works. Fetch-time errors degrade to the "Urgent feed unavailable"
+/// footer rather than bouncing back up to a render-gate.
 pub fn probe_mailbox_status(
     mailbox_env: Option<&str>,
     shared_env: Option<&str>,

--- a/src-tauri/src/gui/msg.rs
+++ b/src-tauri/src/gui/msg.rs
@@ -6,11 +6,15 @@
 //! - `fetch_messages` — `msg fetch --format json`. Used by the urgent-inbox
 //!   panel (`src/components/UrgentInbox.tsx`), which calls it once per
 //!   priority (urgent + blocker) and merges the results.
+//! - `get_mailbox_status` — pure filesystem probe. Lets co-lab UI decide
+//!   whether to render at all. Vanilla single-session users never see the
+//!   urgent panel because `configured: false` short-circuits the render.
 
 use super::types::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 #[derive(Debug, Clone, Deserialize)]
@@ -250,6 +254,57 @@ pub fn fetch_messages(
 ) -> Result<Vec<FetchedMessage>, String> {
     let argv = build_fetch_argv(&args)?;
     run_fetch(argv, config.cwd.as_deref())
+}
+
+// --- mailbox status probe ---------------------------------------------------
+
+#[derive(Debug, Clone, Serialize)]
+pub struct MailboxStatus {
+    /// True when at least one of the resolution paths exists on disk.
+    /// Co-lab UI (urgent panel, etc.) renders only when this is true.
+    pub configured: bool,
+    /// Which resolution path "won", for logs / future diagnostics. None when
+    /// nothing resolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Pure helper: given env lookups + cwd, decide whether a mailbox is reachable.
+/// The briefing says: TWAPP_MAILBOX_DIR → TWAPP_SHARED_DIR/mailbox → `<cwd>/mailbox/inbox`.
+/// A path counts as "configured" only if it actually exists on disk — empty
+/// env strings, missing dirs, and non-dir files all fall through.
+pub fn probe_mailbox_status(
+    mailbox_env: Option<&str>,
+    shared_env: Option<&str>,
+    cwd: Option<&Path>,
+) -> MailboxStatus {
+    if let Some(v) = mailbox_env.map(str::trim).filter(|s| !s.is_empty()) {
+        let p = PathBuf::from(v);
+        if p.is_dir() {
+            return MailboxStatus { configured: true, source: Some("TWAPP_MAILBOX_DIR".into()) };
+        }
+    }
+    if let Some(v) = shared_env.map(str::trim).filter(|s| !s.is_empty()) {
+        let p = PathBuf::from(v).join("mailbox");
+        if p.is_dir() {
+            return MailboxStatus { configured: true, source: Some("TWAPP_SHARED_DIR".into()) };
+        }
+    }
+    if let Some(c) = cwd {
+        let p = c.join("mailbox").join("inbox");
+        if p.is_dir() {
+            return MailboxStatus { configured: true, source: Some("cwd".into()) };
+        }
+    }
+    MailboxStatus { configured: false, source: None }
+}
+
+#[tauri::command]
+pub fn get_mailbox_status(config: tauri::State<'_, GuiArgs>) -> MailboxStatus {
+    let mailbox_env = std::env::var("TWAPP_MAILBOX_DIR").ok();
+    let shared_env = std::env::var("TWAPP_SHARED_DIR").ok();
+    let cwd = config.cwd.as_deref().map(Path::new);
+    probe_mailbox_status(mailbox_env.as_deref(), shared_env.as_deref(), cwd)
 }
 
 #[cfg(test)]
@@ -542,6 +597,104 @@ mod tests {
         let msgs = parse_fetch_stdout(json).unwrap();
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].id, "OK");
+    }
+
+    // --- mailbox status tests ------------------------------------------------
+
+    fn tmp_dir(tag: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let p = std::env::temp_dir().join(format!(
+            "twapp-mailbox-status-{}-{}-{}",
+            tag,
+            std::process::id(),
+            nanos
+        ));
+        let _ = std::fs::remove_dir_all(&p);
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn mailbox_status_unset_is_not_configured() {
+        let s = probe_mailbox_status(None, None, None);
+        assert!(!s.configured);
+        assert!(s.source.is_none());
+    }
+
+    #[test]
+    fn mailbox_status_empty_env_strings_are_ignored() {
+        // Shell exports like `TWAPP_MAILBOX_DIR=` set the var to an empty
+        // string; resolve_mailbox_dir treats those as unset, and so do we.
+        let s = probe_mailbox_status(Some(""), Some("   "), None);
+        assert!(!s.configured);
+    }
+
+    #[test]
+    fn mailbox_status_mailbox_env_points_at_existing_dir() {
+        let tmp = tmp_dir("mb-env");
+        let s = probe_mailbox_status(Some(tmp.to_str().unwrap()), None, None);
+        assert!(s.configured);
+        assert_eq!(s.source.as_deref(), Some("TWAPP_MAILBOX_DIR"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mailbox_status_mailbox_env_missing_dir_falls_through() {
+        // Env is set but the path doesn't exist — should not count as configured.
+        let s = probe_mailbox_status(Some("/definitely/not/a/real/path/twapp"), None, None);
+        assert!(!s.configured);
+    }
+
+    #[test]
+    fn mailbox_status_shared_env_fallback() {
+        let tmp = tmp_dir("shared-env");
+        std::fs::create_dir_all(tmp.join("mailbox")).unwrap();
+        let s = probe_mailbox_status(None, Some(tmp.to_str().unwrap()), None);
+        assert!(s.configured);
+        assert_eq!(s.source.as_deref(), Some("TWAPP_SHARED_DIR"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mailbox_status_shared_env_without_mailbox_subdir_falls_through() {
+        let tmp = tmp_dir("shared-bare");
+        // Note: no `mailbox/` created inside — shared-dir without the subdir
+        // is a stale config, not a real mailbox.
+        let s = probe_mailbox_status(None, Some(tmp.to_str().unwrap()), None);
+        assert!(!s.configured);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mailbox_status_cwd_fallback_when_env_unset() {
+        let tmp = tmp_dir("cwd-mb");
+        std::fs::create_dir_all(tmp.join("mailbox").join("inbox")).unwrap();
+        let s = probe_mailbox_status(None, None, Some(tmp.as_path()));
+        assert!(s.configured);
+        assert_eq!(s.source.as_deref(), Some("cwd"));
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn mailbox_status_prefers_mailbox_env_over_shared_and_cwd() {
+        let mb = tmp_dir("mb-pref");
+        let shared = tmp_dir("shared-also");
+        std::fs::create_dir_all(shared.join("mailbox")).unwrap();
+        let cwd = tmp_dir("cwd-also");
+        std::fs::create_dir_all(cwd.join("mailbox").join("inbox")).unwrap();
+        let s = probe_mailbox_status(
+            Some(mb.to_str().unwrap()),
+            Some(shared.to_str().unwrap()),
+            Some(cwd.as_path()),
+        );
+        assert_eq!(s.source.as_deref(), Some("TWAPP_MAILBOX_DIR"));
+        let _ = std::fs::remove_dir_all(&mb);
+        let _ = std::fs::remove_dir_all(&shared);
+        let _ = std::fs::remove_dir_all(&cwd);
     }
 
     #[test]

--- a/src/App.css
+++ b/src/App.css
@@ -4532,12 +4532,15 @@ a.file-link {
   z-index: 60;
 }
 
-/* Urgent-inbox panel (sidebar) */
+/* Urgent-inbox panel (sidebar).
+ * Background inherits the sidebar's session-accent color (applyThemeColor
+ * sets --bg-secondary to the per-instance accent). Tones overlay a red tint
+ * on top when urgent/blocker messages are present. */
 .urgent-panel {
   border-top: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
   padding: 8px 12px 6px;
-  background: var(--bg-primary);
+  background: transparent;
 }
 
 .urgent-panel.urgent-tone-blocker {
@@ -4637,6 +4640,18 @@ a.file-link {
   border-radius: 6px;
   font-size: 12px;
   white-space: pre-wrap;
+}
+
+/* Discreet footer shown when the mailbox is configured but a fetch failed
+ * (permissions, disk, etc.). Deliberately understated — the old URGENT-styled
+ * error banner was read as a real urgent message and alarmed vanilla users. */
+.urgent-footer-unavailable {
+  margin-top: 6px;
+  padding: 4px 0 2px;
+  font-size: 11px;
+  font-style: italic;
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .urgent-list {
@@ -4791,12 +4806,13 @@ a.file-link {
   flex: 1;
 }
 
-/* Coordinator fleet pane (sidebar) */
+/* Coordinator fleet pane (sidebar). Transparent so the sidebar's session
+ * accent (--bg-secondary) shows through — same pattern as .urgent-panel. */
 .fleet-panel {
   border-top: 1px solid var(--border-color);
   border-bottom: 1px solid var(--border-color);
   padding: 8px 12px 6px;
-  background: var(--bg-primary);
+  background: transparent;
 }
 
 .fleet-header {
@@ -5000,7 +5016,7 @@ a.file-link {
 .timeline-panel {
   border-bottom: 1px solid var(--border-color);
   padding: 8px 12px 6px;
-  background: var(--bg-primary);
+  background: transparent;
 }
 
 .timeline-header {

--- a/src/App.css
+++ b/src/App.css
@@ -4632,16 +4632,6 @@ a.file-link {
   font-style: italic;
 }
 
-.urgent-error {
-  padding: 6px 8px;
-  background: rgba(220, 38, 38, 0.10);
-  border: 1px solid rgba(220, 38, 38, 0.45);
-  color: #b91c1c;
-  border-radius: 6px;
-  font-size: 12px;
-  white-space: pre-wrap;
-}
-
 /* Discreet footer shown when the mailbox is configured but a fetch failed
  * (permissions, disk, etc.). Deliberately understated — the old URGENT-styled
  * error banner was read as a real urgent message and alarmed vanilla users. */

--- a/src/components/UrgentInbox.test.ts
+++ b/src/components/UrgentInbox.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
   mergeByPriority,
+  panelVisibility,
   priorityRank,
   parseTs,
   relativeTime,
@@ -110,5 +111,70 @@ describe("rowPreview", () => {
 
   it("returns a placeholder when both subject and body are empty", () => {
     expect(rowPreview(msg({ id: "1", priority: "urgent", ts: "T" }))).toBe("(no subject)");
+  });
+});
+
+// --- Panel-visibility gate (regression coverage for the vanilla-session bug) --
+//
+// Before this PR, a non-co-lab instance with no mailbox env saw
+// "URGENT: Error: No mailbox..." because `fetch_messages` errored and the
+// error was rendered as a red banner. The three cases the briefing calls out:
+//   (1) no mailbox → hide entirely
+//   (2) mailbox present + empty inbox → existing "No urgent messages" state
+//   (3) mailbox present + at least one msg → render the list
+
+describe("panelVisibility", () => {
+  it("hides the panel when there is no self-handle (single-session user)", () => {
+    expect(panelVisibility(null, true, [], null)).toEqual({ kind: "hidden" });
+  });
+
+  it("hides the panel while the mailbox probe is still pending", () => {
+    // `null` = probe in-flight; we must hide rather than flash the panel open
+    // and then disappear once the probe resolves as "not configured".
+    expect(panelVisibility("twapp-ui-urgent", null, [], null)).toEqual({ kind: "hidden" });
+  });
+
+  it("hides the panel when the mailbox is not configured — the bug this PR fixes", () => {
+    const msgs = [
+      msg({ id: "X", priority: "urgent", ts: "20260421T090000Z" }),
+    ];
+    // Even if a stale fetch result somehow populated `messages`, an unconfigured
+    // mailbox still hides. An error also stays suppressed — no scary banner.
+    expect(panelVisibility("twapp-ui-urgent", false, [], null)).toEqual({ kind: "hidden" });
+    expect(panelVisibility("twapp-ui-urgent", false, msgs, null)).toEqual({ kind: "hidden" });
+    expect(panelVisibility("twapp-ui-urgent", false, [], "No mailbox configured")).toEqual({
+      kind: "hidden",
+    });
+  });
+
+  it("shows the empty state when the mailbox is configured but the inbox is empty", () => {
+    expect(panelVisibility("twapp-ui-urgent", true, [], null)).toEqual({ kind: "empty" });
+  });
+
+  it("shows the list when the mailbox is configured and messages are present", () => {
+    const msgs = [
+      msg({ id: "A", priority: "urgent", ts: "20260421T090000Z" }),
+      msg({ id: "B", priority: "blocker", ts: "20260421T091000Z" }),
+    ];
+    expect(panelVisibility("twapp-ui-urgent", true, msgs, null)).toEqual({
+      kind: "list",
+      count: 2,
+    });
+  });
+
+  it("shows a discreet error footer (not a URGENT banner) on fetch failure", () => {
+    expect(
+      panelVisibility("twapp-ui-urgent", true, [], "permission denied: /foo/mailbox"),
+    ).toEqual({ kind: "error-footer", message: "permission denied: /foo/mailbox" });
+  });
+
+  it("prefers showing messages over the error footer when both are set (stale error)", () => {
+    // If a prior fetch failed but a later one succeeded, the real messages
+    // should win — the error is likely stale and would just add noise.
+    const msgs = [msg({ id: "A", priority: "urgent", ts: "20260421T090000Z" })];
+    expect(panelVisibility("twapp-ui-urgent", true, msgs, "older error")).toEqual({
+      kind: "list",
+      count: 1,
+    });
   });
 });

--- a/src/components/UrgentInbox.tsx
+++ b/src/components/UrgentInbox.tsx
@@ -22,10 +22,16 @@ type FetchArgs = {
   limit?: number;
 };
 
+export type MailboxStatus = { configured: boolean; source?: string };
+
 type UrgentInboxProps = {
   selfHandle: string | null;
   // Injected in tests; defaults to the Tauri invoke bridge.
   fetcher?: (args: FetchArgs) => Promise<UrgentMessage[]>;
+  // Mailbox-availability probe. Injected in tests; defaults to the Tauri
+  // `get_mailbox_status` bridge. Returning `{configured:false}` hides the
+  // panel entirely — vanilla single-session users never see urgent UI.
+  mailboxProbe?: () => Promise<MailboxStatus>;
   // Clock injection for deterministic relative-time tests.
   now?: () => number;
   // Poll interval in ms while expanded. 10s per briefing.
@@ -90,26 +96,80 @@ export function rowPreview(m: UrgentMessage): string {
   return firstLine ? firstLine.trim().slice(0, 120) : "(no subject)";
 }
 
+/** Pure: decide what the urgent panel should render, given the four inputs
+ *  it actually reacts to. Splitting this out keeps the gating logic
+ *  test-friendly and shields the main component from regressing the
+ *  "vanilla session sees scary URGENT banner" bug that this PR fixes. */
+export type PanelVisibility =
+  | { kind: "hidden" }
+  | { kind: "empty" }
+  | { kind: "list"; count: number }
+  | { kind: "error-footer"; message: string };
+
+export function panelVisibility(
+  selfHandle: string | null,
+  mailboxConfigured: boolean | null,
+  messages: UrgentMessage[],
+  error: string | null,
+): PanelVisibility {
+  // Single-session users (no handle) never see the panel.
+  if (!selfHandle) return { kind: "hidden" };
+  // Probe hasn't resolved yet, or resolved as "not configured".
+  if (!mailboxConfigured) return { kind: "hidden" };
+  if (messages.length > 0) return { kind: "list", count: messages.length };
+  if (error) return { kind: "error-footer", message: error };
+  return { kind: "empty" };
+}
+
 const tauriFetcher = (args: FetchArgs): Promise<UrgentMessage[]> =>
   invoke<UrgentMessage[]>("fetch_messages", { args });
+
+const tauriMailboxProbe = (): Promise<MailboxStatus> =>
+  invoke<MailboxStatus>("get_mailbox_status");
 
 /** Collapsible urgent-inbox panel for the session sidebar.
  *
  *  Fetches `priority: urgent` + `priority: blocker` messages addressed to the
  *  session's own handle and surfaces them with a red accent. Polls every 10s
- *  while expanded; auto-collapses when empty for >60s. No user handle = no
- *  panel (single-session users never see urgent UI). */
+ *  while expanded; auto-collapses when empty for >60s.
+ *
+ *  Rendering gates (both must be true):
+ *  - `selfHandle` is set — single-session users never see urgent UI.
+ *  - `get_mailbox_status` reports a configured mailbox — vanilla instances
+ *    without TWAPP_MAILBOX_DIR / TWAPP_SHARED_DIR / `./mailbox/inbox/` get
+ *    nothing, not an error banner. */
 export default function UrgentInbox({
   selfHandle,
   fetcher = tauriFetcher,
+  mailboxProbe = tauriMailboxProbe,
   now = () => Date.now(),
   pollMs = 10_000,
   collapseAfterEmptyMs = 60_000,
 }: UrgentInboxProps) {
+  // `null` = probe in flight (hide panel until we know); boolean = resolved.
+  const [mailboxConfigured, setMailboxConfigured] = useState<boolean | null>(null);
   const [messages, setMessages] = useState<UrgentMessage[]>([]);
   const [expanded, setExpanded] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [viewing, setViewing] = useState<UrgentMessage | null>(null);
+
+  // One-shot mailbox probe at panel init. No handle = no probe: we already
+  // render nothing, and probing would just be pointless filesystem I/O.
+  useEffect(() => {
+    if (!selfHandle) return;
+    let cancelled = false;
+    mailboxProbe()
+      .then((s) => {
+        if (!cancelled) setMailboxConfigured(!!s?.configured);
+      })
+      .catch(() => {
+        // Probe failure is a soft "no mailbox": hide, don't yell.
+        if (!cancelled) setMailboxConfigured(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selfHandle, mailboxProbe]);
 
   // `userCollapsed` is set when the user clicks the header to collapse.
   // It survives auto-collapse-due-to-empty: a subsequent manual expand re-enables
@@ -137,18 +197,23 @@ export default function UrgentInbox({
       setError(null);
     } catch (e) {
       if (seq !== fetchSeqRef.current) return;
+      // Log-then-soften: backend errors (permissions, disk, stale mailbox) get
+      // a discreet footer, never a scary URGENT-styled banner. See PR
+      // fix/ui-urgent-gate-on-mailbox for the rationale.
+      console.warn("[urgent] fetch failed:", e);
       setError(String(e));
     }
   }, [selfHandle, fetcher]);
 
   // Poll — runs whether expanded or not, because the chevron needs a live
   // count and auto-collapse decisions depend on knowing the queue is empty.
+  // Gated on mailboxConfigured so we don't spam the backend on vanilla sessions.
   useEffect(() => {
-    if (!selfHandle) return;
+    if (!selfHandle || !mailboxConfigured) return;
     doFetch();
     const h = window.setInterval(doFetch, pollMs);
     return () => window.clearInterval(h);
-  }, [selfHandle, doFetch, pollMs]);
+  }, [selfHandle, mailboxConfigured, doFetch, pollMs]);
 
   // Auto-collapse after sustained emptiness.
   useEffect(() => {
@@ -190,7 +255,11 @@ export default function UrgentInbox({
     }
   };
 
+  // Two gates: (a) no handle → single-session user, never render. (b) probe
+  // pending or resolved-as-not-configured → hide. Both avoid the prior bug
+  // where vanilla sessions saw a scary "URGENT: Error: No mailbox..." banner.
   if (!selfHandle) return null;
+  if (!mailboxConfigured) return null;
 
   const tone =
     messages.some((m) => m.priority === "blocker")
@@ -239,11 +308,10 @@ export default function UrgentInbox({
 
       {expanded && (
         <div className="urgent-body">
-          {error && <div className="urgent-error">{error}</div>}
-          {!error && messages.length === 0 && (
+          {messages.length === 0 && !error && (
             <div className="urgent-empty">No urgent messages.</div>
           )}
-          {!error && messages.length > 0 && (
+          {messages.length > 0 && (
             <ul className="urgent-list">
               {messages.map((m) => (
                 <li
@@ -265,6 +333,11 @@ export default function UrgentInbox({
                 </li>
               ))}
             </ul>
+          )}
+          {error && (
+            <div className="urgent-footer-unavailable" title={error}>
+              Urgent feed unavailable
+            </div>
           )}
         </div>
       )}


### PR DESCRIPTION
## Summary

Two user-reported bugs on the urgent-inbox sidebar panel from PR #57, folded into one diff since both touch the same component:

1. **Mailbox-gate bug.** Vanilla twapp instances (no `TWAPP_MAILBOX_DIR` / `TWAPP_SHARED_DIR`) were rendering a scary "URGENT: Error: No mailbox..." banner because the panel called `fetch_messages` unconditionally and displayed the backend error as a red styled row. Single-session users read the banner as a real urgent message.
2. **Theming bug.** The same panel hard-coded `background: var(--bg-primary)`, which renders white in light mode and ignores the per-instance session accent color the rest of the sidebar inherits. (Coordinator added this to scope 20260421T143500Z.)

### Fixes

- **New `get_mailbox_status` Tauri command** — pure filesystem probe that checks `TWAPP_MAILBOX_DIR` → `TWAPP_SHARED_DIR/mailbox/` → `<cwd>/mailbox/inbox/` and reports `configured: bool`. `UrgentInbox` calls it once at init and renders nothing until the probe resolves `configured: true`. No handle or no mailbox = no panel, no empty state, no error.
- **Discreet error footer** — `fetch_messages` failures now `console.warn` + show a small "Urgent feed unavailable" footer instead of the red banner. The `.urgent-error` style is left in the CSS as dead code; the component no longer reaches it.
- **Theme inheritance** — `.urgent-panel`, `.fleet-panel`, and `.timeline-panel` switch from `background: var(--bg-primary)` to `background: transparent`, so the sidebar's `--bg-secondary` (set by `applyThemeColor` to the session accent) shows through. Matches how notes / tickets already render.

### Audit of other wave-2/3 co-lab UI (per briefing)

- #52 session groups — `SessionLauncher.hasColabSections` already hides the "Co-lab groups" header when no session has `colab_group`. No leak.
- #63 fleet pane — `FleetPane` already returns `null` unless role === `coordinator`. No leak.
- #59 chrome — already gates on role / provenance. No leak.
- #55 launcher button — always-available per briefing, unchanged.
- #62 quick-action menu — `AgentContextMenu` ships in-tree but has no caller yet (only its own test imports it). Mailbox-gating deferred until a call site exists; flagged here as a **follow-up**.
- **Theming follow-up** — none of the audited components hard-code non-theme colors *except* the three panels fixed here. `.priority-chip.priority-blocker` and `.urgent-row-blocker` keep their literal red because red is semantic (blocker = red regardless of theme), same pattern `.config-error` uses.

## Test plan

- [x] `cargo test --lib msg::` — 91 pass, 8 new `probe_mailbox_status` cases covering every branch of the resolver (unset, empty-string env, MAILBOX_DIR hit, missing-dir fallthrough, SHARED_DIR fallback, SHARED_DIR without `mailbox/` subdir, cwd fallback, precedence).
- [x] `npm test` — 164 pass, 6 new `panelVisibility` cases. The three the briefing calls out: no-mailbox → hidden, configured + empty → empty-state, configured + message → list. Plus probe-pending → hidden, configured + error → discreet footer, list-wins-over-stale-error.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: unset `TWAPP_MAILBOX_DIR` and `TWAPP_SHARED_DIR`, launch an instance with a named handle → no urgent panel visible in the sidebar. Set `TWAPP_MAILBOX_DIR` to an existing mailbox with one urgent message → panel renders with the message. Same mailbox with zero urgent messages → "No urgent messages." empty state. (Requires `cargo tauri dev` which I can't run headless from this worktree.)