### PR TITLE
docs: codify implementer-briefing template in spawn-agent + agent-coordinator skills

### DIFF
--- a/docs/briefing-template.md
+++ b/docs/briefing-template.md
@@ -1,0 +1,138 @@
+# Implementer briefing template
+
+Copy this file to `<shared-dir>/briefings/<handle>.md` (or wherever your
+co-lab keeps briefings) and fill in the placeholders. Every section below
+is required for an implementer briefing — see the [`spawn-agent`](../skills/spawn-agent/SKILL.md#briefing-requirements)
+skill for why each one earns its place, and the [`agent-coordinator`](../skills/agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings)
+skill for the coordinator-side checks to run before spawning.
+
+The four sections that are load-bearing for safety — the ones whose absence
+caused real worktree-trampling incidents — are **Setup**, **Do-not-touch**,
+**PR pattern**, and **Acceptance criteria**. Do not delete them, even if
+the work feels too small to need them.
+
+```text
+<repo-root>      = the canonical checkout of the target repo
+<repo>_<short>   = the dedicated worktree this implementer creates and works in
+<repo>_live      = the user's live working worktree (READ-ONLY for spawned workers)
+```
+
+---
+
+## Template
+
+Copy everything in the fenced block below into a new briefing file and
+fill in the angle-bracketed placeholders.
+
+````markdown
+---
+id: <kebab-case-id>
+role: implementer
+priority: low | medium | high | critical
+model: sonnet | haiku | opus
+spawn_name: <short-name>
+repo: <owner>/<repo>
+---
+
+# <Title>
+
+## Why
+
+<1–2 paragraphs: the user-facing problem this PR solves and how we know
+it's a problem. Link to the upstream incident, audit, or PR if one exists.
+The worker reads this section to judge trade-offs in edge cases the briefing
+doesn't anticipate, so be specific about the motivation.>
+
+## Setup
+
+The worker runs these exact commands before doing anything else. The
+`git worktree add` step is mandatory — it creates a fresh worktree
+*outside* any shared, live, or coordinator-owned worktree. All edits,
+commits, and pushes happen inside the new worktree.
+
+```bash
+cd /path/to/<repo-root>
+git fetch origin
+git worktree add -b <scope>/<short-name> /path/to/<repo>_<short-name> origin/main
+cd /path/to/<repo>_<short-name>
+```
+
+Seed `.claude/settings.local.json` per the [`spawn-agent`](../skills/spawn-agent/SKILL.md#worktree-permission-pre-approval)
+worktree-permission pre-approval pattern if the worker isn't being spawned
+by a wrapper that already does this for you.
+
+## Do-not-touch
+
+- /path/to/<repo>_live/         — user's live working worktree
+- /path/to/<repo>_<other-worker>/ — sibling implementer in flight
+- Any file this briefing does not explicitly name
+
+(List the live / staging worktree by absolute path even when there is no
+obvious reason this PR would touch it. List every sibling implementer's
+worktree currently in flight. Anything not authorized below is implicitly
+out of scope; explicit do-not-touch lines convert the worst trampling
+failures from "unlikely" to "unreachable".)
+
+## What to ship
+
+<Concrete deliverable. Files to touch, functions to add, behavior to
+implement, tests to include. Use code anchors (`path/to/file.rs:42`) when
+pointing at existing code.>
+
+## Acceptance criteria
+
+- [ ] <concrete, self-checkable item>
+- [ ] <concrete, self-checkable item>
+- [ ] Existing test suite passes (e.g. `cargo test --lib`,
+      `npx tsc --noEmit` if any frontend file was touched).
+
+## Out of scope
+
+- <Things the worker MUST NOT expand into.>
+- <Adjacent refactors, drive-by cleanups, dependency bumps, etc. that
+  would make this PR harder to review or revert.>
+
+## PR pattern
+
+- Branch: `<scope>/<short-name>`
+- Commit: `<type>(<scope>): <subject>` (conventional commits — `feat`,
+  `fix`, `chore`, `docs`, `refactor`, `test`).
+- PR body uses the repo's standard PR template; reference the briefing
+  motivation under "Why" and call out non-obvious trade-offs.
+- Open with:
+
+  ```bash
+  gh pr create --title "<type>(<scope>): <subject>" --body "$(cat <<'EOF'
+  ## Summary
+  - <bullet>
+
+  ## Test plan
+  - [ ] <checkable item>
+  EOF
+  )"
+  ```
+
+## Coordinates with
+
+- <Other in-flight workers / scopes whose work overlaps. Sync via mailbox
+  before touching shared files. Omit this section if the work is fully
+  isolated.>
+````
+
+---
+
+## Coordinator pre-spawn checklist
+
+Before invoking `twapp work --from-file <briefing> --role implementer`,
+the coordinator MUST confirm:
+
+1. The four mandatory sections (**Setup**, **Do-not-touch**, **PR pattern**,
+   **Acceptance criteria**) are present and non-empty.
+2. The Setup section's `git worktree add` path is unique among all
+   currently in-flight implementers on the same repo, and the branch name
+   does not collide with another in-flight branch.
+3. If the target repo has a live / staging / `_live` worktree, it is named
+   by absolute path in the Do-not-touch section.
+
+See the [`agent-coordinator`](../skills/agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings)
+skill for the rationale on each check.

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -166,6 +166,16 @@ Pass `--model` at spawn time; the flag is pass-through to the provider CLI and t
 
 Budget note: un-pinned spawns inherit the user's global default. For a batch of workers of mixed scope, pin each one explicitly so a default swap (e.g. user switching to opus while debugging) doesn't silently re-cost the whole batch.
 
+### Coordinator obligations when writing implementer briefings
+
+The [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill defines four mandatory briefing sections every implementer needs — **Setup**, **Do-not-touch**, **PR pattern**, and **Acceptance criteria** — and the rationale incident behind them. The coordinator owns whether those sections actually appear before the spawn:
+
+- **Verify before you spawn.** Before invoking `twapp work --from-file <briefing>` for any `--role implementer`, scan the briefing and confirm all four mandatory sections are present and non-empty. A grep, a quick visual pass, or both — but skipping this once will eventually cost you a trampled worktree. The §2 template above plus the [`docs/briefing-template.md`](../../docs/briefing-template.md) starter both already include the four sections; the failure mode is briefings that drift from the template, not briefings that start from it.
+- **Distinct worktree path + branch per parallel implementer.** When two or more implementers are in flight on the same repo at the same time, every briefing MUST name a distinct `git worktree add` path and a distinct branch in its Setup section. Two implementers sharing a worktree fight over `.twapp-*.json` files and stomp each other's commits; two implementers sharing a branch race-condition the push. Stamp the worktree path and branch from the worker's handle (e.g. `<repo>_<handle>` and `<scope>/<handle>`) so the uniqueness falls out of the naming convention.
+- **Always call out the live worktree.** If the target repo has a live / production / staging / `_live` worktree the user runs out of, name it by absolute path in the Do-not-touch section of every implementer briefing — even when the briefing has no obvious reason to touch it. The worker may search for files broadly, follow a tool to a fuzzy match, or improvise a setup command that lands there. An explicit do-not-touch line short-circuits all of those failure paths up front.
+
+The [`docs/briefing-template.md`](../../docs/briefing-template.md) file is the canonical starting point. Copy it, fill it in, run the three checks above, then spawn. If the template gains a new required field, edit the template *and* the [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill so future briefings inherit it; do not patch a missing field into only the briefing in front of you.
+
 ## 3. Mailbox protocol
 
 A plain-directory mailbox is the coordination bus. No database, no service — just files you can `ls`, `grep`, and `mv`.

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -53,6 +53,21 @@ Notes:
 - The `Read <path> and execute.` wrapper is deliberately short — every character is literal text the shell must carry intact to Claude. Keep what's in the markdown file.
 - Treat the briefing file as the contract. Put acceptance criteria, protocol, and a handle name in it. Don't try to squeeze those into `--run`.
 
+## Briefing requirements
+
+A worker briefing is a literal contract — the worker will follow what's written and improvise where the briefing is silent. Any required step you leave out becomes a coin-flip on whether the worker invents something safe. To take that coin-flip off the table, every briefing for an implementer (any `--from-file` spawn with `--role implementer`) MUST contain the following four sections, alongside whatever role-specific content the work needs:
+
+- **Setup** — the exact bash commands the worker runs to prepare its working environment. For any briefing that touches a git repo, this MUST include a `git worktree add -b <branch> <new-worktree-path> <base-ref>` step that creates a fresh worktree OUTSIDE any shared, live, or coordinator-owned worktree. The worker's edits, commits, and pushes happen inside that new worktree — never the spawning session's cwd, never a shared `_live` / `_staging` worktree, never a peer's worktree.
+- **Do-not-touch** — an explicit list of paths the worker must not modify. At minimum, name any live / production worktree of the repo by absolute path, plus any sibling worker's worktree currently in flight. Anything the briefing doesn't explicitly authorize is implicitly out of scope; listing the dangerous paths converts the worst-case trampling failure from "unlikely" to "unreachable".
+- **PR pattern** — the branch name convention (`<scope>/<short-name>`), the commit message convention (conventional commits — `feat(...)`, `fix(...)`, `chore(...)`, `docs(...)`), and the `gh pr create` invocation shape the worker should follow.
+- **Acceptance criteria** — a concrete, self-checkable checklist the reviewer and the coordinator can both use to verify the PR delivers what the briefing asked for.
+
+### Why these four are mandatory
+
+A real incident shaped this rule. A coordinator spawned several implementers in parallel against a repo whose live working copy was the user's active worktree. The briefings did not include an explicit Setup section, so some workers defaulted to operating in the spawning session's cwd — which happened to be the live worktree. They stashed the user's uncommitted edits, left the live tree checked out on a feature branch, and trampled each other's in-progress work. None of the workers disobeyed instructions; the briefings were silent on where to work. Codifying Setup + Do-not-touch makes that silence impossible.
+
+A copy-paste template that ships these four sections out of the box lives at [`docs/briefing-template.md`](../../docs/briefing-template.md). Coordinators should start from it rather than improvising. See [`agent-coordinator`](../agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings) for the coordinator-side obligations (verification before spawn, distinct paths for parallel implementers, calling out the live worktree). A worked-out minimum-viable briefing appears at the bottom of this file under [Minimum-viable briefing example](#minimum-viable-briefing-example).
+
 ## Role + provenance
 
 Tag each spawned session with its **role** and mark it as **agent-spawned** so later UI, dashboards, and sessions-list output can distinguish workers from the human-driven session you're typing into.
@@ -373,3 +388,50 @@ kill -TERM "$(pgrep -f 'twapp --name my-reviewer')"
 ```
 
 Replace `my-*` / `example-*` with your own names. Neither example assumes a particular project, language, or toolchain.
+
+## Minimum-viable briefing example
+
+The shape every implementer briefing has to satisfy. Use this as a sanity check; for a full copy-paste starter, use [`docs/briefing-template.md`](../../docs/briefing-template.md). All paths are placeholders — `<repo-root>` is the canonical checkout, `<repo>_<short-name>` is the per-worker worktree, `<repo>_live` is the user's live worktree.
+
+````markdown
+---
+id: example-feature-fix
+role: implementer
+priority: medium
+model: sonnet
+spawn_name: example-fix
+repo: <owner>/<repo>
+---
+
+# example-feature-fix — short description
+
+## Why
+<1–2 paragraphs: user-facing problem and how we know it's a problem.>
+
+## Setup
+```bash
+cd /path/to/<repo-root>
+git fetch origin
+git worktree add -b example-scope/example-fix /path/to/<repo>_example-fix origin/main
+cd /path/to/<repo>_example-fix
+```
+
+## Do-not-touch
+- /path/to/<repo>_live/         — user's live working worktree
+- /path/to/<repo>_other-worker/ — sibling implementer in flight
+- Any file this briefing does not explicitly name
+
+## What to ship
+<concrete deliverable with code anchors>
+
+## Acceptance criteria
+- [ ] <self-checkable item>
+- [ ] Existing test suite passes (e.g. `cargo test --lib`).
+
+## PR pattern
+- Branch: `example-scope/example-fix`
+- Commit: `fix(example-scope): one-line subject` (conventional commits)
+- Open with `gh pr create --title "fix(example-scope): subject" --body "$(cat <<'EOF' … EOF)"`
+````
+
+The four mandatory sections are **Setup**, **Do-not-touch**, **PR pattern**, and **Acceptance criteria**. Add **Why**, **What to ship**, and **Out of scope** in every real briefing — they're not enforced here because the failure mode they prevent (scope drift) is gentler than the one the four mandatory sections prevent (worktree trampling).


### PR DESCRIPTION
## Summary

Codifies the minimum required structure for every implementer briefing
so coordinators can't silently omit a section and let a worker default
to a behavior that trampling-collides with another agent or with the
user's live worktree.

The four mandatory sections in every implementer briefing are now
explicit in the skill docs:

- **Setup** — exact `git worktree add -b <branch> <new-path> <base-ref>`
  block that creates a fresh per-worker worktree outside any shared,
  live, or coordinator-owned worktree.
- **Do-not-touch** — explicit absolute paths the worker must not
  modify, including the live worktree (always) and any sibling
  implementer's worktree (when applicable).
- **PR pattern** — branch name convention, conventional-commits commit
  shape, `gh pr create` invocation.
- **Acceptance criteria** — concrete, self-checkable checklist for the
  reviewer and coordinator.

### Motivating incident (conceptual)

The trigger was a recent multi-implementer coordination run where the
coordinator-written briefings did not include an explicit Setup
section. Several workers correctly followed what was written; without
guidance on where to work, they defaulted to operating in the spawning
session's cwd — which happened to be the user's live working
worktree. They stashed the user's uncommitted edits, left the live
tree on a feature branch, and trampled each other's in-progress
work. None of the workers misbehaved; the briefings were silent on
the question. This PR makes that silence impossible to repeat by
elevating the four sections from convention to contract.

### What changed

**`skills/spawn-agent/SKILL.md`** — new \`## Briefing requirements\`
section between \`## The file-reference pattern\` and \`## Role +
provenance\`. Lists the four mandatory sections, explains the rationale
incident at a conceptual level, and cross-links the template + the
coordinator-side obligations. A new \`## Minimum-viable briefing
example\` section at the bottom of the file shows the four sections
filled in with placeholder scope.

Before / after excerpt of the surrounding structure in
\`skills/spawn-agent/SKILL.md\`:

\`\`\`
Before                                  After
─────────────────────────               ─────────────────────────
## The file-reference pattern           ## The file-reference pattern
## Role + provenance                    ## Briefing requirements        ← new
## Model selection                      ## Role + provenance
## Worktree permission pre-approval     ## Model selection
## Hello-within-2-min verification      ## Worktree permission pre-approval
…                                       ## Hello-within-2-min verification
## Examples                             …
                                        ## Examples
                                        ## Minimum-viable briefing example  ← new
\`\`\`

**\`skills/agent-coordinator/SKILL.md\`** — new
\`### Coordinator obligations when writing implementer briefings\`
subsection at the end of \`## 2. Briefing structure\`. References the
spawn-agent contract and adds the three coordinator-side obligations:
verify all four sections before spawn, distinct worktree path + branch
per parallel implementer, always call out the live worktree by
absolute path.

**\`docs/briefing-template.md\`** — new file. Canonical copy-paste
starter with the seven sections (\`Why\`, \`Setup\`, \`Do-not-touch\`,
\`What to ship\`, \`Acceptance criteria\`, \`Out of scope\`, \`PR
pattern\`, plus optional \`Coordinates with\`). Both skill docs link to
it; it links back to both skill docs.

### Out of scope

- CLI changes to \`twapp work\` (e.g. a \`--repo\` flag that
  auto-creates worktrees). Phase 2, separate PR — the briefing
  requirements stand regardless.
- A \`.twapp-protected\` sentinel for protected-worktree enforcement.
  Phase 3, separate.
- Reviewer heartbeat protocol. Separate track.
- Schema changes to \`.twapp-session.json\`. Pure docs.

## Test plan

- [x] \`cargo test --lib\` (in \`src-tauri/\`) — 285 passed, 0 failed.
- [x] No frontend / TS files touched, so \`npx tsc --noEmit\` not
      required by the briefing's acceptance criteria.
- [x] All three changed files cross-reference each other consistently
      (spawn-agent ↔ agent-coordinator ↔ briefing-template).
- [x] Anchors in cross-links resolve to the headings actually in the
      target files (\`#briefing-requirements\`,
      \`#coordinator-obligations-when-writing-implementer-briefings\`,
      \`#worktree-permission-pre-approval\`,
      \`#minimum-viable-briefing-example\`).