### PR TITLE
docs: Completion check section in briefing template + spawn-agent + coordinator

### DIFF
--- a/docs/briefing-template.md
+++ b/docs/briefing-template.md
@@ -6,10 +6,12 @@ is required for an implementer briefing — see the [`spawn-agent`](../skills/sp
 skill for why each one earns its place, and the [`agent-coordinator`](../skills/agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings)
 skill for the coordinator-side checks to run before spawning.
 
-The four sections that are load-bearing for safety — the ones whose absence
-caused real worktree-trampling incidents — are **Setup**, **Do-not-touch**,
-**PR pattern**, and **Acceptance criteria**. Do not delete them, even if
-the work feels too small to need them.
+The five sections that are load-bearing — **Setup**, **Do-not-touch**,
+**PR pattern**, **Acceptance criteria**, and **Completion check** — each
+close a distinct real failure mode. The first four were codified after a
+worktree-trampling incident; **Completion check** was added after multiple
+agents silently stalled after their last commit without opening their PR.
+Do not delete them, even if the work feels too small to need them.
 
 ```text
 <repo-root>      = the canonical checkout of the target repo
@@ -86,6 +88,24 @@ pointing at existing code.>
 - [ ] Existing test suite passes (e.g. `cargo test --lib`,
       `npx tsc --noEmit` if any frontend file was touched).
 
+## Completion check — DO NOT SKIP
+
+Before stopping, run:
+
+```bash
+git push -u origin <your-branch>            # push if not already
+gh pr view <your-branch> --json number,url  # confirm PR exists with a number
+```
+
+Then post `<shared-dir>/mailbox/inbox/<ISO-Z>-<your-name>-done.md` with:
+- PR number + URL
+- Branch name
+- Acceptance-criteria checklist status
+
+Agent is NOT done until BOTH:
+- `gh pr view` returns a real PR number, AND
+- the `-done.md` mailbox file exists.
+
 ## Out of scope
 
 - <Things the worker MUST NOT expand into.>
@@ -126,8 +146,8 @@ pointing at existing code.>
 Before invoking `twapp work --from-file <briefing> --role implementer`,
 the coordinator MUST confirm:
 
-1. The four mandatory sections (**Setup**, **Do-not-touch**, **PR pattern**,
-   **Acceptance criteria**) are present and non-empty.
+1. The five mandatory sections (**Setup**, **Do-not-touch**, **PR pattern**,
+   **Acceptance criteria**, **Completion check**) are present and non-empty.
 2. The Setup section's `git worktree add` path is unique among all
    currently in-flight implementers on the same repo, and the branch name
    does not collide with another in-flight branch.

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -133,6 +133,15 @@ and a link to any relevant upstream data, audit, or prior PR.>
 ## Acceptance criteria
 <Unambiguous checklist the worker can self-verify before declaring done.>
 
+## Completion check — DO NOT SKIP
+<Two-command self-verify (`git push -u origin <branch>` +
+`gh pr view <branch> --json number,url`) plus a
+`<shared-dir>/mailbox/inbox/<ISO-Z>-<handle>-done.md` post. Agent is not
+done until `gh pr view` returns a real PR number AND the `-done.md` file
+exists. See [`docs/briefing-template.md`](../../docs/briefing-template.md)
+for the standard block and [`spawn-agent`'s briefing-requirements](../spawn-agent/SKILL.md#briefing-requirements)
+for the rationale.>
+
 ## Out of scope
 <Explicit carve-outs to prevent drift into adjacent concerns.>
 
@@ -167,6 +176,7 @@ Why each section earns its place:
 
 - **Why / Context** — anchors the worker to the motivation so it judges trade-offs instead of following the letter.
 - **What to ship / Acceptance criteria** — the part the worker self-verifies against; skimping here is where scope drifts.
+- **Completion check** — turns PR-open + notify from narrative into a verifiable acceptance item. Without it, agents finish the code work, commit, and stop without pushing or opening the PR — a silent stall the coordinator only discovers by chance.
 - **Out of scope** — load-bearing. Prevents the common failure mode of a worker "helpfully" rewriting adjacent code.
 - **Protocol** — the handshake contract. Without it you cannot distinguish a slow worker from a dead one.
 - **Coordinate with** — prevents collisions on shared files. Cheap to write, expensive to omit.
@@ -202,9 +212,9 @@ Budget note: un-pinned spawns inherit the user's global default. For a batch of 
 
 ### Coordinator obligations when writing implementer briefings
 
-The [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill defines four mandatory briefing sections every implementer needs — **Setup**, **Do-not-touch**, **PR pattern**, and **Acceptance criteria** — and the rationale incident behind them. The coordinator owns whether those sections actually appear before the spawn:
+The [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill defines five mandatory briefing sections every implementer needs — **Setup**, **Do-not-touch**, **PR pattern**, **Acceptance criteria**, and **Completion check** — and the rationale incidents behind them. The coordinator owns whether those sections actually appear before the spawn:
 
-- **Verify before you spawn.** Before invoking `twapp work --from-file <briefing>` for any `--role implementer`, scan the briefing and confirm all four mandatory sections are present and non-empty. A grep, a quick visual pass, or both — but skipping this once will eventually cost you a trampled worktree. The §2 template above plus the [`docs/briefing-template.md`](../../docs/briefing-template.md) starter both already include the four sections; the failure mode is briefings that drift from the template, not briefings that start from it.
+- **Verify before you spawn.** Before invoking `twapp work --from-file <briefing>` for any `--role implementer`, scan the briefing and confirm all five mandatory sections are present and non-empty. A grep, a quick visual pass, or both — but skipping this once will eventually cost you a trampled worktree or a silent PR-open stall. The §2 template above plus the [`docs/briefing-template.md`](../../docs/briefing-template.md) starter both already include the five sections; the failure mode is briefings that drift from the template, not briefings that start from it.
 - **Distinct worktree path + branch per parallel implementer.** When two or more implementers are in flight on the same repo at the same time, every briefing MUST name a distinct `git worktree add` path and a distinct branch in its Setup section. Two implementers sharing a worktree fight over `.twapp-*.json` files and stomp each other's commits; two implementers sharing a branch race-condition the push. Stamp the worktree path and branch from the worker's handle (e.g. `<repo>_<handle>` and `<scope>/<handle>`) so the uniqueness falls out of the naming convention.
 - **Always call out the live worktree.** If the target repo has a live / production / staging / `_live` worktree the user runs out of, name it by absolute path in the Do-not-touch section of every implementer briefing — even when the briefing has no obvious reason to touch it. The worker may search for files broadly, follow a tool to a fuzzy match, or improvise a setup command that lands there. An explicit do-not-touch line short-circuits all of those failure paths up front.
 
@@ -601,6 +611,15 @@ status, before merging:
       flight): *"have you seen anything unusual since the previous
       merge?"* Unexplained recent weirdness is a reason to pause, not to
       accelerate.
+- [ ] **Stale-branch scan (automated, coordinator-side):** every
+      monitoring cycle, for each active-agent's known branch, check
+      `git ls-remote origin <branch>` AND `gh pr list --head <branch>`.
+      Branch exists + commits-ahead-of-main AND no open PR = stall. Kick
+      or force-stop+respawn. Catches the failure mode the per-briefing
+      [Completion check](../spawn-agent/SKILL.md#briefing-requirements)
+      is meant to prevent — an agent that finished its code work but
+      never opened the PR — when that agent's self-verify slipped
+      anyway.
 
 If the checklist surfaces a concern, block the merge and mailbox the
 implementer with the specific input case the PR would reject — not a

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -55,18 +55,21 @@ Notes:
 
 ## Briefing requirements
 
-A worker briefing is a literal contract — the worker will follow what's written and improvise where the briefing is silent. Any required step you leave out becomes a coin-flip on whether the worker invents something safe. To take that coin-flip off the table, every briefing for an implementer (any `--from-file` spawn with `--role implementer`) MUST contain the following four sections, alongside whatever role-specific content the work needs:
+A worker briefing is a literal contract — the worker will follow what's written and improvise where the briefing is silent. Any required step you leave out becomes a coin-flip on whether the worker invents something safe. To take that coin-flip off the table, every briefing for an implementer (any `--from-file` spawn with `--role implementer`) MUST contain the following five sections, alongside whatever role-specific content the work needs:
 
 - **Setup** — the exact bash commands the worker runs to prepare its working environment. For any briefing that touches a git repo, this MUST include a `git worktree add -b <branch> <new-worktree-path> <base-ref>` step that creates a fresh worktree OUTSIDE any shared, live, or coordinator-owned worktree. The worker's edits, commits, and pushes happen inside that new worktree — never the spawning session's cwd, never a shared `_live` / `_staging` worktree, never a peer's worktree.
 - **Do-not-touch** — an explicit list of paths the worker must not modify. At minimum, name any live / production worktree of the repo by absolute path, plus any sibling worker's worktree currently in flight. Anything the briefing doesn't explicitly authorize is implicitly out of scope; listing the dangerous paths converts the worst-case trampling failure from "unlikely" to "unreachable".
 - **PR pattern** — the branch name convention (`<scope>/<short-name>`), the commit message convention (conventional commits — `feat(...)`, `fix(...)`, `chore(...)`, `docs(...)`), and the `gh pr create` invocation shape the worker should follow.
 - **Acceptance criteria** — a concrete, self-checkable checklist the reviewer and the coordinator can both use to verify the PR delivers what the briefing asked for.
+- **Completion check** — explicit agent-self-verification that the PR is actually open on the remote and a completion mailbox is posted. Without this, agents can finish the code work and silently stall before opening the PR. See [`docs/briefing-template.md`](../../docs/briefing-template.md) for the standard checklist.
 
-### Why these four are mandatory
+### Why these five are mandatory
 
-A real incident shaped this rule. A coordinator spawned several implementers in parallel against a repo whose live working copy was the user's active worktree. The briefings did not include an explicit Setup section, so some workers defaulted to operating in the spawning session's cwd — which happened to be the live worktree. They stashed the user's uncommitted edits, left the live tree checked out on a feature branch, and trampled each other's in-progress work. None of the workers disobeyed instructions; the briefings were silent on where to work. Codifying Setup + Do-not-touch makes that silence impossible.
+A real incident shaped the first four. A coordinator spawned several implementers in parallel against a repo whose live working copy was the user's active worktree. The briefings did not include an explicit Setup section, so some workers defaulted to operating in the spawning session's cwd — which happened to be the live worktree. They stashed the user's uncommitted edits, left the live tree checked out on a feature branch, and trampled each other's in-progress work. None of the workers disobeyed instructions; the briefings were silent on where to work. Codifying Setup + Do-not-touch makes that silence impossible.
 
-A copy-paste template that ships these four sections out of the box lives at [`docs/briefing-template.md`](../../docs/briefing-template.md). Coordinators should start from it rather than improvising. See [`agent-coordinator`](../agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings) for the coordinator-side obligations (verification before spawn, distinct paths for parallel implementers, calling out the live worktree). A worked-out minimum-viable briefing appears at the bottom of this file under [Minimum-viable briefing example](#minimum-viable-briefing-example).
+Completion check closes a different failure mode. Agents are optimized to satisfy primary acceptance criteria and exit. Without explicit PR-lifecycle checkpoints in the acceptance list, an agent can reasonably conclude "tests pass + code is committed = done" and stop, missing the push + PR-open + notify steps. The coordinator then has to discover the stall manually hours later. Completion check turns those steps from narrative into verifiable acceptance items — the agent runs the two-command self-verify, posts the `-done.md` mailbox, and only then exits.
+
+A copy-paste template that ships these five sections out of the box lives at [`docs/briefing-template.md`](../../docs/briefing-template.md). Coordinators should start from it rather than improvising. See [`agent-coordinator`](../agent-coordinator/SKILL.md#coordinator-obligations-when-writing-implementer-briefings) for the coordinator-side obligations (verification before spawn, distinct paths for parallel implementers, calling out the live worktree, stale-branch scans in the review loop). A worked-out minimum-viable briefing appears at the bottom of this file under [Minimum-viable briefing example](#minimum-viable-briefing-example).
 
 ## Role + provenance
 
@@ -467,10 +470,20 @@ cd /path/to/<repo>_example-fix
 - [ ] <self-checkable item>
 - [ ] Existing test suite passes (e.g. `cargo test --lib`).
 
+## Completion check — DO NOT SKIP
+Before stopping:
+```bash
+git push -u origin example-scope/example-fix
+gh pr view example-scope/example-fix --json number,url
+```
+Then post `<shared-dir>/mailbox/inbox/<ISO-Z>-<handle>-done.md` with PR
+number + URL, branch, and acceptance-criteria status. Not done until both
+the PR exists on the remote and the `-done.md` file is posted.
+
 ## PR pattern
 - Branch: `example-scope/example-fix`
 - Commit: `fix(example-scope): one-line subject` (conventional commits)
 - Open with `gh pr create --title "fix(example-scope): subject" --body "$(cat <<'EOF' … EOF)"`
 ````
 
-The four mandatory sections are **Setup**, **Do-not-touch**, **PR pattern**, and **Acceptance criteria**. Add **Why**, **What to ship**, and **Out of scope** in every real briefing — they're not enforced here because the failure mode they prevent (scope drift) is gentler than the one the four mandatory sections prevent (worktree trampling).
+The five mandatory sections are **Setup**, **Do-not-touch**, **PR pattern**, **Acceptance criteria**, and **Completion check**. Add **Why**, **What to ship**, and **Out of scope** in every real briefing — they're not enforced here because the failure mode they prevent (scope drift) is gentler than the ones the five mandatory sections prevent (worktree trampling and silent PR-open stalls).


### PR DESCRIPTION
## Summary

- Adds a mandatory **Completion check** section to the briefing template — a two-command self-verify (`git push -u origin <branch>` + `gh pr view <branch> --json number,url`) plus a `-done.md` mailbox post — so an implementer can't consider itself done until the PR is actually open on the remote.
- Promotes Completion check to the fifth mandatory briefing section alongside Setup, Do-not-touch, PR pattern, and Acceptance criteria across `spawn-agent` and `agent-coordinator`, with a conceptual paragraph on the failure mode it closes.
- Adds a stale-branch-scan bullet to `agent-coordinator` §6.1 as a coordinator-side belt-and-suspenders backstop: every monitoring cycle, branches that are ahead of main with no open PR flag as stalls.

## Why

Recent coordination runs surfaced a repeating pattern: implementer agents finished and committed the code work, then stopped without pushing or opening the PR. Root cause is that the briefing's PR pattern reads as narrative, not as acceptance criteria — agents reasonably conclude "tests pass + code committed = done" and exit. Elevating push + PR-open + `-done.md` notify into a verifiable acceptance item converts the silent stall into a self-checkable failure.

Extends PR #67, which codified the original four-section implementer briefing template. No code changes — docs/skills only.

## Test plan

- [x] `cargo test --lib` in `src-tauri/` — 285 passed, 0 failed (baseline unchanged; no code touched).
- [x] Cross-references between `docs/briefing-template.md`, `skills/spawn-agent/SKILL.md`, and `skills/agent-coordinator/SKILL.md` consistently name the five mandatory sections.
- [ ] Next time a new implementer is spawned from the template, confirm the Completion check block survives the copy-paste into the per-worker briefing.