### PR TITLE
docs: coordination playbooks — completion signals, review red flags, worktree discipline, safety-critical scoping

### DIFF
--- a/docs/briefing-template.md
+++ b/docs/briefing-template.md
@@ -97,14 +97,41 @@ git push -u origin <your-branch>            # push if not already
 gh pr view <your-branch> --json number,url  # confirm PR exists with a number
 ```
 
-Then post `<shared-dir>/mailbox/inbox/<ISO-Z>-<your-name>-done.md` with:
-- PR number + URL
-- Branch name
-- Acceptance-criteria checklist status
+Then write the completion signal on **two channels** — primary and
+secondary. The primary is load-bearing; the secondary is best-effort.
+See [`docs/playbooks/completion-signals.md`](playbooks/completion-signals.md)
+for the rationale.
+
+**Primary (always works): `DONE.md` in your worktree.**
+
+Write `<your-worktree>/DONE.md` with:
+- PR URL
+- `mergeStateStatus` (from `gh pr view --json mergeStateStatus`)
+- Commit SHA
+- Acceptance-criteria checklist with ticks
+- One-line test summary
+
+The worktree is a path you have permission to write to by
+construction, so this write cannot fail on permissions. The
+coordinator scans for `DONE.md` on every monitoring cycle as the
+load-bearing completion signal.
+
+**Secondary (best-effort): completion mailbox post.**
+
+Also attempt to post `<shared-dir>/mailbox/inbox/<ISO-Z>-<your-name>-done.md`
+with the same content. If the write succeeds, good — the message
+shows up in the normal mailbox flow. If it prompts for permission or
+fails silently (the shared mailbox path often sits outside the
+worker's permitted write scope, even with
+`--dangerously-skip-permissions`), skip it and move on. Do not let
+the secondary mechanism's failure prevent the primary from being
+written.
 
 Agent is NOT done until BOTH:
 - `gh pr view` returns a real PR number, AND
-- the `-done.md` mailbox file exists.
+- `<your-worktree>/DONE.md` exists.
+
+The mailbox post is a courtesy. The `DONE.md` is the contract.
 
 ## Out of scope
 

--- a/docs/playbooks/completion-signals.md
+++ b/docs/playbooks/completion-signals.md
@@ -1,0 +1,154 @@
+# Completion signals — how agents tell the coordinator they're done
+
+> Field guide for any team running multi-agent work on twapp.
+> Start here when you've watched an agent finish its code work and then
+> sit silently for an hour while nobody noticed.
+
+## Why this is hard
+
+A worker agent is optimized to satisfy its primary acceptance criteria
+and exit. The implementer reads "ship feature X with tests"; once the
+tests are green and the diff looks right, the worker has done what was
+asked of it.
+
+Everything that happens *after* "code is correct" — pushing the branch,
+opening the PR, posting a notification — is housekeeping. From the
+agent's point of view, it's narrative wrap-up rather than a graded
+acceptance item. So when a step in that wrap-up sequence fails (the
+push prompts for a credential, the mailbox path is outside the
+agent's permission scope, the `gh pr create` invocation hits a flag it
+doesn't recognize), the agent will often note the failure in its
+internal monologue and stop anyway. The work is done; the signal that
+the work is done is missing.
+
+This is the **idle-finish** failure mode. It looks identical to a
+crash, a stalled tool call, or a worker that's just slow — but the
+recovery is different in each case, and you can't tell which one you
+have without poking the worker.
+
+## The two-channel solution
+
+Treat completion as a separate, explicit acceptance item, and make the
+signal redundant: a **primary** mechanism the agent always controls,
+and a **secondary** mechanism that gives the coordinator richer
+metadata when it works.
+
+### Primary: `DONE.md` in the agent's own worktree
+
+Every spawned worker writes its completion signal to `DONE.md` at the
+root of its dedicated worktree.
+
+The worktree is the path the agent was created in — by construction,
+it has write permission there. No settings flag, no permission prompt,
+no shared-path gotcha can break this write. If the agent can edit any
+file at all, it can write `DONE.md`.
+
+The coordinator scans for `DONE.md` on every monitoring cycle:
+
+```bash
+for wt in $(git worktree list --porcelain | awk '/^worktree/ {print $2}'); do
+  [ -f "$wt/DONE.md" ] && echo "DONE: $wt"
+done
+```
+
+`DONE.md` is the load-bearing signal. If it exists, the agent has
+declared itself complete; if it doesn't, the agent is still working
+(or stalled — but at least the absence of the file is unambiguous).
+
+### Secondary: completion mailbox post
+
+In parallel, the agent attempts to post a completion message to the
+shared mailbox — typically something like
+`<shared-dir>/mailbox/inbox/<ISO-Z>-<handle>-done.md`.
+
+This is best-effort. The shared mailbox path frequently sits *outside*
+the worker's permitted write scope: even with
+`--dangerously-skip-permissions`, Claude Code may prompt for an
+out-of-tree write because the path is not under the worktree the
+session was started in. A headless worker has nobody to answer the
+prompt and will silently skip the write (or hang on it, depending on
+the build).
+
+When it works, the mailbox post is valuable: it integrates with the
+rest of the messaging flow, shows up in `twapp msg fetch`, and
+notifies sibling agents. When it doesn't, the `DONE.md` in the
+worktree is still there, so the coordinator never loses the signal.
+
+Briefings should call out *both* mechanisms and explicitly tell the
+worker that `DONE.md` is the load-bearing one. If the mailbox write
+prompts for permission or fails, skip it and move on — don't let the
+secondary mechanism's failure prevent the primary from being written.
+
+## Example `DONE.md` shape
+
+Keep it simple and parseable. The coordinator should be able to scan
+it for PR URL, merge state, and acceptance status without invoking a
+markdown parser.
+
+```markdown
+# <agent-name> — DONE
+
+PR: <url>
+mergeStateStatus: CLEAN
+Commit: <sha>
+
+## Acceptance
+- [x] <criterion>
+- [x] <criterion>
+- [x] <criterion>
+
+## Tests
+<one-line test summary, e.g. "cargo test --lib: 412 passed, 0 failed">
+```
+
+Optional sections worth adding when relevant:
+
+- **Generalization audit** — when the briefing called for generic /
+  domain-free output, a one-paragraph confirmation that the agent
+  searched the diff for project-specific references and found none.
+- **Open follow-ups** — anything the agent surfaced that wasn't in
+  scope but the coordinator should know about before reaping.
+- **Hello-to-merge time** — useful telemetry when the team is tuning
+  briefing tightness.
+
+## Why two channels and not one
+
+A previous version of the completion-check pattern (the immediate
+predecessor of this playbook) used the mailbox post alone. It worked
+in the common case but had a known silent-failure mode: workers
+spawned with worktree-scoped permissions could write to their own
+worktree but not to the shared mailbox path, and the failure was
+indistinguishable from "agent is still working". The two-channel
+version eliminates that ambiguity at the cost of one extra acceptance
+item in every briefing.
+
+The lineage:
+
+- twapp PR #67 introduced the briefing template with five mandatory
+  sections.
+- twapp PR #68 codified the coordinator-side hygiene around verifying
+  those sections before spawn.
+- twapp PR #69 added the explicit Completion check section to the
+  template, using the mailbox-only signal — phase 1.
+- This playbook is phase 2: the same Completion check, now with
+  `DONE.md` as the primary signal and the mailbox as the secondary.
+
+If a coordinator is reviewing a briefing written before this playbook
+existed (mailbox-only), upgrading it to the two-channel version is
+cheap: add one line to the Completion check telling the worker to
+write `DONE.md` first, then attempt the mailbox post.
+
+## What this playbook does not solve
+
+- **Agents that crash before reaching the completion step.** No
+  signal mechanism helps if the loop dies. Pair `DONE.md` with the
+  presence-heartbeat pattern (see the agent-coordinator skill's
+  presence section) — heartbeat absence is the early-warning signal,
+  `DONE.md` is the success signal.
+- **Agents that write `DONE.md` and *then* discover their PR didn't
+  actually merge cleanly.** Treat `DONE.md` as the agent's *claim* of
+  doneness; the coordinator still verifies via `gh pr view` before
+  reaping.
+- **Coordinator-side automation reading `DONE.md` arrays in bulk.**
+  This playbook describes the convention; automated readers and
+  dashboard integration are separate twapp infrastructure work.

--- a/docs/playbooks/review-red-flags.md
+++ b/docs/playbooks/review-red-flags.md
@@ -1,0 +1,193 @@
+# Review red flags — anti-patterns a coordinator catches before merge
+
+> Field guide for any team running multi-agent work on twapp.
+> The reviewer agent answers "is this code correct?" The coordinator
+> asks a different question — "what real-world inputs used to work
+> that this rewrite now rejects?" These four red flags are the
+> recurring shapes of that question.
+
+A clean CI run does not mean a PR is safe to merge. An implementer
+operates with blinders on: it reads a narrow briefing, writes narrow
+tests, and confirms only that the cases the briefing considered still
+work. Production input distributions are wider than briefing
+authors anticipate. Four anti-patterns recur often enough to deserve
+their own checklist.
+
+Run the four checks below on every implementer PR, regardless of CI
+status. Each one is a 30-second scan of the diff plus one targeted
+question. None of them require running the code.
+
+---
+
+## 1. Tolerant → strict rewrites
+
+**Rule:** when a diff replaces permissive parsing or validation with
+exhaustive match arms, ask "what inputs did the old code accept that
+the new code rejects?"
+
+The old code probably did not have an explicit list of accepted
+inputs — it accepted whatever happened to flow through, and the
+production input distribution shaped its behavior over time. The new
+code has a list, and that list was written from the briefing, not
+from the data.
+
+**Worked example.** Imagine a parser that splits a record into tokens
+and pulls the first three:
+
+```
+fn parse(s: &str) -> Option<Record> {
+    let mut it = s.split(',');
+    Some(Record {
+        a: it.next()?.parse().ok()?,
+        b: it.next()?.parse().ok()?,
+        c: it.next()?.parse().ok()?,
+    })
+}
+```
+
+A briefing arrives that says "make this parser strict — reject
+malformed input". An implementer rewrites it as an exhaustive match:
+
+```
+fn parse(s: &str) -> Option<Record> {
+    match s.split(',').collect::<Vec<_>>().as_slice() {
+        [a, b, c] => Some(Record { a: a.parse().ok()?, b: b.parse().ok()?, c: c.parse().ok()? }),
+        _ => None,
+    }
+}
+```
+
+The tests pass. The diff is clean. CI is green. But the old parser
+silently ignored extra tokens — and a non-trivial fraction of real
+production inputs are 4-token records (a recent format extension that
+nobody updated the parser briefing for). The new code rejects all of
+them.
+
+**What to ask before merging:** "Name three inputs that the old code
+accepted and the new code rejects. If you can't name any, are you
+sure you sampled real production data?"
+
+---
+
+## 2. Fix too aggressive
+
+**Rule:** the scope of the fix should match the scope of the bug. A
+presentational bug gets a presentational fix. A controller-lifecycle
+bug gets a controller-lifecycle fix. Mixing the two is scope creep
+disguised as completeness.
+
+When the original bug is "the UI shows stale data after a context
+switch", the fix is "hide or refresh the stale view". It is not "tear
+down the underlying background process". The background process may
+be doing legitimate work that survives the context switch.
+
+**Worked example.** A bug report says: "when the user changes
+profiles, the inbox panel still shows messages from the previous
+profile until I refresh."
+
+The right fix is presentational — clear or hide the inbox panel on
+profile change, then re-render once the new profile's inbox loads.
+
+The wrong fix, which keeps showing up in implementer PRs because it
+*also* makes the test pass, is to also stop the background sync
+process on profile change. That kills legitimate work — a long-poll
+that was holding the connection open, an in-flight upload, a queued
+action waiting for the user to come back. The presentational symptom
+goes away, and a new class of bug ("uploads sometimes vanish if I
+switch profiles mid-upload") replaces it.
+
+**What to ask before merging:** "Does this fix change behavior
+*beyond* the symptom that was reported? If yes, is the additional
+behavior change justified by a separate, named requirement?"
+
+---
+
+## 3. Tests cover documented cases, not real ones
+
+**Rule:** a clean CI run confirms that the cases the briefing
+considered still work. It does not confirm the change is safe. Sample
+inputs from actual runtime data and add at least one real-data test
+before merging parser, validator, or transformer changes.
+
+Implementers write tests against the examples in the briefing. The
+briefing examples were written by the briefing author from memory or
+from a small sample. Real production traffic has shapes neither the
+briefing author nor the implementer thought to enumerate.
+
+**Worked example.** A briefing says: "validate that timestamps are
+ISO-8601." The implementer writes tests for `2025-01-01T00:00:00Z`
+and a few obvious malformed cases, all passing.
+
+In production, half the upstream feeds emit `2025-01-01T00:00:00.000Z`
+(milliseconds), some emit `2025-01-01T00:00:00+00:00` (explicit
+offset), and a handful emit `2025-01-01T00:00:00` with no zone at
+all. The validator the implementer wrote rejects all three. CI was
+green because the test corpus was the briefing's two examples.
+
+**What to ask before merging:** "Is at least one test case sourced
+from a real production payload, log line, or recent record? If
+not, sample one before merging."
+
+If the implementer can't easily get real samples, the coordinator can
+provide them — copy-paste a few recent inputs from logs into the
+mailbox and tell the implementer to add tests for each. Don't merge
+on a promise that real-data tests will come "in a follow-up PR";
+that follow-up rarely materializes.
+
+---
+
+## 4. Silent-failure paths downstream
+
+**Rule:** when a function returns `Option::None`, falls back to a
+weaker comparator, or otherwise quietly degrades, ask where that
+fallback ends up being observed. Often it surfaces as a second-order
+bug (sort order, rendering, label) that looks like a different
+system's problem.
+
+A `None` that propagates up through three or four call sites can
+manifest as a UI element that doesn't render, a sort that goes
+lexicographic when it should be chronological, a color that defaults
+to grey, or a log line that quietly drops a field. Reviewers fixated
+on the diff itself rarely follow the `None` to its observation
+point — but that's where the bug actually shows up.
+
+**Worked example.** A diff changes a date-parser to return
+`Option<Date>` instead of `Date`, with `None` for malformed input.
+The reviewer approves: "looks correct, malformed input shouldn't
+crash."
+
+But the date is consumed by a sort comparator three levels up the
+call stack. The comparator was written assuming the parser always
+returns a `Date`; on `None`, it falls back to comparing the raw
+strings. The list now sorts lexicographically — `"2025-10-01"` before
+`"2025-9-01"` — and a UI that was chronological an hour ago is now
+visibly wrong.
+
+The bug report comes in as "the sort is broken" and gets routed to
+the UI team. The actual cause is two systems away.
+
+**What to ask before merging:** "Follow every new `None` /
+`Result::Err` / fallback at least one level out from the diff. Where
+does it get observed? Is the observer prepared to handle the
+degraded value, or does it silently produce a wrong-but-plausible
+output?"
+
+---
+
+## Where this fits in the coordinator's review pass
+
+These four checks are the coordinator's own review pass, run *after*
+the reviewer's "is this correct?" pass and *before* merge. They
+complement — they don't replace — the holistic-PR-review checklist
+in the agent-coordinator skill's "Reviewing implementer PRs
+holistically" section, which covers subsumption, replay against
+recent reality, blast-radius judgment, and observer-asks. The four
+red flags above are the *common shapes* of the questions that
+checklist asks; the checklist is the framework, the playbook is the
+field manual.
+
+Block the merge when any of these surface, and mailbox the
+implementer with the *specific* failing input case (or call path).
+"Add a test for 4-token inputs" produces a fix in one round.
+"Please add more tests" produces three rounds of clarifying
+questions.

--- a/docs/playbooks/safety-critical-scoping.md
+++ b/docs/playbooks/safety-critical-scoping.md
@@ -1,0 +1,164 @@
+# Safety-critical scoping — structural beats behavioral
+
+> Field guide for any team running multi-agent work on twapp.
+> When a new feature could accidentally affect a safety-critical
+> adjacent code path, scoping is a code-organization problem, not a
+> review-discipline problem.
+
+## The pattern
+
+When you add a feature whose flag could be misread by an adjacent
+safety-critical code path, **thread the flag through as a parameter
+on every relevant function signature** rather than reading it from
+shared state inside those functions.
+
+The compiler then enforces the scoping. Every call site has to pass
+a value, so non-feature call sites visibly pass the safe default at
+the call site itself. Forgetting to pass anything is a build error.
+
+Compare to the alternative: every relevant function reads the flag
+from shared state. Now *every* caller implicitly depends on whether
+the flag happens to be set, including callers that should never be
+affected by the feature at all. Scoping is enforced by convention —
+"don't set the flag while these other paths are running" — and
+convention erodes the moment a new caller is added.
+
+The slogan: **structural scoping is enforced by the compiler;
+behavioral scoping is enforced by hope.**
+
+## Worked example
+
+Imagine a system with a function `submit_order` that has a built-in
+safety check (call it `validate_against_limits`) before sending the
+order to an external system. The safety check is the *whole point*
+of having `submit_order` go through this code path — it exists so
+nobody can accidentally submit an unvalidated order.
+
+A new feature lands: a manual override mode, where an authenticated
+operator can submit an order that bypasses the safety check. Call
+the override flag `armed`.
+
+### The wrong way: state-reading
+
+```rust
+struct AppState {
+    armed: bool,  // set when the operator opens the override UI
+    // ...
+}
+
+fn submit_order(state: &AppState, order: Order) -> Result<...> {
+    if !state.armed {
+        validate_against_limits(&order)?;
+    }
+    send_to_external(order)
+}
+```
+
+Why this looks fine: the override UI sets `armed = true`, calls
+`submit_order`, the validation is skipped, the override works. Tests
+pass. Ship it.
+
+Why it isn't fine: `submit_order` is now globally affected by
+`state.armed`. If any *other* code path calls `submit_order` while
+`armed` happens to be true — the retry queue, the scheduled-batch
+sender, the cancel-and-resubmit logic, a background reconciliation
+job — *that* call also bypasses the safety check. Six months from
+now, somebody adds a "resubmit recent failed orders" button, calls
+`submit_order` from its handler, and never thinks to check the
+global override flag because they didn't write the override feature
+and don't know it exists. The first time the new button fires while
+the override UI is open, an unvalidated order goes out.
+
+There is no test you can write today that catches this future bug.
+The bug is in code that doesn't exist yet.
+
+### The right way: parameter-threading
+
+```rust
+fn submit_order(order: Order, bypass_checks: bool) -> Result<...> {
+    if !bypass_checks {
+        validate_against_limits(&order)?;
+    }
+    send_to_external(order)
+}
+
+// Override UI — the only caller that passes true:
+submit_order(order, /* bypass_checks */ true)?;
+
+// Every other caller — retry queue, scheduled-batch, resubmit
+// handler, background reconciliation — passes false at the call site:
+submit_order(order, /* bypass_checks */ false)?;
+```
+
+Now the scoping is structural. A reviewer reading any caller of
+`submit_order` can see at the call site whether validation is being
+bypassed. The future "resubmit recent failed orders" handler the
+six-months-from-now developer adds will pass `false` because every
+*other* caller passes `false`, and the developer copy-paste-pattern
+will inherit the safe default. Forgetting to pass *any* value is a
+build error, not a runtime bypass.
+
+Pair this with an invariant test that asserts non-override call
+sites pass `false`:
+
+```rust
+#[test]
+fn no_auto_path_bypasses_validation() {
+    // Grep-style assertion: every call to submit_order outside
+    // src/override_ui.rs passes bypass_checks=false.
+    // (Or a lint, or a structural codemod test — the mechanism
+    // matters less than that the invariant is named and checked.)
+}
+```
+
+## Why state-reading keeps tempting people
+
+The state-reading version is shorter to write the *first* time. The
+override flag already exists in shared state for the UI to check, so
+"just read it inside `submit_order`" feels natural. Threading a new
+parameter through the whole call graph is more typing, more diff,
+and you have to update every caller — which is exactly the property
+that makes it safe.
+
+If the brevity of the state-reading version is what attracts an
+implementer to it, that's a signal the briefing should call out the
+parameter-threading requirement explicitly. Don't let the
+implementer choose; the implementer doesn't have visibility into
+which adjacent call paths might consume the same flag wrongly.
+
+## When to reach for this pattern
+
+The cost of parameter-threading is small but real (more diff, more
+function-signature churn). Reach for it when:
+
+- The new feature's flag could be misread by an adjacent code path
+  whose failure mode is **safety-critical** — money, units, real
+  external effects, anything that doesn't have an undo.
+- The function whose behavior the flag changes has *more than one
+  caller*, especially callers that may grow over time (a public API,
+  a widely-used helper, a module-level function).
+- The flag's "armed" state is held in shared mutable state that any
+  caller could observe.
+
+Skip it when:
+
+- The flag and the function are in the same module, with one caller,
+  and adding a new caller would obviously require touching the
+  flag-handling code anyway.
+- The "wrong" behavior under the flag is recoverable — a UI glitch,
+  a logged warning, a missing label. Not catastrophic.
+
+## Where this fits in the coordinator's review pass
+
+This pattern is a review red flag of its own: when an implementer's
+diff adds a new feature gated by a flag-on-shared-state, the
+coordinator should ask "could a non-feature caller of this function
+be affected by the flag?" If the answer is "yes, in principle, but
+no caller does that today", require a parameter-threading rewrite
+before merge. The compiler-enforced version is the only one that
+stays correct as the call graph grows.
+
+Cross-reference: the holistic review checklist in the
+agent-coordinator skill covers blast-radius judgment more generally;
+this playbook is the specific structural pattern to require when
+the blast radius includes a safety-critical adjacent path.

--- a/docs/playbooks/worktree-discipline.md
+++ b/docs/playbooks/worktree-discipline.md
@@ -1,0 +1,138 @@
+# Worktree discipline — one worktree per agent, never shared
+
+> Field guide for any team running multi-agent work on twapp.
+> The shortest playbook in this set, because the rule is short.
+
+## The rule
+
+Every implementer spawn gets a dedicated git worktree, created by the
+coordinator before spawn, and the worker operates only inside that
+path:
+
+```bash
+git worktree add -b <scope>/<short-name> <new-path> <base-ref>
+```
+
+`<new-path>` is unique per worker. `<scope>/<short-name>` is unique
+per worker. No two in-flight workers share either.
+
+## Why it matters
+
+Multiple agents writing into the same worktree create a small set of
+predictable failures:
+
+- **Stashed edits.** Worker A is mid-edit on `src/foo.rs`. Worker B
+  starts up in the same worktree, runs `git checkout -b new-branch`,
+  and the checkout either fails (if A's edits conflict with the
+  target branch) or stashes A's changes silently. A returns from a
+  tool call to find its working tree empty.
+- **Branch state trampling.** Worker A is on branch `feat/a`. Worker
+  B switches the same worktree to branch `feat/b`. A's next `git
+  status` shows it on the wrong branch, often without noticing.
+- **`.twapp-*.json` fights.** Each twapp session writes session-state
+  files into its cwd. Two sessions in the same cwd race-condition
+  these files; the loser sees stale state and either confuses itself
+  or stops responding to mailbox messages.
+- **Push collisions.** If both workers happen to be on the same
+  branch (because A's branch was overwritten by B, or because the
+  briefings collided on naming), `git push` from one will reject the
+  other with a non-fast-forward error — and the agent that gets
+  rejected often retries silently rather than escalating.
+
+None of these failures produce a clear error message. They produce
+*confusing* error messages that look like the worker has bugs in its
+code, when actually the bug is in the coordination.
+
+## What this looks like in practice
+
+### In every implementer briefing
+
+The Setup section names a fresh worktree path and a unique branch:
+
+```bash
+cd /path/to/<repo-root>
+git fetch origin
+git worktree add -b <scope>/<short-name> /path/to/<repo>_<short-name> origin/main
+cd /path/to/<repo>_<short-name>
+```
+
+The path is derived from the worker's handle so uniqueness falls out
+of the naming convention rather than requiring a registry. The
+branch follows `<scope>/<short-name>`, also derived from the handle.
+
+### In the coordinator's pre-spawn check
+
+Before invoking `twapp work --from-file <briefing>`, scan the
+briefing's Setup section and confirm:
+
+1. The `<new-path>` is not in use by another in-flight worker.
+2. The branch name is not in use by another in-flight worker.
+
+If either collides, regenerate the handle (and therefore the path
+and branch) before spawning. The cost is a one-line briefing edit;
+the cost of skipping the check is recovering from a trampled
+worktree later.
+
+### In every briefing's Do-not-touch list
+
+The coordinator's own live or production worktree — if one exists —
+goes in the Do-not-touch list of *every* implementer briefing. By
+absolute path. Even when the briefing has no obvious reason to
+touch it.
+
+The failure mode this prevents: the worker improvises a setup
+command that lands in the live tree, follows a fuzzy `find` match
+into the live tree, or reads a stale session-state file that points
+at the live tree. None of these are likely; all of them are
+catastrophic. An explicit do-not-touch line short-circuits the
+whole class.
+
+## Branch naming
+
+`<scope>/<short-name>`, mirroring the worker's handle. The same
+shape that the [briefing template](../briefing-template.md) (PR #67)
+already uses.
+
+Two reasons to keep the convention tight:
+
+- `gh pr list` is more readable when branch names share a prefix
+  structure.
+- Worker handle, branch name, and worktree path all derive from the
+  same string, which makes it trivial to grep across them.
+
+## Cleanup on completion
+
+The coordinator removes the worktree and deletes the local branch
+after merge:
+
+```bash
+git worktree remove <path>
+git branch -d <scope>/<short-name>
+```
+
+The remote branch is deleted automatically when the PR is merged
+with `gh pr merge --delete-branch`. The local branch and worktree are
+the coordinator's responsibility — the worker should not delete its
+own worktree, because force-pushed extra commits can land between
+the worker's last commit and the coordinator's reap.
+
+If `git worktree remove` complains that the worktree is dirty, that
+is a signal to investigate (the worker may have left untracked files
+or in-progress work behind), not to force the removal. Use
+`--force` only after you've looked.
+
+## What this playbook does not cover
+
+- **Reviewer / log-watcher / auditor agents** that don't write code.
+  These don't need a worktree at all; any cwd with a seeded
+  `.claude/settings.local.json` will do (see the spawn-agent
+  skill's worktree-permission pre-approval section).
+- **Coordinator's own worktree.** The coordinator typically operates
+  from a long-lived path of its own and doesn't share the worker
+  worktree convention. Its path goes in every briefing's
+  Do-not-touch list anyway.
+- **Concurrent edits to the same file across worktrees.** Worktrees
+  isolate the working tree, not the underlying object database.
+  When two implementers genuinely need to touch the same file,
+  resolve the merge order via the coordinator, not the worktree
+  layout.

--- a/skills/agent-coordinator/SKILL.md
+++ b/skills/agent-coordinator/SKILL.md
@@ -183,6 +183,14 @@ Why each section earns its place:
 - **Worktree** — copy-paste beats improvisation; workers that improvise their worktree path get lost.
 - **Domain facts** — how you avoid the class of bug where an agent silently misinterprets units, multipliers, field semantics, or ownership boundaries.
 
+### Why idle-finishing happens
+
+Workers are optimized to satisfy primary acceptance criteria and exit. Without explicit completion-lifecycle checkpoints, post-code-work steps — pushing the branch, opening the PR, writing a completion-signal file — are treated as narrative wrap-up rather than required acceptance items, and a partial failure in that sequence can leave the agent stopped with no signal anyone can see. The Completion check section turns those steps into verifiable acceptance items; the **two-channel `DONE.md` + mailbox** pattern in [`docs/playbooks/completion-signals.md`](../../docs/playbooks/completion-signals.md) makes the signal work even when the shared mailbox path sits outside the agent's permission scope (the `DONE.md` in the worker's own worktree is always writable by construction).
+
+### Agents don't proactively poll shared channels
+
+A running worker only checks the channels its briefing tells it to check, on the cadence its briefing specifies. If the coordinator needs to change a running agent's instructions mid-run, a directed mailbox message is unreliable unless the worker's briefing explicitly sets up a poll loop that reads it. For one-off mid-run updates the priority lane (§3 Priority lanes) is more reliable than a regular `to: <handle>` post; for substantial scope changes, the cleanest pattern is to stop the agent and respawn it with an updated briefing plus the previous session id (`twapp work --session-id <id>`), so context continuity is preserved even though the briefing changed.
+
 ### Headless operation — worker contract
 
 **Headless operation.** Every worker invokes `/loop` after its hello and operates autonomously. Never end a turn waiting for user input. If stuck, mailbox the coordinator. The coordinator decides when to escalate to the user.
@@ -219,6 +227,8 @@ The [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill defines
 - **Always call out the live worktree.** If the target repo has a live / production / staging / `_live` worktree the user runs out of, name it by absolute path in the Do-not-touch section of every implementer briefing — even when the briefing has no obvious reason to touch it. The worker may search for files broadly, follow a tool to a fuzzy match, or improvise a setup command that lands there. An explicit do-not-touch line short-circuits all of those failure paths up front.
 
 The [`docs/briefing-template.md`](../../docs/briefing-template.md) file is the canonical starting point. Copy it, fill it in, run the three checks above, then spawn. If the template gains a new required field, edit the template *and* the [`spawn-agent`](../spawn-agent/SKILL.md#briefing-requirements) skill so future briefings inherit it; do not patch a missing field into only the briefing in front of you.
+
+For the rationale behind the worktree-per-implementer rule and the cleanup-on-merge step — including the specific failure modes (stashed edits, branch-state trampling, `.twapp-*.json` fights, push collisions) it converts from "unlikely" to "unreachable" — see [`docs/playbooks/worktree-discipline.md`](../../docs/playbooks/worktree-discipline.md).
 
 ## 3. Mailbox protocol
 
@@ -620,11 +630,27 @@ status, before merging:
       is meant to prevent — an agent that finished its code work but
       never opened the PR — when that agent's self-verify slipped
       anyway.
+- [ ] **Safety-critical scoping.** If the diff adds a new feature gated
+      by a flag, ask whether a non-feature caller of the same function
+      could be affected by the flag. If yes — even hypothetically, even
+      if no such caller exists today — require the implementer to
+      thread the flag as an explicit parameter rather than reading it
+      from shared state, so the compiler enforces the scoping. See
+      [`docs/playbooks/safety-critical-scoping.md`](../../docs/playbooks/safety-critical-scoping.md)
+      for the worked pattern.
 
 If the checklist surfaces a concern, block the merge and mailbox the
 implementer with the specific input case the PR would reject — not a
 vague "please add more tests". Implementers correct fastest when handed a
 concrete failing example they can turn into a test.
+
+The four anti-patterns this checklist is built around — tolerant→strict
+rewrites, fix-too-aggressive scope, tests covering documented cases
+rather than real ones, and silent-failure paths downstream — have their
+own field guide with worked examples in
+[`docs/playbooks/review-red-flags.md`](../../docs/playbooks/review-red-flags.md).
+Reach for it when a checklist item is firing and you want a more
+concrete pattern to point the implementer at.
 
 Review quality on this pass is bounded by the coordinator's own model
 tier — holding the diff, the briefing, and the sibling-PR state

--- a/skills/spawn-agent/SKILL.md
+++ b/skills/spawn-agent/SKILL.md
@@ -487,3 +487,27 @@ the PR exists on the remote and the `-done.md` file is posted.
 ````
 
 The five mandatory sections are **Setup**, **Do-not-touch**, **PR pattern**, **Acceptance criteria**, and **Completion check**. Add **Why**, **What to ship**, and **Out of scope** in every real briefing — they're not enforced here because the failure mode they prevent (scope drift) is gentler than the ones the five mandatory sections prevent (worktree trampling and silent PR-open stalls).
+
+## Further reading
+
+The patterns above are the minimum a working spawn needs. Once you've
+spawned a few workers, four short field guides cover the recurring
+operational issues coordinators hit in practice:
+
+- [`docs/playbooks/completion-signals.md`](../../docs/playbooks/completion-signals.md) —
+  the two-channel `DONE.md` + mailbox completion signal, and why the
+  mailbox-only version isn't load-bearing on its own.
+- [`docs/playbooks/review-red-flags.md`](../../docs/playbooks/review-red-flags.md) —
+  four anti-patterns a coordinator catches before merge:
+  tolerant→strict rewrites, fix too aggressive, narrow tests, and
+  silent-failure paths downstream.
+- [`docs/playbooks/worktree-discipline.md`](../../docs/playbooks/worktree-discipline.md) —
+  why every implementer gets a dedicated worktree and what breaks
+  when two workers share one.
+- [`docs/playbooks/safety-critical-scoping.md`](../../docs/playbooks/safety-critical-scoping.md) —
+  thread feature flags as parameters rather than reading them from
+  shared state, so the compiler enforces scoping for safety-critical
+  adjacent paths.
+
+Pair these with the canonical starter at
+[`docs/briefing-template.md`](../../docs/briefing-template.md).


### PR DESCRIPTION
## Summary

Layers practitioner-style field guides on top of the structural rules from #67 (briefing template), #68 (coordinator hygiene), and #69 (completion check). **Audience: anyone using twapp to coordinate agents on any project.** Zero project-specific references — every example is an invented generic scenario.

### Four new playbooks (`docs/playbooks/`)

- **`completion-signals.md`** — the two-channel `DONE.md` + mailbox completion-signal pattern. Explains why the mailbox-only version (phase 1, #69) wasn't load-bearing on its own: the shared mailbox path often sits outside the worker's permitted write scope, even with `--dangerously-skip-permissions`. The `DONE.md` in the worker's own worktree is always writable by construction, so it's the load-bearing signal; the mailbox post is best-effort.
- **`review-red-flags.md`** — four anti-patterns the coordinator catches before merge, each with a worked generic example: tolerant→strict rewrites (silently rejecting inputs the old code accepted), fix-too-aggressive scope (presentational bug, lifecycle-killing fix), tests covering documented cases rather than real ones, and silent-failure paths downstream (`None` propagating into a sort/render/label as wrong-but-plausible output).
- **`worktree-discipline.md`** — one worktree per agent, never shared. Covers the failure modes (stashed edits, branch trampling, `.twapp-*.json` fights, push collisions), the branch-naming convention, the live-worktree do-not-touch rule, and cleanup-on-merge.
- **`safety-critical-scoping.md`** — when a new feature could affect a safety-critical adjacent code path, thread the flag as a parameter through the relevant function signatures rather than reading shared state. Compiler enforces scoping; behavioral conventions don't. Generic worked example with `submit_order(..., bypass_checks: bool)`.

### Skill / template updates

- **`skills/agent-coordinator/SKILL.md`** — adds a "Why idle-finishing happens" subsection (3–4 sentences explaining the post-acceptance-criteria stop pattern), an "agents don't proactively poll shared channels" coordinator-behavior note, and cross-links to the four playbooks. §6.1 (holistic PR review) gains a new "Safety-critical scoping" checklist item that points at the playbook, plus a footer paragraph linking the review-red-flags field guide. The coordinator-obligations subsection links the worktree-discipline playbook for the rationale-and-failure-modes deep dive.
- **`skills/spawn-agent/SKILL.md`** — adds a "Further reading" section at the bottom linking the four playbooks plus `docs/briefing-template.md`.
- **`docs/briefing-template.md`** — replaces the mailbox-only Completion check with the two-channel `DONE.md` + mailbox version. The `gh pr view` self-verify step is retained; the agent is "not done" until BOTH the PR exists on the remote AND `<your-worktree>/DONE.md` has been written.

### Lineage

- #67 — briefing template with five mandatory sections.
- #68 — coordinator hygiene around verifying briefings before spawn.
- #69 — Completion check section in the template (mailbox-only, phase 1).
- this PR — phase 2: `DONE.md` + mailbox two-channel signal, plus four field-guide playbooks codifying the operational patterns the first three PRs imply but don't spell out.

## Generalization audit

Searched the diff for project-specific terms (trading vocabulary, repo names, domain-specific jargon, real PR numbers from other repos) and removed everything found. The only `#NN` references in the new docs are twapp PRs #67 / #68 / #69, which the briefing explicitly allows because they are the lineage of this work. Every code example in the playbooks is invented — the parser, the override flag, the inbox panel, the date-validator — and uses placeholder identifiers, not anything taken from a real codebase.

## Test plan

- [x] `cargo test --lib` in `src-tauri/` — 285 passed, 0 failed (no code changes; baseline preserved).
- [x] Cross-link audit: every `docs/playbooks/...` link resolves to a file in this PR; the briefing template's relative `playbooks/...` link resolves correctly from `docs/`.
- [x] Generalization audit: grep for trading / project / repo terms in `docs/playbooks/*.md` returns nothing project-specific.