### PR TITLE
fix(restore): reopen session windows after a macOS restart

### DIFF
--- a/src-tauri/src/cli/app_bundle.rs
+++ b/src-tauri/src/cli/app_bundle.rs
@@ -239,8 +239,69 @@ pub fn resign_app_bundle(app_path: &Path) -> Result<(), String> {
     }
 }
 
+/// Sidecar file (next to an instance `.app`) recording the exact `--args`
+/// the bundle was last launched with. macOS relaunches session-window bundles
+/// after a restart with no argv, dropping the `--cwd`/`--command`/`--session-id`
+/// that distinguish a session window from the launcher; this file lets the GUI
+/// recover them. Kept outside the bundle so it never breaks the codesign seal.
+fn instance_args_path(instance_app: &Path) -> Option<PathBuf> {
+    let stem = instance_app.file_stem()?;
+    let dir = instance_app.parent()?;
+    Some(dir.join(format!("{}.args.json", stem.to_string_lossy())))
+}
+
+/// Persist an instance's launch args. Best-effort: a failure only costs
+/// session restoration after a restart, never the launch itself.
+pub fn save_instance_args(instance_app: &Path, args: &[String]) {
+    if let Some(path) = instance_args_path(instance_app) {
+        if let Ok(json) = serde_json::to_string(args) {
+            let _ = std::fs::write(path, json);
+        }
+    }
+}
+
+/// Remove an instance's saved launch args (on session delete or rename).
+pub fn remove_instance_args(instance_app: &Path) {
+    if let Some(path) = instance_args_path(instance_app) {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Resolve the instance `.app` a given executable lives inside, but only for
+/// our per-instance bundles under `instances/`. Returns `None` for the master
+/// bundle (launcher), dev binaries, or anything else — pure path logic so it
+/// can be unit-tested without touching the real filesystem.
+fn instance_bundle_for_exe(exe: &Path) -> Option<PathBuf> {
+    // exe = <...>/instances/<name>.app/Contents/MacOS/<bin>
+    let bundle = exe.ancestors().nth(3)?;
+    if bundle.extension().and_then(|e| e.to_str()) != Some("app") {
+        return None;
+    }
+    if bundle.parent()?.file_name().and_then(|n| n.to_str()) != Some("instances") {
+        return None;
+    }
+    Some(bundle.to_path_buf())
+}
+
+/// If the current process is a per-instance session-window bundle, return the
+/// launch args saved for it. Used to recover session context after a macOS
+/// restart relaunches the bundle with no argv. `None` for the launcher or when
+/// no sidecar exists.
+pub fn current_instance_args() -> Option<Vec<String>> {
+    let exe = std::env::current_exe().ok()?;
+    let bundle = instance_bundle_for_exe(&exe)?;
+    let path = instance_args_path(&bundle)?;
+    let json = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&json).ok()
+}
+
 /// Launch a GUI instance via `open -n -a`
 pub fn launch_gui(instance_app: &Path, args: &[String]) -> Result<(), String> {
+    // Record the args first so a later macOS-restart relaunch (which arrives
+    // with no argv) can recover this window's session instead of falling back
+    // to the launcher.
+    save_instance_args(instance_app, args);
+
     let mut open_args = vec![
         "-n".to_string(),
         "-a".to_string(),
@@ -255,4 +316,94 @@ pub fn launch_gui(instance_app: &Path, args: &[String]) -> Result<(), String> {
         .map_err(|e| format!("Failed to launch: {}", e))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_tmp(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!("{}-{}", prefix, uuid::Uuid::new_v4()))
+    }
+
+    #[test]
+    fn instance_args_path_sits_beside_bundle() {
+        let bundle = PathBuf::from("/x/.config/twapp/instances/My-Session.app");
+        let path = instance_args_path(&bundle).expect("sidecar path");
+        assert_eq!(
+            path,
+            PathBuf::from("/x/.config/twapp/instances/My-Session.args.json")
+        );
+    }
+
+    #[test]
+    fn instance_bundle_for_exe_accepts_instance_rejects_others() {
+        // A real per-instance session window.
+        let exe = PathBuf::from("/u/.config/twapp/instances/Foo.app/Contents/MacOS/twapp");
+        assert_eq!(
+            instance_bundle_for_exe(&exe),
+            Some(PathBuf::from("/u/.config/twapp/instances/Foo.app"))
+        );
+
+        // The master bundle (launcher) must NOT be treated as an instance,
+        // otherwise opening the launcher from Spotlight would hijack stale args.
+        let master = PathBuf::from("/u/.config/twapp/twapp.app/Contents/MacOS/twapp");
+        assert_eq!(instance_bundle_for_exe(&master), None);
+
+        // A bare dev binary.
+        let dev = PathBuf::from("/u/Dev/twapp/src-tauri/target/release/twapp");
+        assert_eq!(instance_bundle_for_exe(&dev), None);
+    }
+
+    #[test]
+    fn save_then_current_round_trips_args() {
+        let instances = unique_tmp("twapp-instances");
+        std::fs::create_dir_all(&instances).unwrap();
+        let bundle = instances.join("Round-Trip.app");
+
+        let args = vec![
+            "--name".to_string(),
+            "Round Trip".to_string(),
+            "--cwd".to_string(),
+            "/work/dir".to_string(),
+            "--command".to_string(),
+            "claude --resume abc123".to_string(),
+            "--session-id".to_string(),
+            "abc123".to_string(),
+        ];
+        save_instance_args(&bundle, &args);
+
+        let json = std::fs::read_to_string(instance_args_path(&bundle).unwrap()).unwrap();
+        let restored: Vec<String> = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, args);
+
+        remove_instance_args(&bundle);
+        assert!(!instance_args_path(&bundle).unwrap().exists());
+        let _ = std::fs::remove_dir_all(&instances);
+    }
+
+    #[test]
+    fn saved_args_reparse_into_matching_gui_args() {
+        // Restoration re-parses saved args through the same clap parser a fresh
+        // launch uses, so this locks that round trip in sync with GuiArgs.
+        use clap::Parser as _;
+        let args = vec![
+            "--name".to_string(),
+            "Foo".to_string(),
+            "--cwd".to_string(),
+            "/work/dir".to_string(),
+            "--command".to_string(),
+            "claude --resume abc123".to_string(),
+            "--session-id".to_string(),
+            "abc123".to_string(),
+        ];
+        let mut argv = vec!["twapp".to_string()];
+        argv.extend(args);
+        let cli = crate::Cli::try_parse_from(&argv).expect("re-parse saved args");
+        assert!(cli.command.is_none());
+        assert_eq!(cli.gui.name, "Foo");
+        assert_eq!(cli.gui.cwd.as_deref(), Some("/work/dir"));
+        assert_eq!(cli.gui.command.as_deref(), Some("claude --resume abc123"));
+        assert_eq!(cli.gui.session_id.as_deref(), Some("abc123"));
+    }
 }

--- a/src-tauri/src/gui/mod.rs
+++ b/src-tauri/src/gui/mod.rs
@@ -31,7 +31,78 @@ fn get_app_config(config: tauri::State<'_, GuiArgs>) -> GuiArgs {
     config.inner().clone()
 }
 
+/// Recover a session window's launch args after a macOS restart.
+///
+/// A freshly launched session window always carries its session identity in
+/// argv. Bare `GuiArgs` means either the real launcher (master bundle, opened
+/// from Spotlight) or a restart relaunching a session-window bundle with no
+/// argv. Only the latter runs from a per-instance bundle under `instances/`,
+/// so that is our cue to restore the args saved at launch — re-parsed through
+/// the same clap parser a fresh launch uses, keeping the two in lockstep.
+///
+/// The saved args are only a starting point: they reliably carry the `cwd`,
+/// but a session's id/name/provider can change in the GUI after launch (the
+/// canonical record is `.twapp-session.json`, not the frozen launch args). So
+/// we overlay that file before returning, ensuring restored windows reflect
+/// the latest edits rather than whatever was true the moment they launched.
+fn restore_args_if_relaunched(args: GuiArgs) -> GuiArgs {
+    let bare = args.cwd.is_none() && args.command.is_none() && args.session_id.is_none();
+    if !bare {
+        return args;
+    }
+    let Some(saved) = crate::cli::app_bundle::current_instance_args() else {
+        return args;
+    };
+    let mut argv = vec!["twapp".to_string()];
+    argv.extend(saved);
+    let mut restored = match <crate::Cli as clap::Parser>::try_parse_from(&argv) {
+        Ok(cli) => cli.gui,
+        Err(_) => return args,
+    };
+    refresh_from_session_file(&mut restored);
+    restored
+}
+
+/// Overlay the live `.twapp-session.json` onto restored launch args so
+/// post-launch GUI edits survive a restart: a manually-changed or
+/// later-captured session id, a rename, a provider switch. The frozen
+/// `--command` is kept only when no provider session id is known yet (e.g. a
+/// brand-new session caught mid-capture) — otherwise we adopt the freshest id
+/// and let the frontend rebuild the resume command from it.
+fn refresh_from_session_file(args: &mut GuiArgs) {
+    let Some(cwd) = args.cwd.clone() else {
+        return;
+    };
+    let Ok(session) = crate::cli::session::read_session(&std::path::PathBuf::from(&cwd)) else {
+        return;
+    };
+
+    let provider = session.provider.unwrap_or(args.provider);
+    args.provider = provider;
+    if !session.name.is_empty() {
+        args.name = session.name.clone();
+    }
+    if !session.color.is_empty() {
+        args.color = Some(session.color.clone());
+    }
+    if let Some(chrome) = session.use_chrome {
+        args.chrome = chrome;
+    }
+    if let Some(override_theme) = session.override_terminal_theme {
+        args.override_terminal_theme = override_theme;
+    }
+
+    if let Some(id) = session.display_session_id(provider) {
+        args.session_id = Some(id);
+        // Clear the snapshot command so the frontend rebuilds `claude --resume
+        // <id>` (or the codex equivalent) from the id we just adopted.
+        args.command = None;
+    }
+}
+
 pub fn run(args: GuiArgs) {
+    let args = restore_args_if_relaunched(args);
+
     // Discover user's PATH from login shell (GUI apps inherit minimal PATH)
     shell_env::init_path();
 
@@ -299,4 +370,107 @@ pub fn run(args: GuiArgs) {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod restore_tests {
+    use super::*;
+    use crate::cli::session::{write_session, SessionData};
+
+    fn unique_dir() -> std::path::PathBuf {
+        let d = std::env::temp_dir().join(format!("twapp-restore-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn session_with(session_id: &str, name: &str) -> SessionData {
+        SessionData {
+            session_id: session_id.into(),
+            name: name.into(),
+            color: String::new(),
+            ticket_key: None,
+            claude_cwd: String::new(),
+            created: String::new(),
+            last_resumed: None,
+            provider: None,
+            codex_session_id: None,
+            codex_cwd: None,
+            forked_from: None,
+            imported: None,
+            imported_from: None,
+            use_chrome: None,
+            override_terminal_theme: None,
+            role: None,
+            provenance: None,
+            colab_group: None,
+        }
+    }
+
+    fn args_for(dir: &std::path::Path, extra: &[&str]) -> GuiArgs {
+        let mut argv = vec![
+            "twapp".to_string(),
+            "--cwd".to_string(),
+            dir.to_string_lossy().to_string(),
+        ];
+        argv.extend(extra.iter().map(|s| s.to_string()));
+        <crate::Cli as clap::Parser>::try_parse_from(&argv)
+            .unwrap()
+            .gui
+    }
+
+    // The headline fix: a session id edited (or captured) in the GUI after
+    // launch lives in `.twapp-session.json`, so a restart must adopt it over
+    // the stale launch-time id and rebuild the resume command.
+    #[test]
+    fn adopts_edited_session_id_and_rebuilds_command() {
+        let dir = unique_dir();
+        write_session(&dir, &session_with("new-id", "Renamed")).unwrap();
+        let mut args = args_for(
+            &dir,
+            &[
+                "--session-id",
+                "old-id",
+                "--command",
+                "claude --resume old-id",
+                "--name",
+                "Old",
+            ],
+        );
+
+        refresh_from_session_file(&mut args);
+
+        assert_eq!(args.session_id.as_deref(), Some("new-id"));
+        assert_eq!(args.command, None, "command cleared so frontend rebuilds resume");
+        assert_eq!(args.name, "Renamed");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // A brand-new session caught before its id is captured has no provider id
+    // in the file yet, so we must keep the frozen launch command as a fallback.
+    #[test]
+    fn keeps_frozen_command_when_no_session_id_yet() {
+        let dir = unique_dir();
+        write_session(&dir, &session_with("", "Fresh")).unwrap();
+        let mut args = args_for(&dir, &["--command", "claude"]);
+
+        refresh_from_session_file(&mut args);
+
+        assert_eq!(args.session_id, None);
+        assert_eq!(args.command.as_deref(), Some("claude"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn missing_session_file_leaves_args_untouched() {
+        let dir = std::env::temp_dir().join(format!("twapp-restore-missing-{}", uuid::Uuid::new_v4()));
+        let mut args = args_for(
+            &dir,
+            &["--session-id", "keep-id", "--command", "claude --resume keep-id"],
+        );
+
+        refresh_from_session_file(&mut args);
+
+        assert_eq!(args.session_id.as_deref(), Some("keep-id"));
+        assert_eq!(args.command.as_deref(), Some("claude --resume keep-id"));
+    }
 }

--- a/src-tauri/src/gui/sessions.rs
+++ b/src-tauri/src/gui/sessions.rs
@@ -797,11 +797,13 @@ pub async fn rename_session(directory: String, new_name: String) -> Result<(), S
             let _ = std::fs::rename(&old_prompts, &new_prompts);
         }
 
-        // Remove old instance bundle (recreated on next launch)
+        // Remove old instance bundle (recreated on next launch) and its
+        // restore-args sidecar so a restart can't revive the old-named window.
         let home = dirs::home_dir().unwrap_or_default();
         let old_app = home
             .join(".config/twapp/instances")
             .join(format!("{}.app", old_safe));
+        crate::cli::app_bundle::remove_instance_args(&old_app);
         if old_app.exists() {
             let _ = std::fs::remove_dir_all(&old_app);
         }
@@ -947,11 +949,12 @@ pub async fn delete_session(directory: String, delete_everything: bool) -> Resul
         })();
     }
 
-    // 3. Clean up instance .app bundle
+    // 3. Clean up instance .app bundle and its restore-args sidecar
     let safe_name = sanitize_instance_name(&session_data.name);
     let instance_app = home
         .join(".config/twapp/instances")
         .join(format!("{}.app", safe_name));
+    crate::cli::app_bundle::remove_instance_args(&instance_app);
     if instance_app.exists() {
         let _ = std::fs::remove_dir_all(&instance_app);
     }


### PR DESCRIPTION
## Problem

After a macOS restart, individual session windows reopen showing the **top-level launcher/explorer view** instead of their terminal session — and get stuck there. The app/dock **names still look correct**, which is the tell.

**Root cause:** each session window is a separate per-instance `.app` bundle under `~/.config/twapp/instances/<name>.app` with the session name baked into its `CFBundleName` (hence the correct names). But the session identity (`--cwd`, `--command`, `--session-id`) is passed only as **process argv** via `open --args`. macOS relaunches the bundles on restart with **no argv**, so `GuiArgs` is all-default and the frontend's view gate trips to launcher mode:

```js
const isLauncherMode = appConfig && !appConfig.command && !appConfig.session_id;
```

## Fix

Backend-only — no frontend changes. Restored `GuiArgs` flows through `get_app_config` into the existing terminal view, which re-runs `claude --resume …`.

- **`app_bundle.rs`** — `launch_gui` writes a `<name>.args.json` sidecar beside each instance bundle on every launch. `current_instance_args()` recovers it on startup, but only when the running exe is a bundle under `instances/` (the launcher runs from the *master* bundle, so it's never hijacked).
- **`gui/mod.rs`** — `run()` calls `restore_args_if_relaunched()`: on a bare relaunch it re-parses the saved args through the same clap parser a fresh launch uses, then **overlays the live `.twapp-session.json`** so post-launch GUI edits win over the frozen snapshot — a manually changed/late-captured **session id**, a **rename**, a **provider switch**, chrome/theme toggles. The frozen `--command` is kept only as a fallback when no provider id is known yet (brand-new session caught mid-capture).
- **`sessions.rs`** — delete/rename clean up the sidecar so a restart can't revive a stale window.

Side effect: double-clicking a session's `.app` in `instances/` now reopens that session directly.

## Tests

7 new unit tests (sidecar path/round-trip/bundle discrimination + the session-file overlay), full suite green (292 passed), clean `cargo check`.

## Deployment note

The restore code lives *inside* the per-instance bundles, which are stale clones until re-created. After `npm run tauri build && twapp install-gui …`, **resume each session once** to re-clone its bundle with the new code and drop its sidecar. Every restart after that restores correctly.