### PR TITLE
fix(ui): persist session-id edits — use camelCase invoke keys

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,7 @@ import { lightTheme, darkTheme, getLightTheme, getDarkTheme } from "./types";
 import { formatTicketBadge, formatTime } from "./utils/format";
 import { isYamlFile, isHtmlFile, isImageFile, imageMimeType, isFilePath, isLikelyPreviewableHref, normalizeFilePathCandidate, isAbsolutePath } from "./utils/file";
 import { remarkAutolinkFilePaths } from "./utils/markdown";
-import { buildResumeCommand } from "./utils/session";
+import { buildResumeCommand, buildSessionFieldsArgs } from "./utils/session";
 import { isNewerVersion } from "./utils/version";
 import { canSendMessage } from "./utils/colab";
 import { renderJsonNode, renderYamlNode } from "./components/FilePreview/renderers";
@@ -1188,19 +1188,17 @@ function App() {
     setSessionFieldsSaving(true);
     setSessionFieldsError(null);
     try {
-      const args: Record<string, string> = { directory: appConfig.cwd };
-      if (sessionFields.name !== sessionFieldsOriginal?.name) args.name = sessionFields.name;
-      if (sessionFields.session_id !== sessionFieldsOriginal?.session_id) args.session_id = sessionFields.session_id;
-      if (sessionFields.claude_cwd !== sessionFieldsOriginal?.claude_cwd) args.claude_cwd = sessionFields.claude_cwd;
-      if (sessionFields.ticket_key !== sessionFieldsOriginal?.ticket_key) args.ticket_key = sessionFields.ticket_key;
+      // camelCase keys are required: Tauri maps them onto the snake_case Rust
+      // params. snake_case keys are silently dropped and never reach disk.
+      const args = buildSessionFieldsArgs(appConfig.cwd, sessionFields, sessionFieldsOriginal);
       await invoke("update_session_fields", args);
       // Update local state
       if (args.name !== undefined) {
         setAppConfig((prev) => prev ? { ...prev, name: args.name } : prev);
         setTabs((prev) => prev.map((t) => t.id === "main" ? { ...t, name: args.name } : t));
       }
-      if (args.session_id !== undefined) {
-        setAppConfig((prev) => prev ? { ...prev, session_id: args.session_id } : prev);
+      if (args.sessionId !== undefined) {
+        setAppConfig((prev) => prev ? { ...prev, session_id: args.sessionId } : prev);
       }
       setSessionFieldsOriginal({ ...sessionFields });
       // A session_id change writes a `manual_edit` audit entry — refresh.

--- a/src/utils/session.test.ts
+++ b/src/utils/session.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildResumeCommand, maskProviderSessionId, shellEscapeSingleQuoted } from "./session";
+import {
+  buildResumeCommand,
+  buildSessionFieldsArgs,
+  maskProviderSessionId,
+  shellEscapeSingleQuoted,
+  type SessionFieldValues,
+} from "./session";
 
 describe("shellEscapeSingleQuoted", () => {
   it("escapes single quotes for shell-safe single-quoted strings", () => {
@@ -34,5 +40,66 @@ describe("maskProviderSessionId", () => {
 
   it("leaves short ids unchanged", () => {
     expect(maskProviderSessionId("123456789012")).toBe("123456789012");
+  });
+});
+
+describe("buildSessionFieldsArgs", () => {
+  const fields = (o: Partial<SessionFieldValues> = {}): SessionFieldValues => ({
+    name: "demo",
+    session_id: "6b8e7694-7969-475b-ae9f-5abd07fbd16a",
+    claude_cwd: "/tmp/demo",
+    ticket_key: "",
+    ...o,
+  });
+
+  it("emits camelCase keys for a changed session id (regression: snake_case keys never reach disk)", () => {
+    const original = fields();
+    const next = fields({ session_id: "25c8ffd1-131a-47ac-9eef-eab69429f96e" });
+    const args = buildSessionFieldsArgs("/tmp/demo", next, original);
+
+    expect(args.sessionId).toBe("25c8ffd1-131a-47ac-9eef-eab69429f96e");
+    // The Tauri command param is `session_id`; a snake_case key here would be
+    // dropped and the change would silently fail to persist.
+    expect(args).not.toHaveProperty("session_id");
+  });
+
+  it("includes only changed fields plus the directory", () => {
+    const original = fields();
+    const next = fields({ session_id: "new-id" });
+    const args = buildSessionFieldsArgs("/tmp/demo", next, original);
+
+    expect(args).toEqual({ directory: "/tmp/demo", sessionId: "new-id" });
+  });
+
+  it("maps every editable field to its camelCase invoke key", () => {
+    const original = fields();
+    const next = fields({
+      name: "renamed",
+      session_id: "new-id",
+      claude_cwd: "/tmp/other",
+      ticket_key: "JTK-1",
+    });
+    const args = buildSessionFieldsArgs("/tmp/demo", next, original);
+
+    expect(args).toEqual({
+      directory: "/tmp/demo",
+      name: "renamed",
+      sessionId: "new-id",
+      claudeCwd: "/tmp/other",
+      ticketKey: "JTK-1",
+    });
+  });
+
+  it("treats a null original as all-changed", () => {
+    const next = fields({ ticket_key: "JTK-9" });
+    const args = buildSessionFieldsArgs("/tmp/demo", next, null);
+
+    expect(args).toEqual({
+      directory: "/tmp/demo",
+      name: "demo",
+      sessionId: "6b8e7694-7969-475b-ae9f-5abd07fbd16a",
+      claudeCwd: "/tmp/demo",
+      ticketKey: "JTK-9",
+    });
   });
 });

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -33,3 +33,33 @@ export function maskProviderSessionId(sessionId: string): string {
   }
   return `${sessionId.slice(0, 4)}...${sessionId.slice(-4)}`;
 }
+
+export type SessionFieldValues = {
+  name: string;
+  session_id: string;
+  claude_cwd: string;
+  ticket_key: string;
+};
+
+/**
+ * Build the argument object for `invoke("update_session_fields", …)`,
+ * including only the fields that changed from `original`.
+ *
+ * Keys MUST be camelCase. Tauri v2 maps camelCase JS invoke keys onto the
+ * snake_case Rust command parameters (`sessionId` -> `session_id`, etc.).
+ * Sending snake_case keys silently drops them: the command receives `None`,
+ * `write_session` rewrites the file with the OLD value, and the optimistic
+ * UI update makes it look like the change took even though disk is untouched.
+ */
+export function buildSessionFieldsArgs(
+  directory: string,
+  fields: SessionFieldValues,
+  original: SessionFieldValues | null,
+): Record<string, string> {
+  const args: Record<string, string> = { directory };
+  if (fields.name !== original?.name) args.name = fields.name;
+  if (fields.session_id !== original?.session_id) args.sessionId = fields.session_id;
+  if (fields.claude_cwd !== original?.claude_cwd) args.claudeCwd = fields.claude_cwd;
+  if (fields.ticket_key !== original?.ticket_key) args.ticketKey = fields.ticket_key;
+  return args;
+}


### PR DESCRIPTION
## Problem

Editing a session's **Session ID** (or **Resume CWD** / **Ticket**) in the UI updated the on-screen value but never reached disk — `.twapp-session.json` kept the old id. Reported in the wild: changing a session id to a new UUID showed the new id in the UI while disk stayed on the old one.

## Root cause

`handleSaveSessionFields` (`src/App.tsx`) built the `update_session_fields` invoke args with **snake_case** keys:

```js
args.session_id = ...   args.claude_cwd = ...   args.ticket_key = ...
```

Tauri v2 maps **camelCase** JS invoke keys onto the snake_case Rust command params, and `update_session_fields` has no `rename_all` override. So `session_id`/`claude_cwd`/`ticket_key` matched nothing and arrived as `None`. `write_session` then rewrote the file with the **unchanged** values, while the frontend optimistically updated local state — producing exactly the "UI shows new id, disk keeps old id" symptom.

`name` and `directory` worked only because single-word keys are identical in camelCase and snake_case.

## Fix

Route the args through a new pure helper `buildSessionFieldsArgs` in `src/utils/session.ts` that emits **camelCase** keys (`sessionId`/`claudeCwd`/`ticketKey`), matching the convention used everywhere else in the codebase (`ticketKey`, `overrideTerminalTheme`, `tabId`).

## Tests

- 4 new vitest cases in `src/utils/session.test.ts`, including a regression guard asserting the args use `sessionId` and contain **no** `session_id` key.
- `npx tsc --noEmit` clean; full suite green (171 passed).